### PR TITLE
Wizard: use stage-left / audience-right corner convention

### DIFF
--- a/docs/stage_default_perspective.svg
+++ b/docs/stage_default_perspective.svg
@@ -192,7 +192,7 @@
 <polygon points="4929.6,2419.9 5164.1,2419.9 5529.2,2371.5 5274.4,2371.5" fill="#5a1212" stroke="#1a0606" stroke-width="0.6"/>
 <polygon points="5197.6,2419.9 5432.1,2419.9 5820.5,2371.5 5565.7,2371.5" fill="#5a1212" stroke="#1a0606" stroke-width="0.6"/>
 <polygon points="5465.6,2419.9 5700.1,2419.9 6111.8,2371.5 5856.9,2371.5" fill="#5a1212" stroke="#1a0606" stroke-width="0.6"/>
-<polygon points="292.0,732.7 1628.0,732.7 1421.6,465.7 498.4,465.7" fill="#c9a14a" fill-opacity="0.10" stroke="#c9a14a" stroke-opacity="0.55" stroke-width="2"/>
+<polygon points="1628.0,732.7 292.0,732.7 498.4,465.7 1421.6,465.7" fill="#c9a14a" fill-opacity="0.10" stroke="#c9a14a" stroke-opacity="0.55" stroke-width="2"/>
 <line x1="292.0" y1="732.7" x2="498.4" y2="465.7" stroke="#c9a14a" stroke-opacity="0.30" stroke-width="1"/>
 <line x1="425.6" y1="732.7" x2="590.7" y2="465.7" stroke="#c9a14a" stroke-opacity="0.30" stroke-width="1"/>
 <line x1="559.2" y1="732.7" x2="683.0" y2="465.7" stroke="#c9a14a" stroke-opacity="0.30" stroke-width="1"/>
@@ -214,13 +214,13 @@
 <line x1="950.0" y1="732.7" x2="970.0" y2="732.7" stroke="#ffbc00" stroke-width="2"/>
 <line x1="960.0" y1="722.7" x2="960.0" y2="742.7" stroke="#ffbc00" stroke-width="2"/>
 <circle cx="960.0" cy="732.7" r="8" fill="none" stroke="#ffbc00" stroke-width="1.5"/>
-<circle cx="292.0" cy="732.7" r="7" fill="rgba(255,188,0,0.8)" stroke="#ffbc00" stroke-width="1.5"/>
-<text x="304.0" y="736.7" fill="rgba(247,245,233,0.8)" font-size="11" font-weight="600">DSL</text>
 <circle cx="1628.0" cy="732.7" r="7" fill="rgba(255,188,0,0.8)" stroke="#ffbc00" stroke-width="1.5"/>
-<text x="1640.0" y="736.7" fill="rgba(247,245,233,0.8)" font-size="11" font-weight="600">DSR</text>
-<circle cx="1421.6" cy="465.7" r="7" fill="rgba(255,188,0,0.8)" stroke="#ffbc00" stroke-width="1.5"/>
-<text x="1433.6" y="469.7" fill="rgba(247,245,233,0.8)" font-size="11" font-weight="600">USR</text>
+<text x="1640.0" y="736.7" fill="rgba(247,245,233,0.8)" font-size="11" font-weight="600">DSL</text>
+<circle cx="292.0" cy="732.7" r="7" fill="rgba(255,188,0,0.8)" stroke="#ffbc00" stroke-width="1.5"/>
+<text x="304.0" y="736.7" fill="rgba(247,245,233,0.8)" font-size="11" font-weight="600">DSR</text>
 <circle cx="498.4" cy="465.7" r="7" fill="rgba(255,188,0,0.8)" stroke="#ffbc00" stroke-width="1.5"/>
-<text x="510.4" y="469.7" fill="rgba(247,245,233,0.8)" font-size="11" font-weight="600">USL</text>
+<text x="510.4" y="469.7" fill="rgba(247,245,233,0.8)" font-size="11" font-weight="600">USR</text>
+<circle cx="1421.6" cy="465.7" r="7" fill="rgba(255,188,0,0.8)" stroke="#ffbc00" stroke-width="1.5"/>
+<text x="1433.6" y="469.7" fill="rgba(247,245,233,0.8)" font-size="11" font-weight="600">USL</text>
 <rect x="0.5" y="0.5" width="1919" height="1079" fill="none" stroke="#000" stroke-width="1"/>
 </svg>

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -6614,12 +6614,16 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
 
         hw, hd = w / 2.0, d / 2.0
 
