### PR TITLE
feat(detection): default bounding-box colour to grey

### DIFF
--- a/openfollow/configuration.py
+++ b/openfollow/configuration.py
@@ -424,7 +424,7 @@ class DetectionConfig:
     interval_ms: int = 67
     show_boxes: bool = True
     show_labels: bool = True
-    box_color: str = "#00ff00"
+    box_color: str = "#808080"
     box_thickness: int = 2
     max_persons: int = 10
     pin_marker: bool = False
@@ -462,7 +462,7 @@ class DetectionConfig:
         self.confidence = _coerce_float(self.confidence, 0.2, lo=0.0, hi=1.0)
         # Upper bounds mirror ``openfollow/web/validation.py``.
         self.interval_ms = _coerce_int(self.interval_ms, 67, lo=1, hi=10000)
-        self.box_color = _coerce_hex_color(self.box_color, "#00ff00")
+        self.box_color = _coerce_hex_color(self.box_color, "#808080")
         self.box_thickness = _coerce_int(self.box_thickness, 2, lo=1, hi=10)
         self.max_persons = _coerce_int(self.max_persons, 10, lo=1, hi=50)
         # ``lo=-1`` admits the "follow selected" sentinel but no other negative.

--- a/openfollow/runtime/overlay_state.py
+++ b/openfollow/runtime/overlay_state.py
@@ -232,7 +232,7 @@ class OverlayState:
     detections: list[DetectionBox] = field(default_factory=list)
     detection_show_boxes: bool = False
     detection_show_labels: bool = False
-    detection_box_color: str = "#00ff00"
+    detection_box_color: str = "#808080"
     detection_box_thickness: int = 2
     # The detection track currently attached to a marker, painted in that
     # marker's colour. ``None`` track id (or empty colour) = no highlight.
@@ -334,7 +334,7 @@ class OverlayState:
         self.detections = []
         self.detection_show_boxes = False
         self.detection_show_labels = False
-        self.detection_box_color = "#00ff00"
+        self.detection_box_color = "#808080"
         self.detection_box_thickness = 2
         self.detection_attached_track_id = None
         self.detection_attached_color = ""

--- a/openfollow/web/help/detection.md
+++ b/openfollow/web/help/detection.md
@@ -45,7 +45,7 @@ What the detection overlay draws on the Operator Screen.
 
 - **Show Boxes** – draw a bounding rectangle around each detected person. On by default.
 - **Show Labels** – draw a text label (confidence score) inside or above each box. On by default.
-- **Box Color** – colour of the boxes. Click the swatch to open the colour picker. Default green (`#00ff00`). The box currently attached to a marker is drawn in **that marker's** colour instead, so you can see which detection is driving the followspot.
+- **Box Color** – colour of the boxes. Click the swatch to open the colour picker. Default grey (`#808080`). The box currently attached to a marker is drawn in **that marker's** colour instead, so you can see which detection is driving the followspot.
 - **Box Thickness (px)** – line weight for the boxes, 1–10 pixels. Default `2`.
 
 ## Tracking

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -2058,7 +2058,7 @@ def test_detection_config_clamps_confidence(bad_conf: object, expected: float) -
 
 def test_detection_config_rejects_bad_box_color() -> None:
     cfg = DetectionConfig(box_color="fuchsia")
-    assert cfg.box_color == "#00ff00"
+    assert cfg.box_color == "#808080"
 
 
 @pytest.mark.parametrize("bad_model", [123, 4.5, None, ["yolov8n.onnx"], {"name": "x"}])

--- a/tests/test_overlay_draw_scene_passes.py
+++ b/tests/test_overlay_draw_scene_passes.py
@@ -256,7 +256,7 @@ class TestDrawDetections:
 
     def test_attached_box_uses_marker_colour_others_default(self) -> None:
         state = _scene_state(
-            detection_box_color="#00ff00",  # default green
+            detection_box_color="#808080",  # default grey
             detection_show_labels=False,
             detection_attached_track_id=2,
             detection_attached_color="#ff0000",  # marker red
@@ -268,15 +268,16 @@ class TestDrawDetections:
         cr = FakeCairo()
         draw_detections(FakeRenderer(), cr, state, 100, 100)
         strokes = [c for c in cr.calls if c[0] == "rgba"]
-        # Box 1 (unattached) renders green; box 2 (attached) renders red.
-        assert strokes[0][1:4] == pytest.approx((0.0, 1.0, 0.0))
+        # Box 1 (unattached) renders grey; box 2 (attached) renders red.
+        grey = 128 / 255
+        assert strokes[0][1:4] == pytest.approx((grey, grey, grey))
         assert strokes[1][1:4] == pytest.approx((1.0, 0.0, 0.0))
 
     def test_attached_colour_ignored_when_track_not_present(self) -> None:
         # An attached track id with no matching detection leaves every box in
         # the default colour (no crash, no stray highlight).
         state = _scene_state(
-            detection_box_color="#00ff00",
+            detection_box_color="#808080",
             detection_show_labels=False,
             detection_attached_track_id=99,
             detection_attached_color="#ff0000",
@@ -285,7 +286,8 @@ class TestDrawDetections:
         cr = FakeCairo()
         draw_detections(FakeRenderer(), cr, state, 100, 100)
         first_rgba = next(c for c in cr.calls if c[0] == "rgba")
-        assert first_rgba[1:4] == pytest.approx((0.0, 1.0, 0.0))
+        grey = 128 / 255
+        assert first_rgba[1:4] == pytest.approx((grey, grey, grey))
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_overlay_state.py
+++ b/tests/test_overlay_state.py
@@ -80,7 +80,7 @@ def test_overlay_state_reset_restores_defaults() -> None:
     assert state.discovered_sources == []
     assert state.available_interfaces == []
     assert state.detection_show_boxes is False
-    assert state.detection_box_color == "#00ff00"
+    assert state.detection_box_color == "#808080"
     assert state.unit_system is UnitSystem.METRIC
     assert state.source_selection_title == "SELECT SOURCE"
     assert len(state._marker_pool) == 16

--- a/tests/test_services_marker_visuals_remaining.py
+++ b/tests/test_services_marker_visuals_remaining.py
@@ -681,7 +681,7 @@ class TestExternalStateSnapshots:
         # Defaults come from DetectionConfig.
         assert state.detection_show_boxes is True
         assert state.detection_show_labels is True
-        assert state.detection_box_color == "#00ff00"
+        assert state.detection_box_color == "#808080"
         assert state.detection_box_thickness == 2
 
     def test_no_detector_leaves_detection_defaults(self, pool: OverlayStatePool) -> None:


### PR DESCRIPTION
Switches the default person-detection bounding-box colour from green (`#00ff00`) to a neutral grey (`#808080`).

Green read as an "active/good" status signal and clashed with marker colours. Grey keeps the boxes legible without implying state; the box currently attached to a marker still highlights in that marker's own colour.

Touches the config default + coercion fallback, the overlay-state default/reset, the help drawer copy, and the tests that pin the default. Existing operators who already set a custom colour are unaffected.