+        # PSN +X is stage left, so the stage-left corners (DSL, USL) sit at
+        # +hw and the stage-right corners (DSR, USR) at -hw. On a front-of-house
+        # camera that places stage left on the right of the image (audience
+        # right) and stage right on the left (audience left).
         corners_psn = np.array(
             [
-                [ox - hw, oy - hd, oz],  # DSL
-                [ox + hw, oy - hd, oz],  # DSR
-                [ox + hw, oy + hd, oz],  # USR
-                [ox - hw, oy + hd, oz],  # USL
+                [ox + hw, oy - hd, oz],  # DSL (downstage stage-left)
+                [ox - hw, oy - hd, oz],  # DSR (downstage stage-right)
+                [ox - hw, oy + hd, oz],  # USR (upstage stage-right)
+                [ox + hw, oy + hd, oz],  # USL (upstage stage-left)
             ],
             dtype=np.float64,
         )

--- a/openfollow/web/templates/wizard.tpl
+++ b/openfollow/web/templates/wizard.tpl
@@ -441,7 +441,7 @@
       <p class="wizard-help">Define where the Reference Point sits within the grid. By default, it's at the <strong>center of the front edge</strong> (X&nbsp;Offset&nbsp;=&nbsp;0, Y&nbsp;Offset&nbsp;=&nbsp;depth&nbsp;/&nbsp;2).</p>
       <div class="row">
         <div class="field">
-          <label for="grid_x_offset">X Offset ({{_len}}) <span style="font-weight:400;text-transform:none;letter-spacing:0;">(right +)</span></label>
+          <label for="grid_x_offset">X Offset ({{_len}}) <span style="font-weight:400;text-transform:none;letter-spacing:0;">(stage left +)</span></label>
           <input type="{{'text' if _imp else 'number'}}"{{!'' if _imp else ' step="0.01"'}} id="grid_x_offset" value="{{format_length(config.grid.x_offset, _us) if _imp else config.grid.x_offset}}" oninput="onGridInputChanged()">
           % if _imp:
           <small class="metric-echo" id="grid_x_offset-echo">Stored: {{metric_echo(config.grid.x_offset)}}</small>
@@ -713,16 +713,10 @@
       % # hooks drag handlers. SVG groups: -edges (partial polygon to
       % # neighbors), -marker (centre handle operator drags).
       % # aria-label for screen readers (semantic stage position names).
+      % # Box order mirrors a front-of-house image: stage left on the right,
+      % # so the top row is USR, USL and the bottom row DSR, DSL.
       <div id="fine-zoom-view" style="display:none;">
         <div class="fine-zoom-grid" id="fine-zoom-grid">
-          <div class="fine-zoom-box" data-corner="USL">
-            <svg class="fine-zoom-svg" data-corner="USL" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" role="group" aria-label="Fine adjust upstage-left corner">
-              <image data-fine-zoom-image x="0" y="0"/>
-              <g data-fine-zoom-edges></g>
-              <g data-fine-zoom-marker></g>
-            </svg>
-            <span class="fine-zoom-corner-label">USL</span>
-          </div>
           <div class="fine-zoom-box" data-corner="USR">
             <svg class="fine-zoom-svg" data-corner="USR" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" role="group" aria-label="Fine adjust upstage-right corner">
               <image data-fine-zoom-image x="0" y="0"/>
@@ -731,13 +725,13 @@
             </svg>
             <span class="fine-zoom-corner-label">USR</span>
           </div>
-          <div class="fine-zoom-box" data-corner="DSL">
-            <svg class="fine-zoom-svg" data-corner="DSL" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" role="group" aria-label="Fine adjust downstage-left corner">
+          <div class="fine-zoom-box" data-corner="USL">
+            <svg class="fine-zoom-svg" data-corner="USL" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" role="group" aria-label="Fine adjust upstage-left corner">
               <image data-fine-zoom-image x="0" y="0"/>
               <g data-fine-zoom-edges></g>
               <g data-fine-zoom-marker></g>
             </svg>
-            <span class="fine-zoom-corner-label">DSL</span>
+            <span class="fine-zoom-corner-label">USL</span>
           </div>
           <div class="fine-zoom-box" data-corner="DSR">
             <svg class="fine-zoom-svg" data-corner="DSR" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" role="group" aria-label="Fine adjust downstage-right corner">
@@ -746,6 +740,14 @@
               <g data-fine-zoom-marker></g>
             </svg>
             <span class="fine-zoom-corner-label">DSR</span>
+          </div>
+          <div class="fine-zoom-box" data-corner="DSL">
+            <svg class="fine-zoom-svg" data-corner="DSL" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" role="group" aria-label="Fine adjust downstage-left corner">
+              <image data-fine-zoom-image x="0" y="0"/>
+              <g data-fine-zoom-edges></g>
+              <g data-fine-zoom-marker></g>
+            </svg>
+            <span class="fine-zoom-corner-label">DSL</span>
           </div>
         </div>
       </div>
@@ -775,7 +777,7 @@
     </div>
 
     <p class="wizard-help" style="margin-top:0.72rem;">
-      <strong>Drag each corner marker</strong> to the corresponding physical mark on the stage, as seen from your camera's point of view. The labels mark image quadrants: <strong>DSL</strong> goes on the front mark at the left of the image, <strong>DSR</strong> on the front mark at the right, and so on. (Note: with a front-of-house camera the left of the image is stage right.)
+      <strong>Drag each corner marker</strong> to its physical mark on the stage. The labels are stage positions: <strong>DSL</strong>/<strong>USL</strong> are stage left, <strong>DSR</strong>/<strong>USR</strong> are stage right (D = downstage/front, U = upstage/back). With a front-of-house camera you see the audience's view, so stage left is on the right of the image (audience right) and stage right is on the left (audience left).
     </p>
     <p class="wizard-tip">Start with the two downstage corners (front), then adjust the upstage corners (back). If a corner turns red, the shape is invalid. For pixel-precise placement, click <strong>Fine adjust</strong> to switch to a 4×-zoomed per-corner view.</p>
     <p>If your corners are invalid, three things could be wrong: The position of your camera relative to the reference point, your marked rectangle has not the same size as the grid, or the corners of your rectangle are not 90 degrees.</p>
@@ -1463,10 +1465,12 @@
       var el = document.getElementById(id);
       el.setAttribute('x', x); el.setAttribute('y', y);
     };
-    setLabel('gs-label-dsl', gx - pad, dsY + 14);
-    setLabel('gs-label-dsr', gx + gw + pad - 20, dsY + 14);
-    setLabel('gs-label-usl', gx - pad, gy - 4);
-    setLabel('gs-label-usr', gx + gw + pad - 20, gy - 4);
+    // +X is stage left, drawn on the right, so DSL/USL sit at the right edge
+    // and DSR/USR at the left edge (audience view: stage left = audience right).
+    setLabel('gs-label-dsr', gx - pad, dsY + 14);
+    setLabel('gs-label-dsl', gx + gw + pad - 20, dsY + 14);
+    setLabel('gs-label-usr', gx - pad, gy - 4);
+    setLabel('gs-label-usl', gx + gw + pad - 20, gy - 4);
 
     // Width dimension (below grid)
     var dimY = dsY + 22;
@@ -1546,7 +1550,7 @@
       offZLabel.style.display = 'none';
     }
 
-    // Diagonal (DSL→USR)
+    // Diagonal (DSR→USL)
     var diag = Math.sqrt(w * w + d * d);
     var diagLine = document.getElementById('gs-diag');
     diagLine.setAttribute('x1', gx); diagLine.setAttribute('y1', dsY);
@@ -1714,11 +1718,13 @@
 
     var svgW = 580, svgH = 400;
     var hw = gw / 2, hd = gd / 2;
+    // Stage convention: +X is stage left, so DSL/USL are at +hw and DSR/USR
+    // at -hw (order: DSL, DSR, USR, USL), matching the other wizard steps.
     var gridCorners = [
-      [gox - hw, goy - hd],
       [gox + hw, goy - hd],
-      [gox + hw, goy + hd],
+      [gox - hw, goy - hd],
       [gox - hw, goy + hd],
+      [gox + hw, goy + hd],
     ];
 
     function isoProject(wx, wy, wz) {
@@ -1992,7 +1998,8 @@
     fovLabel.setAttribute('text-anchor', 'end');
     fovLabel.textContent = 'FOV ' + fov.toFixed(0) + '\u00b0';
 
-    // Downstage / Upstage labels – near DSL and USL corners
+    // Downstage label near the downstage stage-right (DSR) corner; upstage
+    // label centered on the upstage edge.
     var dsLabelPos = toSvg(gox - hw, goy - hd, goz + 1.0);
     document.getElementById('cp-ds-label').setAttribute('x', dsLabelPos[0] + 6);
     document.getElementById('cp-ds-label').setAttribute('y', dsLabelPos[1]);
@@ -2527,11 +2534,13 @@
     var g = state.grid;
     var hw = g.width / 2, hd = g.depth / 2;
     var ox = g.x_offset, oy = g.y_offset, oz = g.z_offset;
+    // Stage convention: +X is stage left, so DSL/USL are at +hw and DSR/USR
+    // at -hw. Each row pairs with the same-named screen corner below.
     var worldCorners = [
-      [ox - hw, oy - hd, oz],
       [ox + hw, oy - hd, oz],
-      [ox + hw, oy + hd, oz],
+      [ox - hw, oy - hd, oz],
       [ox - hw, oy + hd, oz],
+      [ox + hw, oy + hd, oz],
     ];
     var screenCorners = [
       cornerPositions.DSL,
@@ -3054,11 +3063,13 @@
     var g = state.grid;
     var hw = g.width / 2, hd = g.depth / 2;
     var ox = g.x_offset, oy = g.y_offset, oz = g.z_offset;
+    // Stage convention: +X is stage left, so DSL/USL are at +hw and DSR/USR
+    // at -hw. Each row pairs with the same-named screen corner below.
     var worldCorners = [
-      [ox - hw, oy - hd, oz],
       [ox + hw, oy - hd, oz],
-      [ox + hw, oy + hd, oz],
+      [ox - hw, oy - hd, oz],
       [ox - hw, oy + hd, oz],
+      [ox + hw, oy + hd, oz],
     ];
 
     var screenCorners = [

--- a/scripts/gen_stage_svg.py
+++ b/scripts/gen_stage_svg.py
@@ -75,17 +75,21 @@ def poly_str(pts_2d) -> str:
 
 
 def grid_corners(grid: GridConfig) -> list[tuple[float, float, float]]:
-    """Return DSL, DSR, USR, USL grid corners in PSN coords."""
+    """Return DSL, DSR, USR, USL grid corners in PSN coords.
+
+    PSN +X is stage left, so the stage-left corners (DSL, USL) sit at +hw and
+    the stage-right corners (DSR, USR) at -hw.
+    """
     hw = grid.width / 2.0
     hd = grid.depth / 2.0
     cx = grid.x_offset
     cy = grid.y_offset
     z = grid.z_offset
     return [
-        (cx - hw, cy - hd, z),
-        (cx + hw, cy - hd, z),
-        (cx + hw, cy + hd, z),
-        (cx - hw, cy + hd, z),
+        (cx + hw, cy - hd, z),  # DSL (downstage stage-left)
+        (cx - hw, cy - hd, z),  # DSR (downstage stage-right)
+        (cx - hw, cy + hd, z),  # USR (upstage stage-right)
+        (cx + hw, cy + hd, z),  # USL (upstage stage-left)
     ]
 
 
@@ -361,12 +365,13 @@ def _draw_tape_corners(out, p, grid: GridConfig):
     cy = grid.y_offset
     z = grid.z_offset
     L = TAPE_BRACKET_LEN
-    # (corner, inward_x_sign, inward_y_sign)
+    # (corner, inward_x_sign, inward_y_sign). +X is stage left, so the -hw
+    # corners are stage right (DSR/USR) and the +hw corners stage left (DSL/USL).
     specs = [
-        ((cx - hw, cy - hd, z), +1, +1),  # DSL
-        ((cx + hw, cy - hd, z), -1, +1),  # DSR
-        ((cx + hw, cy + hd, z), -1, -1),  # USR
-        ((cx - hw, cy + hd, z), +1, -1),  # USL
+        ((cx - hw, cy - hd, z), +1, +1),  # DSR (downstage stage-right)
+        ((cx + hw, cy - hd, z), -1, +1),  # DSL (downstage stage-left)
+        ((cx + hw, cy + hd, z), -1, -1),  # USL (upstage stage-left)
+        ((cx - hw, cy + hd, z), +1, -1),  # USR (upstage stage-right)
     ]
     for (x0, y0, z0), sx, sy in specs:
         x_arm_end = (x0 + sx * L, y0, z0)

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -215,22 +215,24 @@ class TestConfigDefaults:
         grid = GridConfig()
         hw = grid.width / 2.0
         hd = grid.depth / 2.0
+        # Stage convention: +X is stage left, so DSL/USL are at +hw and DSR/USR
+        # at -hw (matching openfollow/web/routes.py and scripts/gen_stage_svg.py).
         corners = np.array(
             [
-                [grid.x_offset - hw, grid.y_offset - hd, grid.z_offset],  # DSL
-                [grid.x_offset + hw, grid.y_offset - hd, grid.z_offset],  # DSR
-                [grid.x_offset + hw, grid.y_offset + hd, grid.z_offset],  # USR
-                [grid.x_offset - hw, grid.y_offset + hd, grid.z_offset],  # USL
+                [grid.x_offset + hw, grid.y_offset - hd, grid.z_offset],  # DSL (stage left)
+                [grid.x_offset - hw, grid.y_offset - hd, grid.z_offset],  # DSR (stage right)
+                [grid.x_offset - hw, grid.y_offset + hd, grid.z_offset],  # USR (stage right)
+                [grid.x_offset + hw, grid.y_offset + hd, grid.z_offset],  # USL (stage left)
             ]
         )
         params = np.array([cam.pos_x, cam.pos_y, cam.pos_z, cam.pitch, cam.yaw, cam.roll, cam.fov])
         projected = project_points(params, corners, 1920.0, 1080.0)
         expected = np.array(
             [
-                [292.0, 732.7],
-                [1628.0, 732.7],
-                [1421.6, 465.7],
-                [498.4, 465.7],
+                [1628.0, 732.7],  # DSL (stage left → image right)
+                [292.0, 732.7],  # DSR (stage right → image left)
+                [498.4, 465.7],  # USR
+                [1421.6, 465.7],  # USL
             ]
         )
         assert np.allclose(projected, expected, atol=0.5), (
@@ -579,6 +581,34 @@ class TestWizardProjectEndpoint:
             x, y = c[name]
             assert 0 <= x <= IMG_W, f"{name} x={x} out of bounds"
             assert 0 <= y <= IMG_H, f"{name} y={y} out of bounds"
+
+    def test_stage_left_corners_project_to_image_right(self, live_server) -> None:
+        """Stage-left corners (DSL/USL) land on the right of a front-of-house image.
+
+        PSN ``+X`` is stage left, and a centred front-of-house camera shows the
+        audience's view, where stage left is on the right (audience right). So
+        the stage-left corners must project to a larger image-x than their
+        stage-right counterparts. This pins the convention the wizard labels and
+        DLT solve depend on (stage left / audience right), not the projection math.
+        """
+        _, base = live_server
+        status, data = _post_json(
+            base,
+            "/api/wizard/project",
+            {
+                "camera": _CAM,
+                "grid": _GRID,
+                "image_width": IMG_W,
+                "image_height": IMG_H,
+            },
+        )
+        assert status == 200
+        c = data["corners"]
+        assert c["DSL"][0] > c["DSR"][0], "DSL (stage left) must be right of DSR (stage right)"
+        assert c["USL"][0] > c["USR"][0], "USL (stage left) must be right of USR (stage right)"
+        # Downstage corners sit lower in the image (larger y) than upstage ones.
+        assert c["DSL"][1] > c["USL"][1], "DSL (downstage) must be below USL (upstage)"
+        assert c["DSR"][1] > c["USR"][1], "DSR (downstage) must be below USR (upstage)"
 
     # Camera sitting inside the grid footprint, nearly level: the two front
     # corners fall at/behind the camera plane and project to NaN.


### PR DESCRIPTION
## What

The setup wizard tagged grid corners `DSL`/`DSR`/`USL`/`USR` by **image quadrant**, so the stage-left corners (`DSL`/`USL`) sat on the low-X side and rendered on the **image-left** for a front-of-house camera. Stage left is `+X` = audience right, so on a FOH camera it belongs on the **right** of the image. (The fine-zoom `aria-label`s already described them as stage positions, confirming the geometry was the bug, not the labels.)

This reassigns the corner labels to the stage convention (`DSL`/`USL` = `+hw`, `DSR`/`USR` = `-hw`) everywhere, keeping the DLT solve correct (world↔screen pairing preserved):

- `/api/wizard/project` corner mapping + both DLT-solve payloads
- Grid-setup plan view labels + the `(stage left +)` X-offset hint
- Corner-pinning overlay, the fine-zoom 2×2 box layout, and the copy ("stage left is on the right of the image (audience right)")
- Camera-position illustration (array order only; its corner labels are hidden, so no visible change)
- Regenerated `docs/stage_default_perspective.svg` (the testpattern asset is byte-identical)

Step 1 (Preparation) keeps its existing isometric labelling.

## Tests

- New regression test `test_stage_left_corners_project_to_image_right`: asserts `DSL`/`USL` project to a larger image-x than `DSR`/`USR` for a front-of-house camera (the spec, not the projection math).
- Updated the stock-SVG projection test to the new corner order.

## CI note

`make ci` passes except for `tests/test_solver_properties.py::test_solve_dlt_reprojects_on_screen_corners_within_2px`, a pre-existing DLT-solver Hypothesis failure that fails identically on `origin/main` and is in a file this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)