### PR TITLE
Shared OSC Destinations (reusable connection profiles)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -733,10 +733,9 @@ zones/
 - `enabled` (bool) – arms the engine (OSC output). Default `False`.
 - `show_overlay` (bool) – renders zone polygons on the HUD. Independent of `enabled` – the overlay hotkey (`z` / `B`) flips this alone, so rendering must not be gated on `enabled`.
 - `eval_fps` (int, one of `1, 5, 10, 15, 30, 60`) – engine evaluation rate; marker/detection collection is skipped between ticks.
-- `default_osc_host` / `default_osc_port` – fallback target when a zone leaves its own `osc_host`/`osc_port` blank.
 - `debounce_ms` (int) – transitions inside the window are **discarded, not queued**.
 - `hysteresis` (float, metres) – inward polygon offset applied to build the exit polygon (`shrink_polygon`), so near-boundary flicker doesn't re-fire OSC.
-- `zones: list[TriggerZoneConfig]` – per-zone: `vertices`, `color`, `trigger_source` (`"markers" | "detection" | "both"`), four OSC addresses (`osc_address_first_entry`, `_additional_entry`, `_partial_exit`, `_final_exit`), optional `osc_host`/`osc_port` override, `enabled`.
+- `zones: list[TriggerZoneConfig]` – per-zone: `vertices`, `color`, `trigger_source` (`"markers" | "detection" | "both"`), four OSC addresses (`osc_address_first_entry`, `_additional_entry`, `_partial_exit`, `_final_exit`), `destination_id` (references a shared `OscDestinationConfig`; blank/dangling = emit nothing), `enabled`.
 
 ### Occupancy state machine (`ZoneEngine._emit_transitions`)
 Per zone, tracks the set of occupants and an integer count. Transitions, in order:

--- a/config.example.toml
+++ b/config.example.toml
@@ -179,12 +179,22 @@ pin_mode = "assist"
 assist_radius_m = 1.0
 assist_strength = 0.5
 
+# Reusable OSC connection profiles. Transmitters and trigger zones reference
+# a destination by `id`; edit one here and every consumer repoints live. The
+# `id` is a stable key (referenced by `destination_id` elsewhere) – keep it
+# fixed once other rows point at it.
+[[osc_destinations.destinations]]
+id = "default"
+name = "Default"
+host = "127.0.0.1"
+port = 8000
+protocol = "udp"   # "udp" | "tcp"
+framing = "slip"   # TCP only: "slip" | "length_prefix"
+
 [trigger_zones]
 enabled = true
 show_overlay = true
 eval_fps = 10
-default_osc_host = "127.0.0.1"
-default_osc_port = 53000
 debounce_ms = 200
 hysteresis = 0.05
 

--- a/openfollow/configuration.py
+++ b/openfollow/configuration.py
@@ -1413,15 +1413,40 @@ class OscDestinationsConfig:
             for d in self.destinations
             if isinstance(d, (dict, OscDestinationConfig))
         ]
+        # The id is the key transmitters/zones reference, so it must be unique:
+        # a hand-edited TOML or crafted import with two entries sharing an id
+        # would make ``get()`` resolve ambiguously (first match wins) and hide
+        # the duplicate from editing. Keep the first occurrence's id stable so
+        # existing references stay valid; re-mint a fresh uuid for each later
+        # collision rather than dropping the entry.
+        seen_ids: set[str] = set()
+        for dest in self.destinations:
+            if dest.id in seen_ids:
+                dest.id = _new_uuid_hex()
+            seen_ids.add(dest.id)
 
     def get(self, destination_id: str) -> OscDestinationConfig | None:
-        """Resolve a destination id to its profile, or ``None`` if unknown."""
+        """Resolve a destination id to its profile, or ``None`` if unknown.
+
+        Linear scan – fine for one-off lookups (web routes, wizard). Hot
+        per-tick consumers stage an :meth:`by_id` index instead.
+        """
         if not destination_id:
             return None
         for d in self.destinations:
             if d.id == destination_id:
                 return d
         return None
+
+    def by_id(self) -> dict[str, OscDestinationConfig]:
+        """Index destinations by id for O(1) resolution on the hot path.
+
+        Built once when the set is staged into a consumer (the transmitter
+        manager / zone engine) so per-row, per-tick resolution is a dict
+        lookup rather than a linear scan under the lock. Ids are unique
+        (see ``__post_init__``), so the comprehension is unambiguous.
+        """
+        return {d.id: d for d in self.destinations}
 
 
 VALID_CURVES = ("linear", "logarithmic", "quadratic", "s-law")
@@ -2821,39 +2846,56 @@ def apply_runtime_config_changes(app: OpenFollowApp, new_config: AppConfig) -> b
         ):
             app._config.rttrpm_output = old_rttrpm_output
 
-    if new_config.osc_transmitters != app._config.osc_transmitters:
+    # OSC routing: transmitter rows reference a shared destination set, and the
+    # zone engine resolves zone sends against the same set. A transmitter or
+    # destination edit (e.g. an IP change) re-resolves at both consumers so
+    # every referencing row and zone repoints live, no restart. Apply both as
+    # one unit – the manager and the zone engine must agree on the same
+    # destination set, and a partial apply would split routing across the two
+    # consumers (manager on the new endpoints while config + zone engine hold
+    # the old ones). Manager always exists once initialised (no on→off teardown).
+    osc_transmitters_changed = new_config.osc_transmitters != app._config.osc_transmitters
+    osc_destinations_changed = new_config.osc_destinations != app._config.osc_destinations
+    # The trigger_zones block below reloads the zone engine too; when zones also
+    # changed, let that block own the single reload so a combined edit doesn't
+    # reload the engine twice in one pass.
+    trigger_zones_changed = new_config.trigger_zones != app._config.trigger_zones
+    if osc_transmitters_changed or osc_destinations_changed:
         old_osc_transmitters = app._config.osc_transmitters
+        old_osc_destinations = app._config.osc_destinations
         app._config.osc_transmitters = new_config.osc_transmitters
-        # Manager always exists once initialised (no on→off teardown).
-        if not _apply(
-            "osc_transmitters",
+        app._config.osc_destinations = new_config.osc_destinations
+
+        def _reload_zone_destinations(destinations: OscDestinationsConfig) -> None:
+            zone_engine = getattr(app._runtime_services, "_zone_engine", None)
+            if zone_engine is not None:
+                zone_engine.reload_config(app._config.trigger_zones, destinations)
+
+        def _revert_osc_routing() -> None:
+            # Restore config first, then re-stage the old routing into the
+            # manager + zone engine so a failed apply can't leave the manager
+            # on the new endpoints while config and the zone engine hold the
+            # old ones. A re-raise here is caught and logged by the helper.
+            app._config.osc_transmitters = old_osc_transmitters
+            app._config.osc_destinations = old_osc_destinations
+            app._runtime_services.apply_osc_transmitters_change(
+                old_osc_transmitters,
+                old_osc_destinations,
+            )
+            _reload_zone_destinations(old_osc_destinations)
+
+        if _apply(
+            "osc_routing",
             lambda: app._runtime_services.apply_osc_transmitters_change(
                 new_config.osc_transmitters,
                 new_config.osc_destinations,
             ),
+            on_failure=_revert_osc_routing,
         ):
-            app._config.osc_transmitters = old_osc_transmitters
-
-    # A destination edit (e.g. an IP change) re-resolves at both consumers so
-    # every referencing transmitter and zone repoints live, no restart.
-    if new_config.osc_destinations != app._config.osc_destinations:
-        old_osc_destinations = app._config.osc_destinations
-        app._config.osc_destinations = new_config.osc_destinations
-        if not _apply(
-            "osc_destinations",
-            lambda: app._runtime_services.apply_osc_transmitters_change(
-                app._config.osc_transmitters,
-                new_config.osc_destinations,
-            ),
-        ):
-            app._config.osc_destinations = old_osc_destinations
-        else:
-            zone_engine = getattr(app._runtime_services, "_zone_engine", None)
-            if zone_engine is not None:
-                zone_engine.reload_config(
-                    app._config.trigger_zones,
-                    new_config.osc_destinations,
-                )
+            # Skip when the trigger_zones block will reload the engine anyway
+            # (with the same committed destinations) – avoids a double reload.
+            if not trigger_zones_changed:
+                _reload_zone_destinations(new_config.osc_destinations)
 
     if new_config.detection != app._config.detection:
         old_detection = app._config.detection
@@ -2909,9 +2951,11 @@ def apply_runtime_config_changes(app: OpenFollowApp, new_config: AppConfig) -> b
         app._config.trigger_zones = new_config.trigger_zones
         zone_engine = getattr(app._runtime_services, "_zone_engine", None)
         if zone_engine is not None:
+            # Use the committed destinations (``app._config``) so a zones edit
+            # stays coherent with an OSC-routing apply that was reverted above.
             zone_engine.reload_config(
                 new_config.trigger_zones,
-                new_config.osc_destinations,
+                app._config.osc_destinations,
             )
         # The endpoint is resolved from ``osc_destinations`` at send time.
         # Stale per-target sockets in the shared ``OscService`` cache are left

--- a/openfollow/configuration.py
+++ b/openfollow/configuration.py
@@ -1403,15 +1403,16 @@ class OscDestinationsConfig:
     )
 
     def __post_init__(self) -> None:
-        coerced: list[OscDestinationConfig] = []
-        for d in self.destinations:
-            if isinstance(d, dict):
-                coerced.append(
-                    OscDestinationConfig(**_filter_known(OscDestinationConfig, d)),
-                )
-            else:
-                coerced.append(d)
-        self.destinations = coerced
+        # Drop non-object destination entries instead of keeping them verbatim:
+        # a hand-edited inline TOML array (``destinations = ["evil"]``) or a
+        # crafted import would otherwise persist a bare str that ``get()`` and
+        # the template dereference (``d.id`` / ``d.host``) → AttributeError.
+        # Already-typed ``OscDestinationConfig`` entries pass through.
+        self.destinations = [
+            OscDestinationConfig(**_filter_known(OscDestinationConfig, d)) if isinstance(d, dict) else d
+            for d in self.destinations
+            if isinstance(d, (dict, OscDestinationConfig))
+        ]
 
     def get(self, destination_id: str) -> OscDestinationConfig | None:
         """Resolve a destination id to its profile, or ``None`` if unknown."""

--- a/openfollow/configuration.py
+++ b/openfollow/configuration.py
@@ -567,8 +567,9 @@ class TriggerZoneConfig:
     osc_address_additional_entry: str = ""
     osc_address_partial_exit: str = ""
     osc_address_final_exit: str = ""
-    osc_host: str = ""
-    osc_port: int = 0
+    # Reference to an :class:`OscDestinationConfig`. Empty = no destination
+    # selected → the zone emits nothing.
+    destination_id: str = ""
     enabled: bool = True
 
     def __post_init__(self) -> None:
@@ -605,6 +606,9 @@ class TriggerZoneConfig:
             except (TypeError, ValueError):
                 continue
         self.triggered_by = cleaned_ids
+        if not isinstance(self.destination_id, str):
+            self.destination_id = ""
+        self.destination_id = self.destination_id.strip()
 
 
 @dataclass
@@ -614,8 +618,6 @@ class TriggerZonesConfig:
     enabled: bool = False
     show_overlay: bool = True
     eval_fps: int = 10
-    default_osc_host: str = "127.0.0.1"
-    default_osc_port: int = 53000
     debounce_ms: int = 200
     hysteresis: float = 0.05  # metres – inward polygon offset for exit threshold
     zones: list[TriggerZoneConfig] = field(default_factory=list)
@@ -634,12 +636,6 @@ class TriggerZonesConfig:
         # survive. Upper bounds mirror ``openfollow/web/validation.py``.
         self.debounce_ms = _coerce_int(self.debounce_ms, 200, lo=0, hi=60000)
         self.hysteresis = _coerce_float(self.hysteresis, 0.05, lo=0.0, hi=10.0)
-        self.default_osc_port = _coerce_int(
-            self.default_osc_port,
-            53000,
-            lo=1,
-            hi=65535,
-        )
         # Drop non-object zone entries instead of keeping them verbatim: a
         # hand-edited inline TOML array (``zones = ["evil"]``) or a crafted
         # payload would otherwise persist a bare str/int that the zone engine
@@ -1231,12 +1227,9 @@ class OscTransmitterConfig:
     id: str = ""
     enabled: bool = False
     name: str = ""
-    host: str = "127.0.0.1"
-    port: int = 8000
-    protocol: str = "udp"
-    # TCP framing selector. Inert for UDP rows but round-trippable so the UI
-    # swap doesn't hide it on protocol toggle.
-    framing: str = "slip"
+    # Reference to an :class:`OscDestinationConfig` (host/port/protocol/framing
+    # live there). Empty = no destination selected → the row skips sending.
+    destination_id: str = ""
     # ``None`` = no default marker picked. Rows using only literals or
     # explicit-marker refs (``[x:markerN]``) still dispatch; rows using a
     # default-marker placeholder (``[x]`` / ``[fy]`` / ``[markerId]``) skip
@@ -1267,20 +1260,9 @@ class OscTransmitterConfig:
         if not isinstance(self.name, str):
             self.name = ""
         self.name = self.name.strip()
-        if not isinstance(self.host, str):
-            self.host = "127.0.0.1"
-        self.host = self.host.strip() or "127.0.0.1"
-        self.port = _coerce_int(self.port, 8000, lo=1, hi=65535)
-        self.protocol = _coerce_choice(
-            self.protocol,
-            VALID_OSC_TRANSMITTER_PROTOCOLS,
-            "udp",
-        )
-        self.framing = _coerce_choice(
-            self.framing,
-            VALID_OSC_FRAMINGS,
-            "slip",
-        )
+        if not isinstance(self.destination_id, str):
+            self.destination_id = ""
+        self.destination_id = self.destination_id.strip()
         self.marker_id = _coerce_optional_marker_id(self.marker_id)
         # ``None`` for unset, else 1..VIRTUAL_FADER_COUNT; out-of-range/junk
         # collapses to ``None`` rather than routing to a valid-but-wrong fader.
@@ -1358,6 +1340,87 @@ class OscTransmittersConfig:
             else:
                 coerced_transmitters.append(t)
         self.transmitters = coerced_transmitters
+
+
+@dataclass
+class OscDestinationConfig:
+    """A named, reusable OSC connection profile.
+
+    Transmitters and trigger zones reference a destination by ``id`` instead
+    of carrying host/port/protocol/framing inline, so re-pointing a single
+    destination repoints every consumer at once.
+    """
+
+    id: str = ""
+    name: str = ""
+    host: str = "127.0.0.1"
+    port: int = 8000
+    protocol: str = "udp"
+    # TCP framing selector. Inert for UDP but round-trippable so the UI swap
+    # doesn't hide it on protocol toggle.
+    framing: str = "slip"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.id, str) or not self.id.strip():
+            self.id = _new_uuid_hex()
+        else:
+            self.id = self.id.strip()
+        if not isinstance(self.name, str):
+            self.name = ""
+        self.name = self.name.strip()
+        if not isinstance(self.host, str):
+            self.host = "127.0.0.1"
+        self.host = self.host.strip() or "127.0.0.1"
+        self.port = _coerce_int(self.port, 8000, lo=1, hi=65535)
+        self.protocol = _coerce_choice(
+            self.protocol,
+            VALID_OSC_TRANSMITTER_PROTOCOLS,
+            "udp",
+        )
+        self.framing = _coerce_choice(
+            self.framing,
+            VALID_OSC_FRAMINGS,
+            "slip",
+        )
+
+
+def _default_osc_destinations() -> list[OscDestinationConfig]:
+    """Seed one pickable destination so fresh installs have a non-empty list.
+
+    The id is fixed (not minted) so two default configs compare equal – the
+    hot-reload diff and a pile of ``AppConfig() == AppConfig()`` tests rely on
+    default-config equality.
+    """
+    return [OscDestinationConfig(id="default", name="Default")]
+
+
+@dataclass
+class OscDestinationsConfig:
+    """Container for the shared OSC destination profiles."""
+
+    destinations: list[OscDestinationConfig] = field(
+        default_factory=_default_osc_destinations,
+    )
+
+    def __post_init__(self) -> None:
+        coerced: list[OscDestinationConfig] = []
+        for d in self.destinations:
+            if isinstance(d, dict):
+                coerced.append(
+                    OscDestinationConfig(**_filter_known(OscDestinationConfig, d)),
+                )
+            else:
+                coerced.append(d)
+        self.destinations = coerced
+
+    def get(self, destination_id: str) -> OscDestinationConfig | None:
+        """Resolve a destination id to its profile, or ``None`` if unknown."""
+        if not destination_id:
+            return None
+        for d in self.destinations:
+            if d.id == destination_id:
+                return d
+        return None
 
 
 VALID_CURVES = ("linear", "logarithmic", "quadratic", "s-law")
@@ -1811,6 +1874,7 @@ class AppConfig:
     otp_output: OtpOutputConfig = field(default_factory=OtpOutputConfig)
     rttrpm_output: RttrpmOutputConfig = field(default_factory=RttrpmOutputConfig)
     osc_transmitters: OscTransmittersConfig = field(default_factory=OscTransmittersConfig)
+    osc_destinations: OscDestinationsConfig = field(default_factory=OscDestinationsConfig)
     detection: DetectionConfig = field(default_factory=DetectionConfig)
     trigger_zones: TriggerZonesConfig = field(default_factory=TriggerZonesConfig)
     midi: MidiConfig = field(default_factory=MidiConfig)
@@ -1909,6 +1973,7 @@ _SUB_CONFIG_MAP: dict[str, type] = {
     "otp_output": OtpOutputConfig,
     "rttrpm_output": RttrpmOutputConfig,
     "osc_transmitters": OscTransmittersConfig,
+    "osc_destinations": OscDestinationsConfig,
     "detection": DetectionConfig,
     "trigger_zones": TriggerZonesConfig,
     "midi": MidiConfig,
@@ -2763,9 +2828,31 @@ def apply_runtime_config_changes(app: OpenFollowApp, new_config: AppConfig) -> b
             "osc_transmitters",
             lambda: app._runtime_services.apply_osc_transmitters_change(
                 new_config.osc_transmitters,
+                new_config.osc_destinations,
             ),
         ):
             app._config.osc_transmitters = old_osc_transmitters
+
+    # A destination edit (e.g. an IP change) re-resolves at both consumers so
+    # every referencing transmitter and zone repoints live, no restart.
+    if new_config.osc_destinations != app._config.osc_destinations:
+        old_osc_destinations = app._config.osc_destinations
+        app._config.osc_destinations = new_config.osc_destinations
+        if not _apply(
+            "osc_destinations",
+            lambda: app._runtime_services.apply_osc_transmitters_change(
+                app._config.osc_transmitters,
+                new_config.osc_destinations,
+            ),
+        ):
+            app._config.osc_destinations = old_osc_destinations
+        else:
+            zone_engine = getattr(app._runtime_services, "_zone_engine", None)
+            if zone_engine is not None:
+                zone_engine.reload_config(
+                    app._config.trigger_zones,
+                    new_config.osc_destinations,
+                )
 
     if new_config.detection != app._config.detection:
         old_detection = app._config.detection
@@ -2821,12 +2908,15 @@ def apply_runtime_config_changes(app: OpenFollowApp, new_config: AppConfig) -> b
         app._config.trigger_zones = new_config.trigger_zones
         zone_engine = getattr(app._runtime_services, "_zone_engine", None)
         if zone_engine is not None:
-            zone_engine.reload_config(new_config.trigger_zones)
-        # Default OSC host/port flows through ``reload_config`` (the engine
-        # reads ``default_osc_*`` at send time). Stale per-target sockets in
-        # the shared ``OscService`` cache are left in place – they're reused if
-        # a future row targets the same destination and can't be safely evicted
-        # without per-caller ownership tracking.
+            zone_engine.reload_config(
+                new_config.trigger_zones,
+                new_config.osc_destinations,
+            )
+        # The endpoint is resolved from ``osc_destinations`` at send time.
+        # Stale per-target sockets in the shared ``OscService`` cache are left
+        # in place – they're reused if a future row targets the same
+        # destination and can't be safely evicted without per-caller
+        # ownership tracking.
 
     # The MIDI ``apply_config`` is idempotent (same device on same patch is a
     # no-op), so re-applying on every reload pass is safe.

--- a/openfollow/osc/transmitter.py
+++ b/openfollow/osc/transmitter.py
@@ -47,6 +47,7 @@ from openfollow.configuration import (
     FaderOnChangeTrigger,
     HotkeyTrigger,
     MidiMessageTrigger,
+    OscDestinationConfig,
     OscDestinationsConfig,
     StreamTrigger,
 )
@@ -243,15 +244,12 @@ class _TickPlan:
     # placeholder skips with ``"no default marker configured"`` until
     # set. Rows with no default-marker placeholder dispatch regardless.
     marker_id: int | None
-    host: str
-    port: int
-    protocol: str
-    framing: str
-    # True when the row's ``destination_id`` didn't resolve to a known
-    # destination (blank id, or an id deleted from ``osc_destinations``).
-    # The render path turns this into a "no destination selected" skip so
-    # the row never sends to a bogus endpoint.
-    destination_unset: bool
+    # The resolved OSC destination (host/port/protocol/framing), or ``None``
+    # when the row's ``destination_id`` didn't resolve to a known destination
+    # (blank id, or an id deleted from ``osc_destinations``). The render path
+    # turns ``None`` into a "no destination selected" skip so the row never
+    # sends to a bogus endpoint.
+    destination: OscDestinationConfig | None
     compiled_address: CompiledTemplate
     compiled_args: tuple[CompiledTemplate, ...]
     ring_buffer: BindingRingBuffer
@@ -373,10 +371,11 @@ class OscTransmitterManager:
         self._lock = threading.Lock()
         self._rows: dict[str, OscTransmitter] = {}
         # Shared OSC destination profiles, staged under ``_lock``. A row's
-        # ``destination_id`` is resolved against this at plan-build time;
-        # an unresolved id skips the send. Empty until ``restart`` provides
-        # the current set.
+        # ``destination_id`` is resolved against ``_dest_index`` (an id→profile
+        # map built once per stage) at plan-build time; an unresolved id skips
+        # the send. Empty until ``restart`` provides the current set.
         self._destinations = OscDestinationsConfig(destinations=[])
+        self._dest_index: dict[str, OscDestinationConfig] = {}
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self._tick: int = 0
@@ -487,6 +486,7 @@ class OscTransmitterManager:
         with self._lock:
             if destinations is not None:
                 self._destinations = destinations
+                self._dest_index = destinations.by_id()
             new_rows: dict[str, OscTransmitter] = {}
             invalidate_cache: set[str] = set()
             for row_cfg in cfg.transmitters:
@@ -851,15 +851,12 @@ class OscTransmitterManager:
             stream_mode = "always"
             stream_min_change_m = 0.0
         # Resolve the row's destination under the lock (caller holds it) so
-        # the plan captures a coherent endpoint snapshot.
-        dest = self._destinations.get(cfg.destination_id)
+        # the plan captures a coherent endpoint snapshot. ``get`` on the
+        # staged index is an O(1) dict lookup, not a per-row linear scan.
+        dest = self._dest_index.get(cfg.destination_id)
         return _TickPlan(
             marker_id=cfg.marker_id,
-            host=dest.host if dest is not None else "",
-            port=dest.port if dest is not None else 0,
-            protocol=dest.protocol if dest is not None else "udp",
-            framing=dest.framing if dest is not None else "slip",
-            destination_unset=dest is None,
+            destination=dest,
             compiled_address=row.compiled_address,
             compiled_args=row.compiled_args,
             ring_buffer=row.ring_buffer,
@@ -1174,7 +1171,7 @@ class OscTransmitterManager:
         templates don't reference it, because the on-change gate uses the
         default marker as its signal source.
         """
-        if plan.destination_unset:
+        if plan.destination is None:
             # Blank or dangling ``destination_id`` – nothing to send to.
             return _RenderResult(
                 address="",
@@ -1326,6 +1323,14 @@ class OscTransmitterManager:
         manual probe can't suppress a subsequent live tick or test
         packet.
         """
+        dest = plan.destination
+        if dest is None:
+            # Blank or dangling ``destination_id`` – nothing to send to.
+            # Record the same skip the render path would and bail before
+            # rendering. (``_render_plan_pure`` keeps its own guard for the
+            # diagnostic preview path, which doesn't go through here.)
+            plan.ring_buffer.record_skipped(error="no destination selected")
+            return
         result = self._render_plan_pure(plan)
         if result.skipped:
             plan.ring_buffer.record_skipped(error=result.error)
@@ -1368,10 +1373,10 @@ class OscTransmitterManager:
         self._service.send(
             result.address,
             list(result.args),
-            host=plan.host,
-            port=plan.port,
-            protocol=plan.protocol,
-            framing=plan.framing,
+            host=dest.host,
+            port=dest.port,
+            protocol=dest.protocol,
+            framing=dest.framing,
         )
         # Update the last-sent cache only after the send went out, so a
         # skipped send can't prime it. Locked so a concurrent

--- a/openfollow/osc/transmitter.py
+++ b/openfollow/osc/transmitter.py
@@ -28,8 +28,8 @@ result to :class:`OscService` for transport.
 - Each row keeps the last ~100 send/skip events in a bounded deque.
   Complements (does not replace) the per-target ``ClientStats`` on
   :class:`OscService`.
-- Per-row health lives on :class:`OscService` via
-  ``service.stats_for(row.host, row.port, row.protocol, row.framing)``.
+- Per-row health lives on :class:`OscService`, keyed by the endpoint the
+  row's ``destination_id`` resolves to (host, port, protocol, framing).
 """
 
 from __future__ import annotations
@@ -47,6 +47,7 @@ from openfollow.configuration import (
     FaderOnChangeTrigger,
     HotkeyTrigger,
     MidiMessageTrigger,
+    OscDestinationsConfig,
     StreamTrigger,
 )
 from openfollow.osc.template import (
@@ -246,6 +247,11 @@ class _TickPlan:
     port: int
     protocol: str
     framing: str
+    # True when the row's ``destination_id`` didn't resolve to a known
+    # destination (blank id, or an id deleted from ``osc_destinations``).
+    # The render path turns this into a "no destination selected" skip so
+    # the row never sends to a bogus endpoint.
+    destination_unset: bool
     compiled_address: CompiledTemplate
     compiled_args: tuple[CompiledTemplate, ...]
     ring_buffer: BindingRingBuffer
@@ -366,6 +372,11 @@ class OscTransmitterManager:
         self._controller_marker_provider = controller_marker_provider
         self._lock = threading.Lock()
         self._rows: dict[str, OscTransmitter] = {}
+        # Shared OSC destination profiles, staged under ``_lock``. A row's
+        # ``destination_id`` is resolved against this at plan-build time;
+        # an unresolved id skips the send. Empty until ``restart`` provides
+        # the current set.
+        self._destinations = OscDestinationsConfig(destinations=[])
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self._tick: int = 0
@@ -457,15 +468,25 @@ class OscTransmitterManager:
     # Configuration
     # ------------------------------------------------------------------
 
-    def restart(self, cfg: OscTransmittersConfig) -> None:
+    def restart(
+        self,
+        cfg: OscTransmittersConfig,
+        destinations: OscDestinationsConfig | None = None,
+    ) -> None:
         """Replace the row list. Existing scheduler thread keeps running.
 
         Rows are diffed by ``cfg.id``: an existing row whose id appears
         in the new config gets its config swapped via ``update_config``;
         a new id gets a fresh :class:`OscTransmitter`; an id absent from
         the new config is dropped from the next tick onward.
+
+        ``destinations`` stages the current OSC destination profiles each
+        row's ``destination_id`` resolves against; ``None`` keeps the
+        previously staged set (e.g. a transmitter-only edit).
         """
         with self._lock:
+            if destinations is not None:
+                self._destinations = destinations
             new_rows: dict[str, OscTransmitter] = {}
             invalidate_cache: set[str] = set()
             for row_cfg in cfg.transmitters:
@@ -829,12 +850,16 @@ class OscTransmitterManager:
         else:
             stream_mode = "always"
             stream_min_change_m = 0.0
+        # Resolve the row's destination under the lock (caller holds it) so
+        # the plan captures a coherent endpoint snapshot.
+        dest = self._destinations.get(cfg.destination_id)
         return _TickPlan(
             marker_id=cfg.marker_id,
-            host=cfg.host,
-            port=cfg.port,
-            protocol=cfg.protocol,
-            framing=cfg.framing,
+            host=dest.host if dest is not None else "",
+            port=dest.port if dest is not None else 0,
+            protocol=dest.protocol if dest is not None else "udp",
+            framing=dest.framing if dest is not None else "slip",
+            destination_unset=dest is None,
             compiled_address=row.compiled_address,
             compiled_args=row.compiled_args,
             ring_buffer=row.ring_buffer,
@@ -1149,6 +1174,14 @@ class OscTransmitterManager:
         templates don't reference it, because the on-change gate uses the
         default marker as its signal source.
         """
+        if plan.destination_unset:
+            # Blank or dangling ``destination_id`` – nothing to send to.
+            return _RenderResult(
+                address="",
+                args=(),
+                skipped=True,
+                error="no destination selected",
+            )
         needs_default = plan.needs_default_marker
         pos: tuple[float, float, float] = (0.0, 0.0, 0.0)
         if plan.marker_id is not None:

--- a/openfollow/services.py
+++ b/openfollow/services.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
     from openfollow.configuration import (
         AppConfig,
         DetectionConfig,
+        OscDestinationsConfig,
         OscTransmittersConfig,
         OtpOutputConfig,
         RttrpmOutputConfig,
@@ -1047,7 +1048,10 @@ class AppRuntimeServices:
             # until it's populated, long before any 60 Hz render.
             controller_marker_provider=self._controller_marker_provider,
         )
-        manager.restart(self._app._config.osc_transmitters)
+        manager.restart(
+            self._app._config.osc_transmitters,
+            self._app._config.osc_destinations,
+        )
         manager.start()
         self._osc_transmitter_manager = manager
         self._sync_osc_binding_conflicts()
@@ -1363,8 +1367,9 @@ class AppRuntimeServices:
     def apply_osc_transmitters_change(
         self,
         new_cfg: OscTransmittersConfig,
+        destinations: OscDestinationsConfig | None = None,
     ) -> None:
-        """Apply an ``osc_transmitters`` config change live.
+        """Apply an ``osc_transmitters`` (or destinations) change live.
 
         Two-state matrix instead of OTP/RTTrPM's four-state because the
         manager always exists once :meth:`init_osc_transmitters` has run:
@@ -1376,12 +1381,18 @@ class AppRuntimeServices:
           Rows are diffed by id; the scheduler thread keeps running
           throughout. An all-rows-deleted config leaves an idle manager
           that wakes up cheaply if rows return on the next reload.
+
+        ``destinations`` stages the current OSC destination profiles so a
+        destination-only edit (e.g. an IP change) re-resolves every row;
+        ``None`` falls back to the app's current set.
         """
+        if destinations is None:
+            destinations = self._app._config.osc_destinations
         manager = self._osc_transmitter_manager
         if manager is None:
             self.init_osc_transmitters()
             return
-        manager.restart(new_cfg)
+        manager.restart(new_cfg, destinations)
         # ``init_osc_transmitters`` syncs conflicts in its own body; this
         # hot-reload branch needs a parallel sync. Keeping it outside
         # ``manager.restart`` keeps the manager registry-agnostic.
@@ -2237,7 +2248,11 @@ class AppRuntimeServices:
         from openfollow.zones import ZoneEngine
 
         cfg = self._app._config.trigger_zones
-        self._zone_engine = ZoneEngine(cfg, self._osc_service)
+        self._zone_engine = ZoneEngine(
+            cfg,
+            self._osc_service,
+            self._app._config.osc_destinations,
+        )
 
     def update_zone_triggers(self) -> None:
         """Evaluate zone membership and emit OSC, throttled by ``eval_fps``."""
@@ -2396,16 +2411,24 @@ class AppRuntimeServices:
             return {"error": f"unclosed quote in field: {exc}"}
         if not address:
             return {"skipped": True, "reason": "field has no address"}
-        host = zone.osc_host or cfg.default_osc_host
-        port = zone.osc_port or cfg.default_osc_port
+        dest = self._app._config.osc_destinations.get(zone.destination_id)
+        if dest is None:
+            return {"skipped": True, "reason": "no destination selected"}
         typed_args = coerce_osc_args(str_args)
-        self._osc_service.send(address, args=typed_args, host=host, port=port)
+        self._osc_service.send(
+            address,
+            args=typed_args,
+            host=dest.host,
+            port=dest.port,
+            protocol=dest.protocol,
+            framing=dest.framing,
+        )
         return {
             "success": True,
             "address": address,
             "args": list(typed_args),
-            "host": host,
-            "port": port,
+            "host": dest.host,
+            "port": dest.port,
         }
 
     def _get_marker_positions_snapshot(self) -> list[tuple[int, float, float]]:

--- a/openfollow/templates/schema.py
+++ b/openfollow/templates/schema.py
@@ -245,9 +245,7 @@ def validate_payload(template_type: str, payload: Mapping[str, Any]) -> None:
                 "address",
                 "args",
                 "name",
-                "host",
-                "port",
-                "protocol",
+                "destination_id",
                 "rate_hz",
                 "trigger",
             }
@@ -281,38 +279,12 @@ def validate_payload(template_type: str, payload: Mapping[str, Any]) -> None:
                     f"osc_output payload 'args[{i}]' must be str, got {type(arg).__name__}",
                 )
         # Optional fields: validate bounds to catch silent coercions at apply.
-        from openfollow.configuration import (
-            VALID_OSC_TRANSMITTER_PROTOCOLS,
-            VALID_OSC_TRANSMITTER_RATES,
-        )
+        from openfollow.configuration import VALID_OSC_TRANSMITTER_RATES
 
-        for field_name in ("name", "host"):
+        for field_name in ("name", "destination_id"):
             if field_name in payload and not isinstance(payload[field_name], str):
                 raise TemplateValidationError(
                     f"osc_output payload {field_name!r} must be str, got {type(payload[field_name]).__name__}",
-                )
-        if "protocol" in payload:
-            protocol = payload["protocol"]
-            if not isinstance(protocol, str):
-                raise TemplateValidationError(
-                    f"osc_output payload 'protocol' must be str, got {type(protocol).__name__}",
-                )
-            if protocol not in VALID_OSC_TRANSMITTER_PROTOCOLS:
-                raise TemplateValidationError(
-                    f"osc_output payload 'protocol' must be one of "
-                    f"{', '.join(VALID_OSC_TRANSMITTER_PROTOCOLS)} "
-                    f"(got {protocol!r})",
-                )
-        if "port" in payload:
-            port = payload["port"]
-            if not isinstance(port, int) or isinstance(port, bool):
-                # bool is int subclass; reject to avoid port=true → 1.
-                raise TemplateValidationError(
-                    f"osc_output payload 'port' must be int, got {type(port).__name__}",
-                )
-            if not 1 <= port <= 65535:
-                raise TemplateValidationError(
-                    f"osc_output payload 'port' must be in 1..65535 (got {port})",
                 )
         if "rate_hz" in payload:
             rate = payload["rate_hz"]

--- a/openfollow/web/help/midi.md
+++ b/openfollow/web/help/midi.md
@@ -1,14 +1,14 @@
 # MIDI
 
-USB MIDI device aliases and virtual fader sources for this station. Once configured, patches and fader values feed OSC Output rows via MIDI message triggers and fader placeholders.
+USB MIDI device aliases and virtual fader sources for this station. Once configured, patches and fader values feed OSC Transmitters rows via MIDI message triggers and fader placeholders.
 
 ## MIDI Patches
 
-A patch is a stable, numbered slot you assign a connected MIDI device to – the same idea as a QLab MIDI patch. The patch ID, not the port name or alias, is the key everything else references (OSC Output triggers, virtual fader sources). IDs are assigned sequentially and stay fixed across reboots and device swaps.
+A patch is a stable, numbered slot you assign a connected MIDI device to – the same idea as a QLab MIDI patch. The patch ID, not the port name or alias, is the key everything else references (OSC Transmitters triggers, virtual fader sources). IDs are assigned sequentially and stay fixed across reboots and device swaps.
 
 Click **Add new MIDI Patch** to create a slot, then fill in its row:
 
-- **ID** – read-only permanent integer key. Referenced by virtual fader sources and OSC Output trigger forms.
+- **ID** – read-only permanent integer key. Referenced by virtual fader sources and OSC Transmitters trigger forms.
 - **Alias** – optional friendly name (up to 64 characters), such as `FOH` or `X-Touch`. Shown alongside the ID in patch dropdowns.
 - **Device** – the MIDI input port bound to this patch. The dropdown lists currently connected ports; an unplugged device shows as `(not connected)`, and saving preserves the binding for when it reconnects.
 
@@ -18,7 +18,7 @@ Each row has its own **Save** and **Delete** buttons.
 
 ## Virtual Faders
 
-Eight normalised faders (0.00 – 1.00), addressed by position on the bus (1 through 8). Each fader's live value shows in its strip and feeds OSC Output rows via fader placeholders. The bus is fixed at eight; you cannot add or remove entries.
+Eight normalised faders (0.00 – 1.00), addressed by position on the bus (1 through 8). Each fader's live value shows in its strip and feeds OSC Transmitters rows via fader placeholders. The bus is fixed at eight; you cannot add or remove entries.
 
 Click a strip to open its settings in the detail panel below.
 
@@ -47,4 +47,4 @@ Click **Save fader** to apply changes to the selected fader.
 
 Read-only. One strip per controlled marker, driven by whichever gamepad currently controls it. Provisioned automatically from the Controlled Markers list – nothing to configure here.
 
-A marker fader's live value feeds OSC Output rows via the `[markerfader]` placeholder. Which gamepad axis feeds the marker faders, and how fast they travel, is set on the Gamepad page.
+A marker fader's live value feeds OSC Transmitters rows via the `[markerfader]` placeholder. Which gamepad axis feeds the marker faders, and how fast they travel, is set on the Gamepad page.

--- a/openfollow/web/help/osc_bindings.md
+++ b/openfollow/web/help/osc_bindings.md
@@ -12,11 +12,7 @@ Identity, destination, and transport.
 - **Name** – a label for your own reference. Appears in the Diagnostics tab and the Overview live counters.
 - **Default marker** – marker ID that bare position placeholders (`[x]`, `[y]`, `[markerid]`, etc.) resolve against when no `:N` index is given. Leave blank if every placeholder names its marker explicitly; the default must be an existing marker (IDs start at 1).
 - **Default fader** – virtual fader that bare fader placeholders (`[fader]`, including transform forms like `[fader.pct]`) resolve against. Leave as `(none)` if you use only explicit `[fader:N]` references or have no fader placeholders.
-- **Host** / **Port** – destination IP address and port number (1–65535).
-- **Protocol** – `UDP` or `TCP`. UDP is correct for most lighting and audio receivers.
-- **Framing** – visible only when Protocol is `TCP`. Choose what your receiver expects:
-  - **SLIP (RFC 1055)** – default per OSC 1.1; each packet is delimited by `0xC0`.
-  - **Length-prefix (OSC 1.0)** – each packet is preceded by a 32-bit big-endian length.
+- **Destination** – the shared OSC connection (host, port, transport) this transmitter sends to, picked from the list you maintain under **OSC Destinations**. A transmitter with no destination selected sends nothing. Edit a destination's IP once and every transmitter and zone pointing at it repoints live – no per-row editing, no restart. The read-only line under the dropdown shows the destination's resolved `host:port`.
 
 ## Trigger
 

--- a/openfollow/web/help/osc_bindings.md
+++ b/openfollow/web/help/osc_bindings.md
@@ -1,4 +1,4 @@
-# OSC Output
+# OSC Transmitters
 
 Configure outbound OSC messages for lighting consoles, media servers, audio engines, and show-control software.
 
@@ -107,7 +107,7 @@ Read-only panels showing what the transmitter is doing right now.
 
 ## Adding and managing transmitters
 
-**Template** dropdown + **+ New OSC output** – choose a template and click the button to add a transmitter pre-filled with its address and arguments. Leave the dropdown on *empty* to start with a blank transmitter. Drag the ⋮⋮ handle on the left of a collapsed transmitter to reorder – order is cosmetic, transmitters evaluate independently.
+**Template** dropdown + **+ New transmitter** – choose a template and click the button to add a transmitter pre-filled with its address and arguments. Leave the dropdown on *empty* to start with a blank transmitter. Drag the ⋮⋮ handle on the left of a collapsed transmitter to reorder – order is cosmetic, transmitters evaluate independently.
 
 ## Saving & sharing
 

--- a/openfollow/web/help/osc_destinations.md
+++ b/openfollow/web/help/osc_destinations.md
@@ -19,7 +19,7 @@ When a receiver of OSC Data moves to a new IP, change that one destination and e
 - **+ New destination** – add a blank destination.
 - **Save** – write the destination's settings to disk. Changes apply immediately to every transmitter and zone that references this destination.
 - **Duplicate** – copy a destination (useful for a second receiver on a different port).
-- **↑ / ↓** – reorder the list (cosmetic).
+- **Reorder** – drag the ⋮⋮ handle on the left of a collapsed destination to reorder the list (cosmetic).
 - **Delete** – remove a destination. Any transmitter or zone still pointing at it stops sending until you repoint it at another destination.
 
 ## Sharing between stations

--- a/openfollow/web/help/osc_destinations.md
+++ b/openfollow/web/help/osc_destinations.md
@@ -1,8 +1,8 @@
 # OSC Destinations
 
-A **destination** is a named, reusable OSC connection: a host, a port, and a transport. Transmitters (OSC Output) and trigger zones don't carry their own connection any more – they point at a destination by name. Edit a destination's host once and every transmitter and zone referencing it repoints live, with no restart.
+A **destination** is a named, reusable OSC connection: a host, a port, and a transport. Transmitters and trigger zones point at a destination by name, so the connection lives in one place. Edit a destination's host once and every transmitter and zone referencing it repoints live, with no restart.
 
-This is the fix for the "the console moved to a new IP" problem: change one destination instead of hand-editing every transmitter row and every zone.
+When a receiver of OSC Data moves to a new IP, change that one destination and every transmitter and zone using it follows.
 
 ## Fields
 

--- a/openfollow/web/help/osc_destinations.md
+++ b/openfollow/web/help/osc_destinations.md
@@ -1,0 +1,27 @@
+# OSC Destinations
+
+A **destination** is a named, reusable OSC connection: a host, a port, and a transport. Transmitters (OSC Output) and trigger zones don't carry their own connection any more – they point at a destination by name. Edit a destination's host once and every transmitter and zone referencing it repoints live, with no restart.
+
+This is the fix for the "the console moved to a new IP" problem: change one destination instead of hand-editing every transmitter row and every zone.
+
+## Fields
+
+- **Name** – a label for your own reference (e.g. `Main console`, `Media server`). Shown in the Destination dropdowns on transmitters and zones.
+- **Host** – destination IP address or hostname.
+- **Port** – destination port number (1–65535).
+- **Protocol** – `UDP` or `TCP`. UDP is correct for most lighting and audio receivers.
+- **Framing** – visible only when Protocol is `TCP`. Choose what your receiver expects:
+  - **SLIP (RFC 1055)** – default per OSC 1.1; each packet is delimited by `0xC0`.
+  - **Length-prefix (OSC 1.0)** – each packet is preceded by a 32-bit big-endian length.
+
+## Managing destinations
+
+- **+ New destination** – add a blank destination.
+- **Save** – write the destination's settings to disk. Changes apply immediately to every transmitter and zone that references this destination.
+- **Duplicate** – copy a destination (useful for a second receiver on a different port).
+- **↑ / ↓** – reorder the list (cosmetic).
+- **Delete** – remove a destination. Any transmitter or zone still pointing at it stops sending until you repoint it at another destination.
+
+## Sharing between stations
+
+Destinations travel with the **config export/import file** alongside the transmitters and zones that reference them, so a saved show carries a consistent routing set. They are deliberately **not** part of real-time peer broadcast: each station keeps its own OSC routing, because the right console IP for one station's network is rarely the right one for another's.

--- a/openfollow/web/help/trigger_zones.md
+++ b/openfollow/web/help/trigger_zones.md
@@ -16,7 +16,6 @@ These settings govern the zone engine as a whole and apply to every zone.
 
 > If zones flicker with rapid in/out events, increase **Hysteresis** first; use **Debounce** as the secondary safety net.
 
-- **Default OSC Host** – IP address that zone OSC messages are sent to, used by any zone that hasn't set its own destination. Default `127.0.0.1`.
-- **Default OSC Port** – UDP port for the default destination. Default `53000` (QLab's standard OSC receive port). Range 1–65535.
+Each zone picks where its OSC messages go by selecting an **OSC Destination** in the zone editor – the same shared connections used by OSC Output. Manage them under **OSC Destinations**; editing a destination's IP repoints every referencing zone and transmitter live.
 
 **Save** – write the global settings to disk. The zone engine reloads immediately; no restart is needed.

--- a/openfollow/web/help/trigger_zones.md
+++ b/openfollow/web/help/trigger_zones.md
@@ -16,6 +16,6 @@ These settings govern the zone engine as a whole and apply to every zone.
 
 > If zones flicker with rapid in/out events, increase **Hysteresis** first; use **Debounce** as the secondary safety net.
 
-Each zone picks where its OSC messages go by selecting an **OSC Destination** in the zone editor – the same shared connections used by OSC Output. Manage them under **OSC Destinations**; editing a destination's IP repoints every referencing zone and transmitter live.
+Each zone picks where its OSC messages go by selecting an **OSC Destination** in the zone editor – the same shared connections used by OSC Transmitters. Manage them under **OSC Destinations**; editing a destination's IP repoints every referencing zone and transmitter live.
 
 **Save** – write the global settings to disk. The zone engine reloads immediately; no restart is needed.

--- a/openfollow/web/help/zone_editor.md
+++ b/openfollow/web/help/zone_editor.md
@@ -48,8 +48,7 @@ One editable row per polygon vertex, labelled V1, V2, … to match the canvas ha
 
 The four OSC messages the zone fires on occupancy transitions. Leave any address blank to suppress that event.
 
-- **OSC Host (optional)** – destination IP for this zone's messages. Blank falls back to the default OSC host in Trigger Zones settings.
-- **OSC Port (0 = default)** – destination UDP port. `0` uses the default port from Trigger Zones settings.
+- **OSC Destination** – the shared connection (host, port, transport) this zone's messages go to, picked from the list you maintain under **OSC Destinations**. A zone with no destination selected emits nothing. Edit the destination's IP once and every referencing zone and transmitter repoints live.
 - **First Entry Address** – sent on empty → occupied (0 → 1 occupant). E.g. trigger a cue or raise an audio bus.
 - **Additional Entry Address** – sent when another occupant enters an already-occupied zone (n → n+1). E.g. increment a counter or layer an effect.
 - **Partial Exit Address** – sent when one occupant leaves but the zone stays occupied (n+1 → n, n ≥ 1). E.g. decrement a counter.

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -51,6 +51,7 @@ from openfollow.configuration import (
     DEFAULT_UPDATE_SERVICE_NAME,
     VALID_BUTTON_NAMES,
     AppConfig,
+    OscDestinationConfig,
     OscTransmitterConfig,
     TriggerZoneConfig,
     config_write_lock,
@@ -170,6 +171,7 @@ VALID_SECTIONS = {
     "rttrpm_output",
     "trigger_zones",
     "osc_bindings",
+    "osc_destinations",
 }
 _WEB_STATIC_DIR = Path(__file__).with_name("static")
 
@@ -1361,8 +1363,6 @@ _TRIGGER_ZONES_FIELD_PARSERS: dict[str, _FieldParser] = {
     "enabled": _as_bool,
     "show_overlay": _as_bool,
     "eval_fps": _as_int,
-    "default_osc_host": _as_str,
-    "default_osc_port": _as_int,
     "debounce_ms": _as_int,
     "hysteresis": _as_float,
 }
@@ -1376,8 +1376,7 @@ _ZONE_FIELD_PARSERS: dict[str, _FieldParser] = {
     "osc_address_additional_entry": _as_str,
     "osc_address_partial_exit": _as_str,
     "osc_address_final_exit": _as_str,
-    "osc_host": _as_str,
-    "osc_port": _as_int,
+    "destination_id": _as_str,
     "enabled": _as_bool,
 }
 
@@ -1443,19 +1442,25 @@ def _apply_zone_fields(zone: TriggerZoneConfig, data: Mapping[str, Any]) -> None
 _OSC_BINDING_FIELD_PARSERS: dict[str, _FieldParser] = {
     "enabled": _as_bool,
     "name": _as_str,
-    "host": _as_str,
-    "port": _as_int,
-    "protocol": _as_str,
-    # Per-binding TCP framing selector. Inert for UDP rows but always
-    # parsed so the form preserves the dropdown; ``__post_init__`` snaps
-    # invalid values back to the default.
-    "framing": _as_str,
+    # Connection is chosen via a shared OSC destination; empty = no
+    # destination selected (the row skips sending).
+    "destination_id": _as_str,
     # ``marker_id`` is :class:`int | None`; clearing means "no default
     # marker", not "marker 0".
     "marker_id": _as_optional_int,
     # Default virtual fader, same shape as ``marker_id``: empty → ``None``,
     # 1..8 preserved, junk collapses to ``None`` in ``__post_init__``.
     "default_fader": _as_optional_int,
+}
+
+
+# Per-destination form parsers, mirroring the dataclass coercion.
+_OSC_DESTINATION_FIELD_PARSERS: dict[str, _FieldParser] = {
+    "name": _as_str,
+    "host": _as_str,
+    "port": _as_int,
+    "protocol": _as_str,
+    "framing": _as_str,
 }
 
 
@@ -1837,6 +1842,19 @@ def _apply_osc_binding_fields(
             row.enabled = False
 
 
+def _apply_osc_destination_fields(
+    dest: OscDestinationConfig,
+    data: Mapping[str, Any],
+) -> None:
+    """Type-coerce posted fields onto a destination, then re-run
+    ``__post_init__`` so bounds / choices match a TOML load."""
+    for field_name, parser in _OSC_DESTINATION_FIELD_PARSERS.items():
+        if field_name in data:
+            current = getattr(dest, field_name)
+            setattr(dest, field_name, parser(data[field_name], current))
+    dest.__post_init__()
+
+
 _DETECTION_FIELD_PARSERS: dict[str, _FieldParser] = {
     "enabled": _as_bool,
     "model": _as_str,
@@ -1910,6 +1928,20 @@ def _config_dict_redacted(cfg: AppConfig) -> dict[str, Any]:
     return d
 
 
+# Sections that travel through the config export/import file (so a
+# ``destination_id`` and its target move together) but are NEVER real-time
+# shared between stations: each station keeps its own OSC routing + zones.
+_BROADCAST_EXCLUDED_SECTIONS = frozenset(
+    {"osc_destinations", "osc_transmitters", "trigger_zones"},
+)
+
+
+def _strip_broadcast_excluded(data: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of a full-config dict without the sections that must
+    not be real-time-shared to peers (they still export/import via file)."""
+    return {k: v for k, v in data.items() if k not in _BROADCAST_EXCLUDED_SECTIONS}
+
+
 def _apply_import_data(
     current_cfg: AppConfig,
     data: dict[str, Any],
@@ -1952,6 +1984,24 @@ def _apply_import_data(
         if section in data and isinstance(data[section], dict):
             apply_section_data(cfg, section, data[section])
     apply_section_data(cfg, "video_source", data)
+
+    # OSC transmitters + destinations: rebuild the lists wholesale so the
+    # references (a transmitter/zone ``destination_id``) and their targets
+    # travel together through the config file. (They are excluded from
+    # real-time peer broadcast – see ``_strip_broadcast_excluded``.)
+    from openfollow.configuration import (
+        OscDestinationsConfig,
+        OscTransmittersConfig,
+    )
+
+    if "osc_transmitters" in data and isinstance(data["osc_transmitters"], dict):
+        rows = data["osc_transmitters"].get("transmitters")
+        if isinstance(rows, list):
+            cfg.osc_transmitters = OscTransmittersConfig(transmitters=rows)
+    if "osc_destinations" in data and isinstance(data["osc_destinations"], dict):
+        dests = data["osc_destinations"].get("destinations")
+        if isinstance(dests, list):
+            cfg.osc_destinations = OscDestinationsConfig(destinations=dests)
 
     # Trigger zones: import global settings + zones list atomically
     if "trigger_zones" in data and isinstance(data["trigger_zones"], dict):
@@ -5050,7 +5100,7 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
                     row.name = payload.get("name", entry.template.name)
                     row.address = payload.get("address", "")
                     row.args = list(payload.get("args", []))
-                    for opt_field in ("host", "port", "protocol", "rate_hz"):
+                    for opt_field in ("destination_id", "rate_hz"):
                         if opt_field in payload:
                             setattr(row, opt_field, payload[opt_field])
                     if "trigger" in payload:
@@ -5233,6 +5283,120 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         # would otherwise block any concurrent CRUD writer for the
         # render duration.
         return _render_osc_bindings_section(cfg, saved=saved)
+
+    # -- OSC destinations CRUD -----------------------------------------
+    #
+    # Shared connection profiles in ``cfg.osc_destinations.destinations``,
+    # keyed on a stable ``id``. Transmitters and zones reference a profile
+    # by id; editing one repoints every consumer live. Same load → mutate →
+    # save → full-re-render shape as the bindings CRUD above.
+
+    def _render_osc_destinations_section(
+        cfg: AppConfig,
+        *,
+        saved: bool = False,
+        focus_id: str = "",
+    ) -> Any:
+        from openfollow.configuration import (
+            VALID_OSC_FRAMINGS,
+            VALID_OSC_TRANSMITTER_PROTOCOLS,
+        )
+
+        return template(
+            "partials/osc_destinations",
+            config=cfg,
+            saved=saved,
+            focus_id=focus_id,
+            valid_protocols=VALID_OSC_TRANSMITTER_PROTOCOLS,
+            valid_framings=VALID_OSC_FRAMINGS,
+        )
+
+    def _find_osc_destination(
+        cfg: AppConfig,
+        dest_id: str,
+    ) -> tuple[int, OscDestinationConfig] | None:
+        for idx, dest in enumerate(cfg.osc_destinations.destinations):
+            if dest.id == dest_id:
+                return idx, dest
+        return None
+
+    @app.get("/section/osc_destinations")
+    def get_osc_destinations_section() -> Any:
+        cfg = _request_scoped_config()
+        focus_id = _as_str(request.query.get("focus", ""), "").strip()
+        return _render_osc_destinations_section(cfg, focus_id=focus_id)
+
+    @app.post("/section/osc_destinations/add")
+    def add_osc_destination() -> Any:
+        with _config_write_lock:
+            cfg = load_config(server.config_path)
+            dest = OscDestinationConfig(name="New destination")
+            cfg.osc_destinations.destinations.append(dest)
+            save_config(cfg, server.config_path)
+        return _render_osc_destinations_section(cfg, saved=True, focus_id=dest.id)
+
+    @app.post("/section/osc_destination/<dest_id>")
+    def save_osc_destination(dest_id: str) -> Any:
+        form_data: dict[str, Any] = dict(request.forms)
+        with _config_write_lock:
+            cfg = load_config(server.config_path)
+            found = _find_osc_destination(cfg, dest_id)
+            if found is None:
+                abort(404, "Unknown destination")
+                return ""  # pragma: no cover – abort() raises first
+            _, dest = found
+            _apply_osc_destination_fields(dest, form_data)
+            save_config(cfg, server.config_path)
+        return _render_osc_destinations_section(cfg, saved=True, focus_id=dest_id)
+
+    @app.post("/section/osc_destination/<dest_id>/duplicate")
+    def duplicate_osc_destination(dest_id: str) -> Any:
+        with _config_write_lock:
+            cfg = load_config(server.config_path)
+            found = _find_osc_destination(cfg, dest_id)
+            if found is None:
+                abort(404, "Unknown destination")
+                return ""  # pragma: no cover – abort() raises first
+            idx, dest = found
+            clone = copy.deepcopy(dest)
+            clone.id = ""  # force a fresh uuid in __post_init__
+            clone.name = (dest.name or "Destination") + " (copy)"
+            clone.__post_init__()
+            cfg.osc_destinations.destinations.insert(idx + 1, clone)
+            save_config(cfg, server.config_path)
+        return _render_osc_destinations_section(cfg, saved=True, focus_id=clone.id)
+
+    @app.post("/section/osc_destination/<dest_id>/delete")
+    def delete_osc_destination(dest_id: str) -> Any:
+        with _config_write_lock:
+            cfg = load_config(server.config_path)
+            found = _find_osc_destination(cfg, dest_id)
+            if found is not None:
+                idx, _ = found
+                del cfg.osc_destinations.destinations[idx]
+                save_config(cfg, server.config_path)
+        return _render_osc_destinations_section(cfg, saved=True)
+
+    @app.post("/section/osc_destination/<dest_id>/move")
+    def move_osc_destination(dest_id: str) -> Any:
+        direction = _as_str(request.forms.get("direction", ""), "")
+        with _config_write_lock:
+            cfg = load_config(server.config_path)
+            found = _find_osc_destination(cfg, dest_id)
+            if found is None:
+                abort(404, "Unknown destination")
+                return ""  # pragma: no cover – abort() raises first
+            idx, _ = found
+            dests = cfg.osc_destinations.destinations
+            target = idx
+            if direction == "up" and idx > 0:
+                target = idx - 1
+            elif direction == "down" and idx < len(dests) - 1:
+                target = idx + 1
+            if target != idx:
+                dests[idx], dests[target] = dests[target], dests[idx]
+                save_config(cfg, server.config_path)
+        return _render_osc_destinations_section(cfg, saved=True, focus_id=dest_id)
 
     @app.get("/section/osc_binding/<row_id>/trigger_form")
     def get_osc_binding_trigger_form(row_id: str) -> Any:
@@ -5564,9 +5728,7 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         trigger_dict = asdict(transient.trigger) if transient.trigger is not None else {"kind": "stream", "rate_hz": 30}
         payload: dict[str, Any] = {
             "name": transient.name,
-            "host": transient.host,
-            "port": transient.port,
-            "protocol": transient.protocol,
+            "destination_id": transient.destination_id,
             "address": transient.address,
             "args": list(transient.args),
             "rate_hz": transient.rate_hz,
@@ -5827,7 +5989,7 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
                     "address": tpl.payload.get("address", ""),
                     "args": list(tpl.payload.get("args", [])),
                 }
-                for opt_field in ("host", "port", "protocol", "rate_hz"):
+                for opt_field in ("destination_id", "rate_hz"):
                     if opt_field in tpl.payload:
                         kwargs[opt_field] = tpl.payload[opt_field]
                 if "trigger" in tpl.payload:
@@ -6261,7 +6423,9 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         # web_pin/web_port are device-local and stripped on receive; also drop
         # the PIN here so the credential never travels in the broadcast body
         # (peer auth still carries it in the signed header via ``pin=``).
-        cfg_data = _config_dict_redacted(cfg)
+        # OSC destinations / transmitters / zones export via file but are never
+        # real-time shared – strip them from the broadcast body.
+        cfg_data = _strip_broadcast_excluded(_config_dict_redacted(cfg))
         peers = server.get_peers()
         pin = cfg.web_pin
         results = _broadcast_to_peers(
@@ -6331,6 +6495,12 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         also filters as defence-in-depth against out-of-date senders.
         """
         response.content_type = "application/json"
+
+        # OSC destinations / transmitters / zones travel via the config file
+        # only – never real-time to peers. Refuse a crafted section-broadcast.
+        if section in _BROADCAST_EXCLUDED_SECTIONS:
+            response.status = 403
+            return json.dumps({"error": "Section is not shareable between stations"})
 
         data = _load_json_body()
         if data is None:
@@ -6410,8 +6580,7 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
                     "osc_address_additional_entry": z.osc_address_additional_entry,
                     "osc_address_partial_exit": z.osc_address_partial_exit,
                     "osc_address_final_exit": z.osc_address_final_exit,
-                    "osc_host": z.osc_host,
-                    "osc_port": z.osc_port,
+                    "destination_id": z.destination_id,
                     "enabled": z.enabled,
                     "is_occupied": occ,
                     "occupant_count": count,
@@ -6423,8 +6592,6 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
                 "globals": {
                     "enabled": tz.enabled,
                     "show_overlay": tz.show_overlay,
-                    "default_osc_host": tz.default_osc_host,
-                    "default_osc_port": tz.default_osc_port,
                     "eval_fps": tz.eval_fps,
                     "debounce_ms": tz.debounce_ms,
                     "hysteresis": tz.hysteresis,
@@ -6501,8 +6668,7 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
                 osc_address_additional_entry=src.osc_address_additional_entry,
                 osc_address_partial_exit=src.osc_address_partial_exit,
                 osc_address_final_exit=src.osc_address_final_exit,
-                osc_host=src.osc_host,
-                osc_port=src.osc_port,
+                destination_id=src.destination_id,
                 enabled=src.enabled,
             )
             zones.append(clone)

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -206,6 +206,52 @@ def asset_version() -> str:
     return _compute_asset_version()
 
 
+def _script_safe_json(obj: Any) -> str:
+    """``json.dumps`` escaped for embedding as raw JS inside a ``<script>``.
+
+    ``json.dumps`` does not escape ``<``, ``>`` or ``&``, so a user-controlled
+    string (e.g. an OSC destination name containing ``</script>``) embedded via
+    ``{{!...}}`` could close the script element and inject markup. Escaping
+    those to ``\\uXXXX`` keeps the value a valid JS string while making the
+    breakout impossible; the U+2028/U+2029 line separators are escaped too
+    since they terminate JS string literals on older engines.
+    """
+    return (
+        json.dumps(obj, separators=(",", ":"))
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )
+
+
+def osc_destinations_client_list(config: AppConfig) -> list[dict[str, Any]]:
+    """Client-facing OSC destination list (id + label + endpoint).
+
+    The single source of truth for the zone editor's destination dropdown,
+    served both at initial render (``osc_destinations_script_json``) and on the
+    ``/api/zones`` poll so the dropdown follows add/rename/delete without a full
+    page reload.
+    """
+    return [
+        {
+            "id": d.id,
+            "name": d.name,
+            "host": d.host,
+            "port": d.port,
+            "protocol": d.protocol,
+            "framing": d.framing,
+        }
+        for d in config.osc_destinations.destinations
+    ]
+
+
+def osc_destinations_script_json(config: AppConfig) -> str:
+    """OSC destinations as ``<script>``-safe JSON for the zone editor's initial render."""
+    return _script_safe_json(osc_destinations_client_list(config))
+
+
 # Help docs served as rendered HTML by ``/help/<id>.html``. A help id is a
 # lowercase slug (no dots/slashes/``..``) so it can't escape ``_WEB_HELP_DIR``.
 _WEB_HELP_DIR = Path(__file__).with_name("help")
@@ -6605,6 +6651,9 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
                 },
                 "zones": zones_out,
                 "markers": [{"id": tid, "x": x, "y": y} for tid, x, y in server.get_marker_positions()],
+                # Shared destinations travel with the poll so the editor's
+                # dropdown follows add/rename/delete without a full reload.
+                "destinations": osc_destinations_client_list(cfg),
             }
         )
 

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -5072,7 +5072,7 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         template_id = _as_str(request.forms.get("template_id", ""), "").strip()
         with _config_write_lock:
             cfg = load_config(server.config_path)
-            row = OscTransmitterConfig(name="New OSC output")
+            row = OscTransmitterConfig(name="New transmitter")
             if template_id:
                 # Both system and user templates flow through one
                 # ``file:<filename>`` lookup. Dropdown values for user

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -24,12 +24,12 @@ import threading
 import time
 import urllib.error
 import urllib.request
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, MutableSequence, Sequence
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import urlsplit
 
 from bottle import Bottle, HTTPResponse, abort, redirect, request, response, static_file, template
@@ -1986,6 +1986,36 @@ def _strip_broadcast_excluded(data: dict[str, Any]) -> dict[str, Any]:
     """Return a copy of a full-config dict without the sections that must
     not be real-time-shared to peers (they still export/import via file)."""
     return {k: v for k, v in data.items() if k not in _BROADCAST_EXCLUDED_SECTIONS}
+
+
+_T = TypeVar("_T")
+
+
+def _find_by_id(items: Sequence[_T], item_id: str) -> tuple[int, _T] | None:
+    """Index-and-item lookup by ``.id`` for the id-keyed config lists (OSC
+    transmitters, OSC destinations). ``None`` when nothing matches, so a route
+    can 404 on stale UI state (a row deleted in another tab) without crashing.
+    """
+    for idx, item in enumerate(items):
+        if getattr(item, "id", None) == item_id:
+            return idx, item
+    return None
+
+
+def _swap_for_direction(items: MutableSequence[Any], idx: int, direction: str) -> bool:
+    """Swap ``items[idx]`` one step ``"up"`` / ``"down"`` in place. No-op at
+    the list edge or for an unknown direction. Returns ``True`` only when a
+    swap actually happened, so the caller persists + flags ``saved`` on a real
+    move rather than on a button-mash against the boundary."""
+    target = idx
+    if direction == "up" and idx > 0:
+        target = idx - 1
+    elif direction == "down" and idx < len(items) - 1:
+        target = idx + 1
+    if target == idx:
+        return False
+    items[idx], items[target] = items[target], items[idx]
+    return True
 
 
 def _apply_import_data(
@@ -5027,8 +5057,6 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         from openfollow.configuration import (
             VALID_KEY_NAMES,
             VALID_MIDI_MESSAGE_TYPES,
-            VALID_OSC_FRAMINGS,
-            VALID_OSC_TRANSMITTER_PROTOCOLS,
             VALID_OSC_TRANSMITTER_RATES,
             VALID_TRIGGER_EDGES,
             VALID_TRIGGER_KINDS,
@@ -5060,8 +5088,6 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
             config=cfg,
             saved=saved,
             focus_id=focus_id,
-            valid_protocols=VALID_OSC_TRANSMITTER_PROTOCOLS,
-            valid_framings=VALID_OSC_FRAMINGS,
             valid_rates=VALID_OSC_TRANSMITTER_RATES,
             valid_kinds=VALID_TRIGGER_KINDS,
             valid_edges=VALID_TRIGGER_EDGES,
@@ -5087,10 +5113,7 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         to short-circuit a 404 on stale UI state (operator deletes a row
         in tab A while tab B still has it open) without crashing the
         request."""
-        for idx, row in enumerate(cfg.osc_transmitters.transmitters):
-            if row.id == row_id:
-                return idx, row
-        return None
+        return _find_by_id(cfg.osc_transmitters.transmitters, row_id)
 
     @app.get("/section/osc_bindings")
     def get_osc_bindings_section() -> Any:
@@ -5265,19 +5288,10 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
                 abort(404, "Unknown binding")
                 return ""  # pragma: no cover – abort() raises before we reach here
             idx, _ = found
-            transmitters = cfg.osc_transmitters.transmitters
-            target = idx
-            if direction == "up" and idx > 0:
-                target = idx - 1
-            elif direction == "down" and idx < len(transmitters) - 1:
-                target = idx + 1
-            if target != idx:
-                transmitters[idx], transmitters[target] = (
-                    transmitters[target],
-                    transmitters[idx],
-                )
+            moved = _swap_for_direction(cfg.osc_transmitters.transmitters, idx, direction)
+            if moved:
                 save_config(cfg, server.config_path)
-        return _render_osc_bindings_section(cfg, saved=True, focus_id=row_id)
+        return _render_osc_bindings_section(cfg, saved=moved, focus_id=row_id)
 
     @app.post("/section/osc_bindings/reorder")
     def reorder_osc_bindings() -> Any:
@@ -5361,10 +5375,7 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         cfg: AppConfig,
         dest_id: str,
     ) -> tuple[int, OscDestinationConfig] | None:
-        for idx, dest in enumerate(cfg.osc_destinations.destinations):
-            if dest.id == dest_id:
-                return idx, dest
-        return None
+        return _find_by_id(cfg.osc_destinations.destinations, dest_id)
 
     @app.get("/section/osc_destinations")
     def get_osc_destinations_section() -> Any:
@@ -5433,16 +5444,46 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
                 abort(404, "Unknown destination")
                 return ""  # pragma: no cover – abort() raises first
             idx, _ = found
-            dests = cfg.osc_destinations.destinations
-            target = idx
-            if direction == "up" and idx > 0:
-                target = idx - 1
-            elif direction == "down" and idx < len(dests) - 1:
-                target = idx + 1
-            if target != idx:
-                dests[idx], dests[target] = dests[target], dests[idx]
+            moved = _swap_for_direction(cfg.osc_destinations.destinations, idx, direction)
+            if moved:
                 save_config(cfg, server.config_path)
-        return _render_osc_destinations_section(cfg, saved=True, focus_id=dest_id)
+        return _render_osc_destinations_section(cfg, saved=moved, focus_id=dest_id)
+
+    @app.post("/section/osc_destinations/reorder")
+    def reorder_osc_destinations() -> Any:
+        """Apply a complete destination ordering from the drag-handle UI.
+
+        Mirrors :func:`reorder_osc_bindings`: ``order`` is a comma-separated
+        list of destination ids in the new order. Unknown ids are dropped; any
+        current destination missing from ``order`` is appended so a stale client
+        can't delete by omission. Empty / malformed ``order`` is a no-op (no
+        success flash). The per-id ``/move`` route stays as a stable JSON-API
+        surface for single-step swaps.
+        """
+        raw_order = _as_str(request.forms.get("order", ""), "")
+        wanted_ids = [s for s in (s.strip() for s in raw_order.split(",")) if s]
+        saved = bool(wanted_ids)
+        with _config_write_lock:
+            cfg = load_config(server.config_path)
+            dests = cfg.osc_destinations.destinations
+            current = {d.id: d for d in dests}
+            if wanted_ids:
+                new_order: list[OscDestinationConfig] = []
+                seen: set[str] = set()
+                for did in wanted_ids:
+                    dest = current.get(did)
+                    if dest is not None and did not in seen:
+                        new_order.append(dest)
+                        seen.add(did)
+                # Append any destinations missing from the wanted list so a
+                # stale form post can't silently drop them.
+                for dest in dests:
+                    if dest.id not in seen:
+                        new_order.append(dest)
+                if [d.id for d in new_order] != [d.id for d in dests]:
+                    cfg.osc_destinations.destinations = new_order
+                    save_config(cfg, server.config_path)
+        return _render_osc_destinations_section(cfg, saved=saved)
 
     @app.get("/section/osc_binding/<row_id>/trigger_form")
     def get_osc_binding_trigger_form(row_id: str) -> Any:

--- a/openfollow/web/templates/base.tpl
+++ b/openfollow/web/templates/base.tpl
@@ -1298,13 +1298,14 @@
  }
  .row-tab-panel { display: none; }
  .row-tab-panel.active { display: block; }
- .osc-binding-row { margin-bottom: 0.6rem; border: 1px solid var(--border-soft); border-radius: 0.6rem; padding: 0.5rem 0.8rem; background: var(--surface); }
- .osc-binding-summary { display: flex; gap: 0.6rem; align-items: center; cursor: pointer; padding-bottom: 0.2rem; }
+ .osc-binding-row, .osc-destination-row { margin-bottom: 0.6rem; border: 1px solid var(--border-soft); border-radius: 0.6rem; padding: 0.5rem 0.8rem; background: var(--surface); }
+ .osc-binding-summary, .osc-destination-summary { display: flex; gap: 0.6rem; align-items: center; cursor: pointer; padding-bottom: 0.2rem; }
  /* Breathing room between the summary and the editor body when the
  row is expanded (``<details open>``). When collapsed the
  ``.osc-binding-form`` is ``display: none`` so the margin is a
  no-op. */
- .osc-binding-row[open] > .osc-binding-form { margin-top: 0.9rem; }
+ .osc-binding-row[open] > .osc-binding-form,
+ .osc-destination-row[open] > .osc-destination-form { margin-top: 0.9rem; }
  /* Drag handle: visible click target inside the collapsed-row
  summary that the operator grabs to reorder rows. The actual
  drag-and-drop wiring lives in the document-level JS at the
@@ -1325,8 +1326,12 @@
  .osc-binding-row.drop-target { outline: 2px dashed var(--accent); outline-offset: 2px; }
  .osc-binding-enabled-dot { width: 0.55rem; height: 0.55rem; border-radius: 999px; background: var(--muted); }
  .osc-binding-enabled-dot.on { background: var(--accent); }
- .osc-binding-kind-badge { font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 0.4rem; background: rgba(255,255,255,0.05); color: var(--muted); }
+ .osc-binding-kind-badge, .osc-destination-proto-badge { font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 0.4rem; background: rgba(255,255,255,0.05); color: var(--muted); }
  .osc-binding-target { color: var(--muted); font-size: 0.8rem; margin-left: auto; }
+ /* Destination collapsed summary: host:port sits right after the name; the
+ protocol badge anchors to the right. */
+ .osc-destination-addr { color: var(--muted); font-size: 0.8rem; }
+ .osc-destination-proto-badge { margin-left: auto; }
  .args-list { display: flex; flex-direction: column; gap: 0.3rem; margin-bottom: 0.4rem; }
  .arg-pill-input { font-family: ui-monospace, monospace; }
  .args-buttons { display: flex; gap: 0.3rem; }

--- a/openfollow/web/templates/base.tpl
+++ b/openfollow/web/templates/base.tpl
@@ -1311,7 +1311,7 @@
  drag-and-drop wiring lives in the document-level JS at the
  bottom of this file. ``cursor: grab`` flips to ``grabbing``
  while the row is mid-drag. */
- .osc-binding-drag-handle {
+ .osc-binding-drag-handle, .osc-destination-drag-handle {
  cursor: grab;
  color: var(--muted);
  font-family: ui-monospace, monospace;
@@ -1320,10 +1320,10 @@
  user-select: none;
  letter-spacing: -0.1em;
  }
- .osc-binding-drag-handle:hover { color: var(--text); }
- .osc-binding-drag-handle:active { cursor: grabbing; }
- .osc-binding-row.dragging { opacity: 0.55; }
- .osc-binding-row.drop-target { outline: 2px dashed var(--accent); outline-offset: 2px; }
+ .osc-binding-drag-handle:hover, .osc-destination-drag-handle:hover { color: var(--text); }
+ .osc-binding-drag-handle:active, .osc-destination-drag-handle:active { cursor: grabbing; }
+ .osc-binding-row.dragging, .osc-destination-row.dragging { opacity: 0.55; }
+ .osc-binding-row.drop-target, .osc-destination-row.drop-target { outline: 2px dashed var(--accent); outline-offset: 2px; }
  .osc-binding-enabled-dot { width: 0.55rem; height: 0.55rem; border-radius: 999px; background: var(--muted); }
  .osc-binding-enabled-dot.on { background: var(--accent); }
  .osc-binding-kind-badge, .osc-destination-proto-badge { font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 0.4rem; background: rgba(255,255,255,0.05); color: var(--muted); }
@@ -4076,11 +4076,17 @@
  if (show) { el.removeAttribute('hidden'); } else { el.setAttribute('hidden', ''); }
  });
  });
+ // Generic drag-reorder shared by the OSC Transmitters + OSC Destinations
+ // row lists: same ⋮⋮ handle on both. Each row carries the bulk-reorder
+ // endpoint + swap target in ``data-reorder-url`` / ``data-reorder-target``,
+ // so one set of listeners drives both lists.
+ const OSC_REORDER_HANDLE_SEL = '.osc-binding-drag-handle, .osc-destination-drag-handle';
+ const OSC_REORDER_ROW_SEL = '.osc-binding-row, .osc-destination-row';
  let oscDragSourceId = null;
  document.addEventListener('dragstart', (event) => {
- const handle = event.target.closest('.osc-binding-drag-handle');
+ const handle = event.target.closest(OSC_REORDER_HANDLE_SEL);
  if (!handle) return;
- const row = handle.closest('.osc-binding-row');
+ const row = handle.closest(OSC_REORDER_ROW_SEL);
  if (!row) return;
  oscDragSourceId = row.dataset.rowId;
  row.classList.add('dragging');
@@ -4094,21 +4100,21 @@
  }
  });
  document.addEventListener('dragend', (event) => {
- const handle = event.target.closest('.osc-binding-drag-handle');
- const row = handle ? handle.closest('.osc-binding-row') : null;
+ const handle = event.target.closest(OSC_REORDER_HANDLE_SEL);
+ const row = handle ? handle.closest(OSC_REORDER_ROW_SEL) : null;
  if (row) row.classList.remove('dragging');
- document.querySelectorAll('.osc-binding-row.drop-target').forEach(el => {
+ document.querySelectorAll('.drop-target').forEach(el => {
  el.classList.remove('drop-target');
  });
  oscDragSourceId = null;
  });
  document.addEventListener('dragover', (event) => {
  if (!oscDragSourceId) return;
- const targetRow = event.target.closest('.osc-binding-row');
+ const targetRow = event.target.closest(OSC_REORDER_ROW_SEL);
  if (!targetRow) return;
  event.preventDefault();
  if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
- document.querySelectorAll('.osc-binding-row.drop-target').forEach(el => {
+ document.querySelectorAll('.drop-target').forEach(el => {
  if (el !== targetRow) el.classList.remove('drop-target');
  });
  if (targetRow.dataset.rowId !== oscDragSourceId) {
@@ -4117,11 +4123,12 @@
  });
  document.addEventListener('drop', (event) => {
  if (!oscDragSourceId) return;
- const targetRow = event.target.closest('.osc-binding-row');
+ const targetRow = event.target.closest(OSC_REORDER_ROW_SEL);
  if (!targetRow) return;
  event.preventDefault();
  const list = targetRow.parentElement;
  if (!list) return;
+ // Don't cross lists: a drag started in one list only reorders within it.
  const sourceRow = list.querySelector('[data-row-id="' + oscDragSourceId + '"]');
  if (!sourceRow || sourceRow === targetRow) {
  oscDragSourceId = null;
@@ -4133,17 +4140,21 @@
  const rect = targetRow.getBoundingClientRect();
  const after = (event.clientY - rect.top) > rect.height / 2;
  list.insertBefore(sourceRow, after ? targetRow.nextSibling : targetRow);
- // Build the new ordering and POST it. HTMX is already loaded so
- // ``htmx.ajax`` is the cleanest path – keeps the re-render flow
- // identical to every other CRUD round-trip in this section.
- const order = Array.from(list.querySelectorAll('.osc-binding-row'))
+ // Build the new ordering and POST it to the row's own reorder
+ // endpoint. HTMX is already loaded so ``htmx.ajax`` keeps the
+ // re-render flow identical to every other CRUD round-trip.
+ const url = targetRow.dataset.reorderUrl;
+ const targetId = targetRow.dataset.reorderTarget;
+ if (url && targetId) {
+ const order = Array.from(list.querySelectorAll(OSC_REORDER_ROW_SEL))
  .map(el => el.dataset.rowId)
  .join(',');
- window.htmx.ajax('POST', '/section/osc_bindings/reorder', {
- target: '#osc-bindings-section',
+ window.htmx.ajax('POST', url, {
+ target: '#' + targetId,
  swap: 'outerHTML',
  values: { order },
  });
+ }
  oscDragSourceId = null;
  });
  document.addEventListener('DOMContentLoaded', () => {

--- a/openfollow/web/templates/index.tpl
+++ b/openfollow/web/templates/index.tpl
@@ -112,6 +112,11 @@
     %     VALID_TRIGGER_MODIFIERS,
     % )
     % from openfollow.osc.template import PLACEHOLDERS
+    % # OSC destinations come first: transmitters/zones reference them.
+    % include('partials/osc_destinations.tpl',
+    %     config=config, saved=False, focus_id="",
+    %     valid_protocols=VALID_OSC_TRANSMITTER_PROTOCOLS,
+    %     valid_framings=VALID_OSC_FRAMINGS)
     % # Trigger forms need operator's fader/patch alias lists passed
     % # from route handler (``_osc_binding_form_sources``); keeps
     % # template declarative without reaching into route module.

--- a/openfollow/web/templates/index.tpl
+++ b/openfollow/web/templates/index.tpl
@@ -122,8 +122,6 @@
     % # template declarative without reaching into route module.
     % include('partials/osc_bindings.tpl',
     %     config=config, saved=False, focus_id="",
-    %     valid_protocols=VALID_OSC_TRANSMITTER_PROTOCOLS,
-    %     valid_framings=VALID_OSC_FRAMINGS,
     %     valid_rates=VALID_OSC_TRANSMITTER_RATES,
     %     valid_kinds=VALID_TRIGGER_KINDS,
     %     valid_edges=VALID_TRIGGER_EDGES,

--- a/openfollow/web/templates/partials/midi.tpl
+++ b/openfollow/web/templates/partials/midi.tpl
@@ -11,7 +11,7 @@
 <div id="midi-section" class="section {{'saved' if defined('saved') and saved else ''}}" data-fold-key="midi" data-help="midi">
  <div class="section-head">
  <h2>MIDI</h2>
- <span class="section-note">USB MIDI device aliases and virtual fader sources. The OSC Output trigger forms reference what's configured here.</span>
+ <span class="section-note">USB MIDI device aliases and virtual fader sources. The OSC Transmitters trigger forms reference what's configured here.</span>
  </div>
 
  % # ----------------------------------------------------------------

--- a/openfollow/web/templates/partials/osc_bindings.tpl
+++ b/openfollow/web/templates/partials/osc_bindings.tpl
@@ -34,13 +34,13 @@
 % end
 <div id="osc-bindings-section" class="section {{'saved' if defined('saved') and saved else ''}}" data-fold-key="osc_bindings" data-help="osc_bindings">
  <div class="section-head">
- <h2>OSC Output</h2>
+ <h2>OSC Transmitters</h2>
  <span class="section-note">Outbound OSC messages – Stream / Hotkey / Controller-button triggers</span>
  </div>
 
  <div class="osc-bindings-list">
  % if not transmitters:
- <p class="empty-state">No OSC outputs configured. Use <em>+ New OSC output</em> below to create one.</p>
+ <p class="empty-state">No transmitters configured. Use <em>+ New transmitter</em> below to create one.</p>
  % end
  % for idx, row in enumerate(transmitters):
  % is_focus = (defined('focus_id') and focus_id == row.id)
@@ -400,7 +400,7 @@
  hx-post="/section/osc_binding/{{row.id}}/delete"
  hx-target="#osc-bindings-section"
  hx-swap="outerHTML"
- hx-confirm="Delete this OSC output?">Delete</button>
+ hx-confirm="Delete this transmitter?">Delete</button>
  </div>
  </form>
  </details>
@@ -443,6 +443,6 @@
  </optgroup>
  % end
  </select>
- <button type="submit" class="save-btn">+ New OSC output</button>
+ <button type="submit" class="save-btn">+ New transmitter</button>
  </form>
 </div>

--- a/openfollow/web/templates/partials/osc_bindings.tpl
+++ b/openfollow/web/templates/partials/osc_bindings.tpl
@@ -21,6 +21,17 @@
 % # round-trip to the server.
 % _unresolved_by_row = defined('unresolved_by_row') and unresolved_by_row or {}
 % _registered_marker_ids = defined('registered_marker_ids') and registered_marker_ids or []
+% # Shared OSC destinations the rows reference. Build an id→profile map so the
+% # collapsed summary + read-only endpoint display resolve without a per-row scan.
+% _destinations = config.osc_destinations.destinations
+% _dest_by_id = {d.id: d for d in _destinations}
+% def _dest_label(did):
+%     d = _dest_by_id.get(did)
+%     if d is None:
+%         return '(no destination)'
+%     end
+%     return '{}://{}:{} ({})'.format(d.protocol, d.host, d.port, d.framing if d.protocol == 'tcp' else d.protocol)
+% end
 <div id="osc-bindings-section" class="section {{'saved' if defined('saved') and saved else ''}}" data-fold-key="osc_bindings" data-help="osc_bindings">
  <div class="section-head">
  <h2>OSC Output</h2>
@@ -58,7 +69,7 @@
  <span class="osc-binding-enabled-dot {{'on' if row.enabled else 'off'}}" aria-label="{{'Enabled' if row.enabled else 'Disabled'}}"></span>
  <span class="osc-binding-title">{{row.name or '(unnamed)'}}</span>
  <span class="osc-binding-kind-badge">{{pretty_label(trigger_kind)}}</span>
- <span class="osc-binding-target">{{row.protocol}}://{{row.host}}:{{row.port}}</span>
+ <span class="osc-binding-target">{{_dest_label(row.destination_id)}}</span>
  </summary>
 
  <form class="osc-binding-form"
@@ -148,35 +159,22 @@
  </div>
  <div class="row">
  <div class="field">
- <label>Host</label>
- <input type="text" name="host" value="{{row.host}}" maxlength="255">
- </div>
- <div class="field">
- <label>Port</label>
- <input type="number" name="port" value="{{row.port}}" min="1" max="65535" step="1">
- </div>
- <div class="field">
- <label>Protocol</label>
- % # ``data-osc-protocol-select`` is the JS hook
- % # base.tpl uses to toggle the sibling
- % # ``framing`` field's visibility – TCP shows
- % # it, UDP hides it.
- <select name="protocol" data-osc-protocol-select>
- % for p in valid_protocols:
- <option value="{{p}}" {{'selected' if p == row.protocol else ''}}>{{p.upper()}}</option>
+ <label for="destination-id-{{row.id}}">Destination</label>
+ <select id="destination-id-{{row.id}}" name="destination_id"
+ hx-get="/api/validate/osc_binding/destination_id"
+ hx-trigger="blur changed delay:200ms"
+ hx-target="#destination-id-{{row.id}}-error"
+ hx-swap="innerHTML"
+ hx-include="closest form"
+ aria-describedby="destination-id-{{row.id}}-error"
+ aria-invalid="false">
+ <option value="" {{'selected' if not row.destination_id else ''}}>(none – row will not send)</option>
+ % for d in _destinations:
+ <option value="{{d.id}}" {{'selected' if d.id == row.destination_id else ''}}>{{d.name or '(unnamed)'}}</option>
  % end
  </select>
- </div>
- % # TCP framing selector. Wrapper always rendered for
- % # round-trip; hidden by JS in base.tpl for non-TCP.
- % # Initial state inline so field shows on first render.
- <div class="field" data-osc-framing-field {{'style="display:none"' if row.protocol != 'tcp' else ''}}>
- <label>Framing</label>
- <select name="framing">
- % for f in valid_framings:
- <option value="{{f}}" {{'selected' if f == row.framing else ''}}>{{'SLIP (RFC 1055)' if f == 'slip' else 'Length-prefix (OSC 1.0)'}}</option>
- % end
- </select>
+ <span id="destination-id-{{row.id}}-error" class="field-error"></span>
+ <span class="field-note">{{_dest_label(row.destination_id)}} – manage in OSC Destinations</span>
  </div>
  </div>
  </div>

--- a/openfollow/web/templates/partials/osc_bindings.tpl
+++ b/openfollow/web/templates/partials/osc_bindings.tpl
@@ -47,7 +47,8 @@
  % trigger_kind = getattr(row.trigger, 'kind', 'stream')
  % row_unresolved = _unresolved_by_row.get(row.id, ())
  % has_unresolved = bool(row_unresolved)
- <details class="osc-binding-row" data-row-id="{{row.id}}" data-trigger-kind="{{trigger_kind}}" {{'open' if is_focus else ''}}>
+ <details class="osc-binding-row" data-row-id="{{row.id}}" data-trigger-kind="{{trigger_kind}}"
+ data-reorder-url="/section/osc_bindings/reorder" data-reorder-target="osc-bindings-section" {{'open' if is_focus else ''}}>
  <summary class="osc-binding-summary">
  % # The drag handle lives inside ``<summary>`` so it
  % # rides the row's collapsed-state header, but pointer
@@ -169,6 +170,12 @@
  aria-describedby="destination-id-{{row.id}}-error"
  aria-invalid="false">
  <option value="" {{'selected' if not row.destination_id else ''}}>(none – row will not send)</option>
+ % # A row pointing at a deleted destination keeps its dangling id: show it as
+ % # a selected (disabled) option so the dropdown reflects the stored state
+ % # instead of silently falling back to "(none)".
+ % if row.destination_id and row.destination_id not in _dest_by_id:
+ <option value="{{row.destination_id}}" selected disabled>(missing destination)</option>
+ % end
  % for d in _destinations:
  <option value="{{d.id}}" {{'selected' if d.id == row.destination_id else ''}}>{{d.name or '(unnamed)'}}</option>
  % end

--- a/openfollow/web/templates/partials/osc_destinations.tpl
+++ b/openfollow/web/templates/partials/osc_destinations.tpl
@@ -1,0 +1,114 @@
+% # Shared OSC destination profiles: collapsible rows with a per-row form.
+% # Transmitters and zones reference a destination by id; editing one here
+% # repoints every consumer live. Every CRUD route returns this full partial
+% # so row order stays consistent; ``focus_id`` re-opens the changed row.
+% destinations = config.osc_destinations.destinations
+<div id="osc-destinations-section" class="section {{'saved' if defined('saved') and saved else ''}}" data-fold-key="osc_destinations" data-help="osc_destinations">
+ <div class="section-head">
+ <h2>OSC Destinations</h2>
+ <span class="section-note">Reusable connections (host, port, transport) referenced by transmitters and zones</span>
+ </div>
+
+ <div class="osc-destinations-list">
+ % if not destinations:
+ <p class="empty-state">No OSC destinations configured. Use <em>+ New destination</em> below to create one.</p>
+ % end
+ % for idx, dest in enumerate(destinations):
+ % is_focus = (defined('focus_id') and focus_id == dest.id)
+ % proto_label = '{}://{}:{} ({})'.format(dest.protocol, dest.host, dest.port, dest.framing if dest.protocol == 'tcp' else dest.protocol)
+ <details class="osc-destination-row" data-row-id="{{dest.id}}" {{'open' if is_focus else ''}}>
+ <summary class="osc-destination-summary">
+ <span class="osc-destination-title">{{dest.name or '(unnamed)'}}</span>
+ <span class="osc-destination-target">{{proto_label}}</span>
+ </summary>
+
+ <form class="osc-destination-form"
+ data-row-id="{{dest.id}}"
+ hx-post="/section/osc_destination/{{dest.id}}"
+ hx-target="#osc-destinations-section"
+ hx-swap="outerHTML"
+ hx-trigger="submit">
+ <div class="row">
+ <div class="field">
+ <label>Name</label>
+ <input type="text" name="name" value="{{dest.name}}" maxlength="64"
+ hx-get="/api/validate/osc_destination/name"
+ hx-trigger="blur changed delay:200ms"
+ hx-target="#dest-name-{{dest.id}}-error"
+ hx-swap="innerHTML"
+ hx-include="closest form"
+ aria-describedby="dest-name-{{dest.id}}-error"
+ aria-invalid="false">
+ <span id="dest-name-{{dest.id}}-error" class="field-error"></span>
+ </div>
+ </div>
+ <div class="row">
+ <div class="field">
+ <label>Host</label>
+ <input type="text" name="host" value="{{dest.host}}" maxlength="255"
+ hx-get="/api/validate/osc_destination/host"
+ hx-trigger="blur changed delay:200ms"
+ hx-target="#dest-host-{{dest.id}}-error"
+ hx-swap="innerHTML"
+ hx-include="closest form"
+ aria-describedby="dest-host-{{dest.id}}-error"
+ aria-invalid="false">
+ <span id="dest-host-{{dest.id}}-error" class="field-error"></span>
+ </div>
+ <div class="field">
+ <label>Port</label>
+ <input type="number" name="port" value="{{dest.port}}" min="1" max="65535" step="1"
+ hx-get="/api/validate/osc_destination/port"
+ hx-trigger="blur changed delay:200ms"
+ hx-target="#dest-port-{{dest.id}}-error"
+ hx-swap="innerHTML"
+ hx-include="closest form"
+ aria-describedby="dest-port-{{dest.id}}-error"
+ aria-invalid="false">
+ <span id="dest-port-{{dest.id}}-error" class="field-error"></span>
+ </div>
+ <div class="field">
+ <label>Protocol</label>
+ <select name="protocol" data-osc-protocol-select>
+ % for p in valid_protocols:
+ <option value="{{p}}" {{'selected' if p == dest.protocol else ''}}>{{p.upper()}}</option>
+ % end
+ </select>
+ </div>
+ % # TCP framing selector; always rendered for round-trip, hidden by JS for non-TCP.
+ <div class="field" data-osc-framing-field {{'style="display:none"' if dest.protocol != 'tcp' else ''}}>
+ <label>Framing</label>
+ <select name="framing">
+ % for f in valid_framings:
+ <option value="{{f}}" {{'selected' if f == dest.framing else ''}}>{{'SLIP (RFC 1055)' if f == 'slip' else 'Length-prefix (OSC 1.0)'}}</option>
+ % end
+ </select>
+ </div>
+ </div>
+ <div class="row-actions">
+ <button type="submit" class="save-btn">Save</button>
+ <button type="button" class="secondary-btn"
+ hx-post="/section/osc_destination/{{dest.id}}/duplicate"
+ hx-target="#osc-destinations-section" hx-swap="outerHTML">Duplicate</button>
+ <button type="button" class="secondary-btn"
+ hx-post="/section/osc_destination/{{dest.id}}/move" hx-vals='{"direction":"up"}'
+ hx-target="#osc-destinations-section" hx-swap="outerHTML">↑</button>
+ <button type="button" class="secondary-btn"
+ hx-post="/section/osc_destination/{{dest.id}}/move" hx-vals='{"direction":"down"}'
+ hx-target="#osc-destinations-section" hx-swap="outerHTML">↓</button>
+ <button type="button" class="danger-btn"
+ hx-post="/section/osc_destination/{{dest.id}}/delete"
+ hx-target="#osc-destinations-section" hx-swap="outerHTML"
+ hx-confirm="Delete this destination? Transmitters and zones referencing it will stop sending until repointed.">Delete</button>
+ </div>
+ </form>
+ </details>
+ % end
+ </div>
+
+ <div class="section-actions">
+ <button type="button" class="add-btn"
+ hx-post="/section/osc_destinations/add"
+ hx-target="#osc-destinations-section" hx-swap="outerHTML">+ New destination</button>
+ </div>
+</div>

--- a/openfollow/web/templates/partials/osc_destinations.tpl
+++ b/openfollow/web/templates/partials/osc_destinations.tpl
@@ -15,11 +15,12 @@
  % end
  % for idx, dest in enumerate(destinations):
  % is_focus = (defined('focus_id') and focus_id == dest.id)
- % proto_label = '{}://{}:{} ({})'.format(dest.protocol, dest.host, dest.port, dest.framing if dest.protocol == 'tcp' else dest.protocol)
+ % addr_label = '{}:{}'.format(dest.host, dest.port)
  <details class="osc-destination-row" data-row-id="{{dest.id}}" {{'open' if is_focus else ''}}>
  <summary class="osc-destination-summary">
  <span class="osc-destination-title">{{dest.name or '(unnamed)'}}</span>
- <span class="osc-destination-target">{{proto_label}}</span>
+ <span class="osc-destination-addr">{{addr_label}}</span>
+ <span class="osc-destination-proto-badge">{{dest.protocol.upper()}}</span>
  </summary>
 
  <form class="osc-destination-form"
@@ -85,18 +86,18 @@
  </select>
  </div>
  </div>
- <div class="row-actions">
+ <div class="actions osc-destination-actions">
  <button type="submit" class="save-btn">Save</button>
- <button type="button" class="secondary-btn"
+ <button type="button" class="secondary"
  hx-post="/section/osc_destination/{{dest.id}}/duplicate"
  hx-target="#osc-destinations-section" hx-swap="outerHTML">Duplicate</button>
- <button type="button" class="secondary-btn"
+ <button type="button" class="secondary"
  hx-post="/section/osc_destination/{{dest.id}}/move" hx-vals='{"direction":"up"}'
  hx-target="#osc-destinations-section" hx-swap="outerHTML">↑</button>
- <button type="button" class="secondary-btn"
+ <button type="button" class="secondary"
  hx-post="/section/osc_destination/{{dest.id}}/move" hx-vals='{"direction":"down"}'
  hx-target="#osc-destinations-section" hx-swap="outerHTML">↓</button>
- <button type="button" class="danger-btn"
+ <button type="button" class="danger"
  hx-post="/section/osc_destination/{{dest.id}}/delete"
  hx-target="#osc-destinations-section" hx-swap="outerHTML"
  hx-confirm="Delete this destination? Transmitters and zones referencing it will stop sending until repointed.">Delete</button>
@@ -107,7 +108,7 @@
  </div>
 
  <div class="section-actions">
- <button type="button" class="add-btn"
+ <button type="button" class="save-btn"
  hx-post="/section/osc_destinations/add"
  hx-target="#osc-destinations-section" hx-swap="outerHTML">+ New destination</button>
  </div>

--- a/openfollow/web/templates/partials/osc_destinations.tpl
+++ b/openfollow/web/templates/partials/osc_destinations.tpl
@@ -16,8 +16,17 @@
  % for idx, dest in enumerate(destinations):
  % is_focus = (defined('focus_id') and focus_id == dest.id)
  % addr_label = '{}:{}'.format(dest.host, dest.port)
- <details class="osc-destination-row" data-row-id="{{dest.id}}" {{'open' if is_focus else ''}}>
+ <details class="osc-destination-row" data-row-id="{{dest.id}}"
+ data-reorder-url="/section/osc_destinations/reorder" data-reorder-target="osc-destinations-section" {{'open' if is_focus else ''}}>
  <summary class="osc-destination-summary">
+ % # Drag handle: pointer-only reorder affordance, same as OSC Transmitters.
+ % # Stop pointer/click propagation so a drag never toggles the <details>.
+ <span class="osc-destination-drag-handle"
+ draggable="true"
+ aria-hidden="true"
+ title="Drag to reorder"
+ onpointerdown="event.stopPropagation()"
+ onclick="event.preventDefault(); event.stopPropagation();">⋮⋮</span>
  <span class="osc-destination-title">{{dest.name or '(unnamed)'}}</span>
  <span class="osc-destination-addr">{{addr_label}}</span>
  <span class="osc-destination-proto-badge">{{dest.protocol.upper()}}</span>
@@ -91,12 +100,6 @@
  <button type="button" class="secondary"
  hx-post="/section/osc_destination/{{dest.id}}/duplicate"
  hx-target="#osc-destinations-section" hx-swap="outerHTML">Duplicate</button>
- <button type="button" class="secondary"
- hx-post="/section/osc_destination/{{dest.id}}/move" hx-vals='{"direction":"up"}'
- hx-target="#osc-destinations-section" hx-swap="outerHTML">↑</button>
- <button type="button" class="secondary"
- hx-post="/section/osc_destination/{{dest.id}}/move" hx-vals='{"direction":"down"}'
- hx-target="#osc-destinations-section" hx-swap="outerHTML">↓</button>
  <button type="button" class="danger"
  hx-post="/section/osc_destination/{{dest.id}}/delete"
  hx-target="#osc-destinations-section" hx-swap="outerHTML"

--- a/openfollow/web/templates/partials/trigger_zones.tpl
+++ b/openfollow/web/templates/partials/trigger_zones.tpl
@@ -52,24 +52,6 @@
                 % end
             </div>
         </div>
-        <div class="row">
-            <div class="field">
-                <label>Default OSC Host</label>
-                <input id="trigger-zones-default-osc-host" type="text" name="default_osc_host" value="{{config.trigger_zones.default_osc_host}}" placeholder="127.0.0.1"
-                       hx-get="/api/validate/trigger_zones/default_osc_host" hx-trigger="blur changed delay:200ms"
-                       hx-target="#trigger-zones-default-osc-host-error" hx-swap="innerHTML" hx-include="closest form"
-                       aria-describedby="trigger-zones-default-osc-host-error" aria-invalid="false">
-                <span id="trigger-zones-default-osc-host-error" class="field-error"></span>
-            </div>
-            <div class="field">
-                <label>Default OSC Port</label>
-                <input id="trigger-zones-default-osc-port" type="number" name="default_osc_port" value="{{config.trigger_zones.default_osc_port}}" min="1" max="65535" step="1"
-                       hx-get="/api/validate/trigger_zones/default_osc_port" hx-trigger="blur changed delay:200ms"
-                       hx-target="#trigger-zones-default-osc-port-error" hx-swap="innerHTML" hx-include="closest form"
-                       aria-describedby="trigger-zones-default-osc-port-error" aria-invalid="false">
-                <span id="trigger-zones-default-osc-port-error" class="field-error"></span>
-            </div>
-        </div>
     </div>
 
     <div class="actions">

--- a/openfollow/web/templates/partials/zone_editor.tpl
+++ b/openfollow/web/templates/partials/zone_editor.tpl
@@ -575,10 +575,18 @@
         html += '    <div class="row">';
         html += '      <div class="field"><label>OSC Destination</label><select data-zone-field="destination_id">';
         html += '        <option value=""' + (!z.destination_id ? ' selected' : '') + '>(none – zone will not send)</option>';
+        var destFound = false;
         for (var di = 0; di < OSC_DESTINATIONS.length; di++) {
             var od = OSC_DESTINATIONS[di];
             var sel = (od.id === z.destination_id) ? ' selected' : '';
+            if (sel) destFound = true;
             html += '<option value="' + escapeAttr(od.id) + '"' + sel + '>' + escapeAttr(od.name || '(unnamed)') + '</option>';
+        }
+        // A zone pointing at a deleted destination keeps its dangling id: show
+        // it as a selected (disabled) option so the dropdown reflects the
+        // stored state instead of silently falling back to "(none)".
+        if (z.destination_id && !destFound) {
+            html += '<option value="' + escapeAttr(z.destination_id) + '" selected disabled>(missing destination)</option>';
         }
         html += '      </select></div>';
         html += '    </div>';

--- a/openfollow/web/templates/partials/zone_editor.tpl
+++ b/openfollow/web/templates/partials/zone_editor.tpl
@@ -1,5 +1,5 @@
-% import json
-% _osc_dests_json = json.dumps([{"id": d.id, "name": d.name, "host": d.host, "port": d.port, "protocol": d.protocol, "framing": d.framing} for d in config.osc_destinations.destinations])
+% from openfollow.web.routes import osc_destinations_script_json
+% _osc_dests_json = osc_destinations_script_json(config)
 <div id="zone-editor-section" class="section" data-fold-key="zone_editor" data-help="zone_editor" data-template-form="1">
     <div class="section-head">
         <h2>Zone Editor</h2>
@@ -35,8 +35,10 @@
     if (window.__zoneEditorInit) return;
     window.__zoneEditorInit = true;
 
-    // Shared OSC destinations a zone can target (id + label + endpoint),
-    // emitted server-side so the Settings-tab dropdown stays in sync.
+    // Shared OSC destinations a zone can target (id + label + endpoint).
+    // Seeded server-side for the first render, then refreshed from the
+    // /api/zones poll so add/rename/delete in the OSC Destinations section
+    // reaches the dropdown without a full page reload.
     var OSC_DESTINATIONS = {{!_osc_dests_json}};
 
     // Zone color palette seeded by base.tpl via window.OPENFOLLOW_PALETTE
@@ -96,14 +98,23 @@
                 }
                 state.markers = data.markers || [];
                 if (data.grid) state.grid = data.grid;
+                // Refresh the shared destinations so the OSC Destination
+                // dropdown follows add/rename/delete live.
+                var newDests = data.destinations || [];
+                var destsChanged = JSON.stringify(newDests) !== JSON.stringify(OSC_DESTINATIONS);
+                OSC_DESTINATIONS = newDests;
                 if (state.selectedIndex >= state.zones.length) {
                     state.selectedIndex = -1;
                 }
                 render();
                 // Only rebuild the details panel when the selection actually
                 // changes; otherwise we'd clobber open dropdowns / color
-                // pickers / focused inputs on every poll tick.
+                // pickers / focused inputs on every poll tick. Destinations
+                // changing is the one extra reason to rebuild, but only when
+                // the operator isn't mid-edit on this zone's details.
                 if (state.selectedIndex !== state.detailsRenderedIndex) {
+                    renderDetails();
+                } else if (destsChanged && state.selectedIndex >= 0 && !editingSelected) {
                     renderDetails();
                 } else if (state.selectedIndex >= 0) {
                     // Refresh Diagnostics tab in place (don't rebuild whole

--- a/openfollow/web/templates/partials/zone_editor.tpl
+++ b/openfollow/web/templates/partials/zone_editor.tpl
@@ -1,3 +1,5 @@
+% import json
+% _osc_dests_json = json.dumps([{"id": d.id, "name": d.name, "host": d.host, "port": d.port, "protocol": d.protocol, "framing": d.framing} for d in config.osc_destinations.destinations])
 <div id="zone-editor-section" class="section" data-fold-key="zone_editor" data-help="zone_editor" data-template-form="1">
     <div class="section-head">
         <h2>Zone Editor</h2>
@@ -32,6 +34,10 @@
 (function() {
     if (window.__zoneEditorInit) return;
     window.__zoneEditorInit = true;
+
+    // Shared OSC destinations a zone can target (id + label + endpoint),
+    // emitted server-side so the Settings-tab dropdown stays in sync.
+    var OSC_DESTINATIONS = {{!_osc_dests_json}};
 
     // Zone color palette seeded by base.tpl via window.OPENFOLLOW_PALETTE
     // (from openfollow.palette). pickZoneColor delegates to shared
@@ -553,11 +559,17 @@
         html += '    </div></div>';
         html += '  </div>';
 
-        // ---- Settings tab: OSC host/port + the four addresses ----
+        // ---- Settings tab: OSC destination + the four addresses ----
         html += '  <div class="row-tab-panel" id="row-tab-zone-settings" role="tabpanel">';
         html += '    <div class="row">';
-        html += '      <div class="field"><label>OSC Host (optional)</label><input type="text" data-zone-field="osc_host" value="' + escapeAttr(z.osc_host || '') + '" placeholder="use default"></div>';
-        html += '      <div class="field"><label>OSC Port (0 = default)</label><input type="number" data-zone-field="osc_port" value="' + (z.osc_port || 0) + '" min="0" max="65535"></div>';
+        html += '      <div class="field"><label>OSC Destination</label><select data-zone-field="destination_id">';
+        html += '        <option value=""' + (!z.destination_id ? ' selected' : '') + '>(none – zone will not send)</option>';
+        for (var di = 0; di < OSC_DESTINATIONS.length; di++) {
+            var od = OSC_DESTINATIONS[di];
+            var sel = (od.id === z.destination_id) ? ' selected' : '';
+            html += '<option value="' + escapeAttr(od.id) + '"' + sel + '>' + escapeAttr(od.name || '(unnamed)') + '</option>';
+        }
+        html += '      </select></div>';
         html += '    </div>';
         html += '    <div class="row">';
         html += oscField('First Entry Address', 'osc_address_first_entry', z.osc_address_first_entry || '', '/zone/enter');

--- a/openfollow/web/validation.py
+++ b/openfollow/web/validation.py
@@ -212,7 +212,7 @@ def _validate_host(value: str, _cfg: AppConfig | None) -> str | None:
     """IPv4 / IPv6 address OR a syntactically valid hostname.
 
     Used for fields like ``rttrpm_output.host`` and
-    ``trigger_zones.default_osc_host`` where the receiver socket can
+    ``osc_destination.host`` where the receiver socket can
     resolve a hostname. Rejects values with internal whitespace,
     schemes, or paths so the operator notices the typo before the
     UDP send silently goes nowhere.

--- a/openfollow/web/validation.py
+++ b/openfollow/web/validation.py
@@ -577,16 +577,11 @@ FIELD_RULES: dict[str, dict[str, FieldRule]] = {
             choices=tuple(str(v) for v in VALID_ZONE_EVAL_FPS),
             human_error=(f"Eval FPS must be one of: {', '.join(str(v) for v in VALID_ZONE_EVAL_FPS)}."),
         ),
-        "default_osc_host": FieldRule(
-            _as_str, max_len=255, custom=_validate_host, human_error="Host must be a hostname or IP."
-        ),
-        "default_osc_port": FieldRule(_as_int, lo=1, hi=65535, human_error="Port must be between 1 and 65535."),
         "debounce_ms": FieldRule(_as_int, lo=0, hi=60000, human_error="Debounce must be between 0 and 60000 ms."),
         "hysteresis": FieldRule(_as_float, lo=0.0, hi=10.0, human_error="Hysteresis must be between 0 and 10 m."),
     },
-    # Per-row OSC binding fields; flat section to avoid routing complexity.
-    "osc_binding": {
-        "enabled": FieldRule(_as_bool),
+    # Shared OSC destination profiles (name + connection).
+    "osc_destination": {
         "name": FieldRule(_as_str, max_len=64, human_error="Name must be 0–64 characters."),
         "host": FieldRule(_as_str, max_len=255, custom=_validate_host, human_error="Host must be a hostname or IP."),
         "port": FieldRule(_as_int, lo=1, hi=65535, human_error="Port must be between 1 and 65535."),
@@ -595,12 +590,19 @@ FIELD_RULES: dict[str, dict[str, FieldRule]] = {
             choices=VALID_OSC_TRANSMITTER_PROTOCOLS,
             human_error=(f"Protocol must be one of: {', '.join(VALID_OSC_TRANSMITTER_PROTOCOLS)}."),
         ),
-        # TCP framing selector; validated even for UDP rows to preserve round-trip.
         "framing": FieldRule(
             _as_str,
             choices=VALID_OSC_FRAMINGS,
             human_error=(f"Framing must be one of: {', '.join(VALID_OSC_FRAMINGS)}."),
         ),
+    },
+    # Per-row OSC binding fields; flat section to avoid routing complexity.
+    "osc_binding": {
+        "enabled": FieldRule(_as_bool),
+        "name": FieldRule(_as_str, max_len=64, human_error="Name must be 0–64 characters."),
+        # Connection chosen via a shared OSC destination; empty allowed –
+        # an unselected enabled row is a soft "no send", not a blur error.
+        "destination_id": FieldRule(_as_str, max_len=64),
         # marker_id is int | None; empty input means "no default marker".
         "marker_id": FieldRule(_as_optional_int, lo=0, human_error="Marker id must be ≥ 0."),
         # address + args input; template picker handles choice at row creation time.

--- a/openfollow/zones/engine.py
+++ b/openfollow/zones/engine.py
@@ -10,6 +10,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from openfollow.configuration import OscDestinationsConfig
 from openfollow.osc.parser import coerce_osc_args, tokenize_osc_message
 from openfollow.zones.geometry import point_in_polygon, shrink_polygon
 
@@ -48,16 +49,34 @@ class ZoneOccupancy:
 class ZoneEngine:
     """Polygon-membership marker with OSC-on-transition semantics."""
 
-    def __init__(self, config: TriggerZonesConfig, osc_service: OscService) -> None:
+    def __init__(
+        self,
+        config: TriggerZonesConfig,
+        osc_service: OscService,
+        destinations: OscDestinationsConfig | None = None,
+    ) -> None:
         self._osc = osc_service
         self._occupancy: list[ZoneOccupancy] = []
         self._config: TriggerZonesConfig = config
+        # Shared OSC destination profiles a zone's ``destination_id`` resolves
+        # against. Empty until provided so an unselected zone emits nothing.
+        self._destinations: OscDestinationsConfig = destinations or OscDestinationsConfig(destinations=[])
         self._states_snapshot: tuple[tuple[int, bool, int], ...] = ()  # immutable snapshot for web thread
         self._diagnostics_snapshot: tuple[dict[str, Any], ...] = ()  # diagnostics snapshot for web thread
-        self.reload_config(config)
+        self.reload_config(config, destinations)
 
-    def reload_config(self, config: TriggerZonesConfig) -> None:
-        """Replace configuration; preserve occupancy for structurally unchanged zones."""
+    def reload_config(
+        self,
+        config: TriggerZonesConfig,
+        destinations: OscDestinationsConfig | None = None,
+    ) -> None:
+        """Replace configuration; preserve occupancy for structurally unchanged zones.
+
+        ``destinations`` stages the OSC destination profiles zone sends
+        resolve against; ``None`` keeps the previously staged set.
+        """
+        if destinations is not None:
+            self._destinations = destinations
         # Multiple zones can share the same signature (identical vertices,
         # trigger_source, enabled) – a stacked duplicate the user created for
         # any reason. Store a FIFO queue per signature so each new zone
@@ -195,6 +214,13 @@ class ZoneEngine:
         if not entered and not exited:
             return True
 
+        # Resolve the zone's destination. A blank or dangling
+        # ``destination_id`` means "no target" – track membership for the
+        # overlay (advance occupancy) but emit nothing.
+        dest = self._destinations.get(zone.destination_id)
+        if dest is None:
+            return True
+
         debounce_s = max(0.0, self._config.debounce_ms / 1000.0)
         if debounce_s > 0.0 and (now - occ.last_event_time) < debounce_s:
             return False
@@ -202,16 +228,10 @@ class ZoneEngine:
         prev_count = len(occ.occupants)
         count = prev_count
 
-        # Resolve the per-zone target, falling back to the section
-        # defaults. The legacy ``OscOutputClient`` did this internally on
-        # empty host / zero port; with the unified ``OscService``, the
-        # service's contract is "host and port required" so the engine
-        # owns the fallback explicitly. The ``or`` form preserves the
-        # legacy semantics for malformed negative ports – they pass
-        # through to the service, which drops them at its ``port <= 0``
-        # guard rather than silently substituting the default.
-        host = zone.osc_host or self._config.default_osc_host
-        port = zone.osc_port or self._config.default_osc_port
+        host = dest.host
+        port = dest.port
+        protocol = dest.protocol
+        framing = dest.framing
 
         last_address: str = ""
         # Handle entries first, then exits – the order matters for first/final
@@ -221,9 +241,9 @@ class ZoneEngine:
         # upstream set-difference, which is not stable across runs).
         for _ in sorted(entered):
             if count == 0:
-                addr = self._send_zone_osc(zone.osc_address_first_entry, host, port)
+                addr = self._send_zone_osc(zone.osc_address_first_entry, host, port, protocol, framing)
             else:
-                addr = self._send_zone_osc(zone.osc_address_additional_entry, host, port)
+                addr = self._send_zone_osc(zone.osc_address_additional_entry, host, port, protocol, framing)
             if addr:
                 last_address = addr
             count += 1
@@ -231,9 +251,9 @@ class ZoneEngine:
         for _ in sorted(exited):
             count -= 1
             if count == 0:
-                addr = self._send_zone_osc(zone.osc_address_final_exit, host, port)
+                addr = self._send_zone_osc(zone.osc_address_final_exit, host, port, protocol, framing)
             else:
-                addr = self._send_zone_osc(zone.osc_address_partial_exit, host, port)
+                addr = self._send_zone_osc(zone.osc_address_partial_exit, host, port, protocol, framing)
             if addr:
                 last_address = addr
 
@@ -242,7 +262,7 @@ class ZoneEngine:
             occ.last_event_address = last_address
         return True
 
-    def _send_zone_osc(self, raw: str, host: str, port: int) -> str:
+    def _send_zone_osc(self, raw: str, host: str, port: int, protocol: str, framing: str) -> str:
         """Tokenise a zone OSC field and forward to the service.
 
         Each ``osc_address_*_entry`` is one freeform string the operator
@@ -281,7 +301,14 @@ class ZoneEngine:
             return ""
         if not address:
             return ""
-        self._osc.send(address, args=coerce_osc_args(str_args), host=host, port=port)
+        self._osc.send(
+            address,
+            args=coerce_osc_args(str_args),
+            host=host,
+            port=port,
+            protocol=protocol,
+            framing=framing,
+        )
         return address
 
     def get_zone_states(self) -> list[tuple[int, bool, int]]:

--- a/openfollow/zones/engine.py
+++ b/openfollow/zones/engine.py
@@ -10,7 +10,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from openfollow.configuration import OscDestinationsConfig
+from openfollow.configuration import OscDestinationConfig, OscDestinationsConfig
 from openfollow.osc.parser import coerce_osc_args, tokenize_osc_message
 from openfollow.zones.geometry import point_in_polygon, shrink_polygon
 
@@ -59,8 +59,11 @@ class ZoneEngine:
         self._occupancy: list[ZoneOccupancy] = []
         self._config: TriggerZonesConfig = config
         # Shared OSC destination profiles a zone's ``destination_id`` resolves
-        # against. Empty until provided so an unselected zone emits nothing.
+        # against, staged as an id→profile index (``_dest_index``) so per-zone
+        # resolution is an O(1) dict lookup. Empty until provided so an
+        # unselected zone emits nothing.
         self._destinations: OscDestinationsConfig = destinations or OscDestinationsConfig(destinations=[])
+        self._dest_index: dict[str, OscDestinationConfig] = self._destinations.by_id()
         self._states_snapshot: tuple[tuple[int, bool, int], ...] = ()  # immutable snapshot for web thread
         self._diagnostics_snapshot: tuple[dict[str, Any], ...] = ()  # diagnostics snapshot for web thread
         self.reload_config(config, destinations)
@@ -77,6 +80,7 @@ class ZoneEngine:
         """
         if destinations is not None:
             self._destinations = destinations
+            self._dest_index = destinations.by_id()
         # Multiple zones can share the same signature (identical vertices,
         # trigger_source, enabled) – a stacked duplicate the user created for
         # any reason. Store a FIFO queue per signature so each new zone
@@ -214,10 +218,10 @@ class ZoneEngine:
         if not entered and not exited:
             return True
 
-        # Resolve the zone's destination. A blank or dangling
-        # ``destination_id`` means "no target" – track membership for the
-        # overlay (advance occupancy) but emit nothing.
-        dest = self._destinations.get(zone.destination_id)
+        # Resolve the zone's destination via the staged index (O(1)). A blank
+        # or dangling ``destination_id`` means "no target" – track membership
+        # for the overlay (advance occupancy) but emit nothing.
+        dest = self._dest_index.get(zone.destination_id)
         if dest is None:
             return True
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -105,6 +105,10 @@ class _DummyRuntimeServices:
     def swap_video(self, new_cfg: AppConfig) -> None:
         self.video_swaps.append(new_cfg)
 
+    def apply_osc_transmitters_change(self, new_cfg, destinations=None) -> None:  # noqa: ANN001
+        # No-op base; subclasses that assert on OSC routing override + record.
+        pass
+
 
 class _DummyWebServer:
     def __init__(self) -> None:
@@ -261,6 +265,32 @@ def test_testpattern_dataclass_defaults_match_plugin_config_fields() -> None:
 # --------------------------------------------------------------------------- #
 # bootstrap_config_if_missing – first-run seed from config.example.toml
 # --------------------------------------------------------------------------- #
+
+
+def test_example_config_matches_current_schema() -> None:
+    """The shipped ``config.example.toml`` must not declare fields the code
+    dropped (they'd be silently filtered on load) and must show the OSC
+    destinations shape transmitters/zones now reference, so an operator
+    copying it as a starting point has a working template."""
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[1]
+    example_path = repo_root / "config.example.toml"
+    data = tomllib.loads(example_path.read_text(encoding="utf-8"))
+
+    tz = data.get("trigger_zones", {})
+    assert "default_osc_host" not in tz
+    assert "default_osc_port" not in tz
+
+    dests = data.get("osc_destinations", {}).get("destinations", [])
+    assert dests, "example must seed at least one [[osc_destinations.destinations]]"
+    assert {"id", "host", "port", "protocol"} <= set(dests[0])
+
+    # And it loads into a config whose seeded destination is resolvable.
+    cfg = load_config(str(example_path))
+    assert cfg.osc_destinations.destinations
+    first = cfg.osc_destinations.destinations[0]
+    assert cfg.osc_destinations.get(first.id) is first
 
 
 def test_bootstrap_copies_example_when_config_absent(tmp_path) -> None:
@@ -3408,8 +3438,8 @@ def test_apply_runtime_osc_destinations_change_without_zone_engine() -> None:
 
 
 def test_apply_runtime_osc_destinations_change_failure_reverts() -> None:
-    """If the transmitter re-resolve raises, the destination change reverts and
-    the zone engine is never reloaded (the failure short-circuits the else)."""
+    """If the re-resolve raises (and the revert re-apply also raises), the
+    destination change reverts config and the zone engine is never reloaded."""
     from openfollow.configuration import OscDestinationConfig, OscDestinationsConfig
 
     class _FailingRuntimeServices(_DummyRuntimeServices):
@@ -3430,6 +3460,122 @@ def test_apply_runtime_osc_destinations_change_failure_reverts() -> None:
     # Reverted to the prior destinations; zone engine never reloaded.
     assert app._config.osc_destinations == old_dests
     assert zone_engine.reloaded == []
+
+
+def test_apply_runtime_osc_routing_combined_change_applies_once() -> None:
+    """A transmitter AND destination change in one pass applies as a single
+    coherent unit: one manager re-stage (no double restart) against the new
+    transmitters + destinations, and one zone-engine reload with the new set."""
+    from openfollow.configuration import (
+        OscDestinationConfig,
+        OscDestinationsConfig,
+        OscTransmitterConfig,
+        OscTransmittersConfig,
+    )
+
+    class _RecordingRuntimeServices(_DummyRuntimeServices):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls: list[tuple[object, object]] = []
+
+        def apply_osc_transmitters_change(self, new_cfg, destinations=None) -> None:  # noqa: ANN001
+            self.calls.append((new_cfg, destinations))
+
+    app = _app_with()
+    app._runtime_services = _RecordingRuntimeServices()
+    zone_engine = _DummyZoneEngine()
+    app._runtime_services._zone_engine = zone_engine  # type: ignore[attr-defined]
+
+    new_txs = OscTransmittersConfig(
+        transmitters=[OscTransmitterConfig(id="r1", name="R1", destination_id="default")],
+    )
+    new_dests = OscDestinationsConfig(
+        destinations=[OscDestinationConfig(id="default", name="Default", host="10.0.0.9")],
+    )
+    apply_runtime_config_changes(
+        app,
+        AppConfig(osc_transmitters=new_txs, osc_destinations=new_dests),
+    )
+
+    # Single apply (not one per section), carrying the new transmitters + dests.
+    assert app._runtime_services.calls == [(new_txs, new_dests)]
+    assert zone_engine.reloaded_destinations == [new_dests]
+    assert app._config.osc_transmitters == new_txs
+    assert app._config.osc_destinations == new_dests
+
+
+def test_apply_runtime_osc_routing_failure_restages_old_routing() -> None:
+    """A failed routing apply re-stages the OLD routing into the manager + zone
+    engine so it can't be left on the new endpoints while config holds the old
+    ones – the split-brain guard. The new apply fails, the revert apply succeeds."""
+    from openfollow.configuration import OscDestinationConfig, OscDestinationsConfig
+
+    class _FlakyRuntimeServices(_DummyRuntimeServices):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls: list[tuple[object, object]] = []
+
+        def apply_osc_transmitters_change(self, new_cfg, destinations=None) -> None:  # noqa: ANN001
+            self.calls.append((new_cfg, destinations))
+            if len(self.calls) == 1:
+                raise RuntimeError("boom")  # fail only the NEW apply
+
+    app = _app_with()
+    app._runtime_services = _FlakyRuntimeServices()
+    zone_engine = _DummyZoneEngine()
+    app._runtime_services._zone_engine = zone_engine  # type: ignore[attr-defined]
+    old_txs = app._config.osc_transmitters
+    old_dests = app._config.osc_destinations
+
+    new_dests = OscDestinationsConfig(
+        destinations=[OscDestinationConfig(id="default", name="Default", host="10.0.0.9")],
+    )
+    apply_runtime_config_changes(app, AppConfig(osc_destinations=new_dests))
+
+    # Two applies: the failed new one, then the revert re-staging the OLD set.
+    assert len(app._runtime_services.calls) == 2
+    assert app._runtime_services.calls[0][1] == new_dests
+    assert app._runtime_services.calls[1] == (old_txs, old_dests)
+    # Config reverted, and the manager + zone engine are coherent with it
+    # (last apply + last reload both carry the OLD destinations), not split.
+    assert app._config.osc_transmitters == old_txs
+    assert app._config.osc_destinations == old_dests
+    assert zone_engine.reloaded_destinations == [old_dests]
+
+
+def test_apply_runtime_osc_destinations_and_zones_reload_engine_once() -> None:
+    """Changing destinations AND trigger zones in one pass reloads the zone
+    engine exactly once (the trigger_zones block owns the single reload, with
+    the committed destinations) rather than twice."""
+    from openfollow.configuration import (
+        OscDestinationConfig,
+        OscDestinationsConfig,
+        TriggerZoneConfig,
+        TriggerZonesConfig,
+    )
+
+    app = _app_with()
+    app._runtime_services = _DummyRuntimeServices()
+    zone_engine = _DummyZoneEngine()
+    app._runtime_services._zone_engine = zone_engine  # type: ignore[attr-defined]
+
+    new_dests = OscDestinationsConfig(
+        destinations=[OscDestinationConfig(id="default", name="Default", host="10.0.0.9")],
+    )
+    new_zones = TriggerZonesConfig(
+        enabled=True,
+        zones=[TriggerZoneConfig(name="Main", vertices=[[0, 0], [1, 0], [1, 1]])],
+    )
+    apply_runtime_config_changes(
+        app,
+        AppConfig(osc_destinations=new_dests, trigger_zones=new_zones),
+    )
+
+    # Single reload, carrying the new zones + the committed new destinations.
+    assert zone_engine.reloaded == [new_zones]
+    assert zone_engine.reloaded_destinations == [new_dests]
+    assert app._config.trigger_zones == new_zones
+    assert app._config.osc_destinations == new_dests
 
 
 def test_apply_runtime_reapplies_midi_devices_to_subsystem() -> None:
@@ -4176,6 +4322,50 @@ class TestOscDestinationsConfig:
     def test_get_blank_id_returns_none(self) -> None:
         cfg = OscDestinationsConfig(destinations=[OscDestinationConfig(id="d1")])
         assert cfg.get("") is None
+
+    def test_duplicate_ids_are_made_unique(self) -> None:
+        """The id is the key transmitters/zones reference, so it must be
+        unique. A hand-edited TOML / crafted import with two entries sharing
+        an id keeps the first occurrence stable (existing references stay
+        valid) and re-mints a fresh id for each later collision instead of
+        leaving ``get()`` to resolve ambiguously to the first match."""
+        cfg = OscDestinationsConfig(
+            destinations=[
+                OscDestinationConfig(id="dup", name="First", host="10.0.0.1"),
+                OscDestinationConfig(id="dup", name="Second", host="10.0.0.2"),
+            ],
+        )
+        ids = [d.id for d in cfg.destinations]
+        assert ids[0] == "dup"  # first occurrence kept stable
+        assert ids[1] != "dup"  # later collision re-minted
+        assert len(set(ids)) == 2  # all unique
+        first = cfg.get("dup")
+        second = cfg.get(ids[1])
+        assert first is not None and first.name == "First"
+        assert second is not None and second.name == "Second"
+
+    def test_duplicate_ids_across_three_entries_all_unique(self) -> None:
+        cfg = OscDestinationsConfig(
+            destinations=[
+                OscDestinationConfig(id="x", name="A"),
+                OscDestinationConfig(id="x", name="B"),
+                OscDestinationConfig(id="x", name="C"),
+            ],
+        )
+        ids = [d.id for d in cfg.destinations]
+        assert ids[0] == "x"  # first occurrence kept stable
+        assert len(set(ids)) == 3  # all unique
+
+    def test_by_id_indexes_every_destination(self) -> None:
+        """``by_id`` is the O(1) index hot consumers stage instead of a
+        per-tick linear scan; it must agree with ``get`` for every id."""
+        a = OscDestinationConfig(id="a", host="10.0.0.1")
+        b = OscDestinationConfig(id="b", host="10.0.0.2")
+        cfg = OscDestinationsConfig(destinations=[a, b])
+        index = cfg.by_id()
+        assert index == {"a": a, "b": b}
+        assert index.get("a") is cfg.get("a")
+        assert index.get("nope") is cfg.get("nope")  # both None for unknown id
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -2371,12 +2371,25 @@ def test_trigger_zones_config_clamps_high_debounce_and_hysteresis() -> None:
     assert zones.hysteresis == 10.0
 
 
-def test_trigger_zones_config_clamps_default_osc_port() -> None:
-    # Port must be in range 1-65535.
+def test_trigger_zones_config_drops_legacy_default_osc_keys() -> None:
+    # Clean break: the section no longer carries default host/port; a
+    # hand-edited TOML keeps the keys out via ``_filter_known``.
     from openfollow.configuration import TriggerZonesConfig
 
-    assert TriggerZonesConfig(default_osc_port=70000).default_osc_port == 65535
-    assert TriggerZonesConfig(default_osc_port=0).default_osc_port == 1
+    tz = TriggerZonesConfig()
+    assert not hasattr(tz, "default_osc_host")
+    assert not hasattr(tz, "default_osc_port")
+
+
+def test_trigger_zone_config_destination_id() -> None:
+    from openfollow.configuration import TriggerZoneConfig
+
+    zone = TriggerZoneConfig(destination_id="  d1  ")
+    assert zone.destination_id == "d1"
+    assert not hasattr(zone, "osc_host")
+    assert not hasattr(zone, "osc_port")
+    # Non-string collapses to empty.
+    assert TriggerZoneConfig(destination_id=5).destination_id == ""  # type: ignore[arg-type]
 
 
 def test_trigger_zones_config_converts_dict_zones_to_dataclasses() -> None:
@@ -2716,9 +2729,11 @@ class _DummyCamera:
 class _DummyZoneEngine:
     def __init__(self) -> None:
         self.reloaded: list[object] = []
+        self.reloaded_destinations: list[object] = []
 
-    def reload_config(self, zones) -> None:
+    def reload_config(self, zones, destinations=None) -> None:  # noqa: ANN001
         self.reloaded.append(zones)
+        self.reloaded_destinations.append(destinations)
 
 
 class _DummyOtpServer:
@@ -3098,6 +3113,7 @@ def test_apply_runtime_applies_osc_transmitters_change_live() -> None:
         def apply_osc_transmitters_change(
             self,
             new_cfg: OscTransmittersConfig,
+            destinations=None,  # noqa: ANN001
         ) -> None:
             self.transmitter_changes.append(new_cfg)
 
@@ -3105,7 +3121,7 @@ def test_apply_runtime_applies_osc_transmitters_change_live() -> None:
     app._runtime_services = _RecordingRuntimeServices()
     new_cfg = OscTransmittersConfig(
         transmitters=[
-            OscTransmitterConfig(id="row-a", host="10.0.0.5"),
+            OscTransmitterConfig(id="row-a", destination_id="d1"),
         ]
     )
     new_config = AppConfig(osc_transmitters=new_cfg)
@@ -3130,6 +3146,7 @@ def test_apply_runtime_osc_transmitters_failure_reverts_config() -> None:
         def apply_osc_transmitters_change(
             self,
             new_cfg: OscTransmittersConfig,
+            destinations=None,  # noqa: ANN001
         ) -> None:
             raise OSError("simulated apply failure")
 
@@ -3138,7 +3155,7 @@ def test_apply_runtime_osc_transmitters_failure_reverts_config() -> None:
     app._runtime_services = _FailingRuntimeServices()
     new_cfg = OscTransmittersConfig(
         transmitters=[
-            OscTransmitterConfig(id="r1", host="10.0.0.5"),
+            OscTransmitterConfig(id="r1", destination_id="d1"),
         ]
     )
     new_config = AppConfig(osc_transmitters=new_cfg, viewer_marker_ids=[9])
@@ -3321,8 +3338,6 @@ def test_apply_runtime_reloads_trigger_zones() -> None:
 
     new_zones = TriggerZonesConfig(
         enabled=True,
-        default_osc_host="10.0.0.5",
-        default_osc_port=4242,
         zones=[TriggerZoneConfig(name="Main", vertices=[[0, 0], [1, 0], [1, 1]])],
     )
     new_config = AppConfig(trigger_zones=new_zones)
@@ -3331,6 +3346,39 @@ def test_apply_runtime_reloads_trigger_zones() -> None:
 
     assert zone_engine.reloaded == [new_zones]
     assert app._config.trigger_zones == new_zones
+
+
+def test_apply_runtime_osc_destinations_change_reapplies_both_consumers() -> None:
+    """A destination-only edit (e.g. an IP change) re-resolves at BOTH the
+    transmitter manager and the zone engine, live, with no restart."""
+    from openfollow.configuration import OscDestinationConfig, OscDestinationsConfig
+
+    class _RecordingRuntimeServices(_DummyRuntimeServices):
+        def __init__(self) -> None:
+            super().__init__()
+            self.transmitter_dests: list[object] = []
+
+        def apply_osc_transmitters_change(self, new_cfg, destinations=None) -> None:  # noqa: ANN001
+            self.transmitter_dests.append(destinations)
+
+    app = _app_with()
+    app._runtime_services = _RecordingRuntimeServices()
+    zone_engine = _DummyZoneEngine()
+    app._runtime_services._zone_engine = zone_engine  # type: ignore[attr-defined]
+
+    new_dests = OscDestinationsConfig(
+        destinations=[OscDestinationConfig(id="default", name="Default", host="10.0.0.9")],
+    )
+    new_config = AppConfig(osc_destinations=new_dests)
+
+    apply_runtime_config_changes(app, new_config)
+
+    assert app._config.osc_destinations == new_dests
+    # Transmitter manager re-resolved against the new destinations.
+    assert app._runtime_services.transmitter_dests == [new_dests]
+    # Zone engine re-resolved against the new destinations.
+    assert zone_engine.reloaded_destinations == [new_dests]
+    assert app._web_commands.restart_requested is False
 
 
 def test_apply_runtime_reapplies_midi_devices_to_subsystem() -> None:
@@ -3778,6 +3826,8 @@ def test_apply_with_fallback_without_on_failure_logs_and_returns(caplog) -> None
 # ---------------------------------------------------------------------------
 
 from openfollow.configuration import (  # noqa: E402
+    OscDestinationConfig,
+    OscDestinationsConfig,
     OscTransmitterConfig,
     OscTransmittersConfig,
 )
@@ -3809,52 +3859,39 @@ class TestOscTransmitterConfig:
         cfg = OscTransmitterConfig(name="  Stage Left  ")
         assert cfg.name == "Stage Left"
 
-    def test_non_string_host_falls_back_to_default(self) -> None:
-        cfg = OscTransmitterConfig(host=123)  # type: ignore[arg-type]
-        assert cfg.host == "127.0.0.1"
+    def test_destination_id_default_is_empty(self) -> None:
+        """A fresh row has no destination selected – it skips sending."""
+        assert OscTransmitterConfig().destination_id == ""
 
-    def test_blank_host_falls_back_to_default(self) -> None:
-        cfg = OscTransmitterConfig(host="   ")
-        assert cfg.host == "127.0.0.1"
+    def test_destination_id_is_stripped(self) -> None:
+        cfg = OscTransmitterConfig(destination_id="  dest-1  ")
+        assert cfg.destination_id == "dest-1"
 
-    def test_host_is_stripped(self) -> None:
-        cfg = OscTransmitterConfig(host="  10.0.0.5  ")
-        assert cfg.host == "10.0.0.5"
+    def test_non_string_destination_id_falls_back_to_empty(self) -> None:
+        cfg = OscTransmitterConfig(destination_id=99)  # type: ignore[arg-type]
+        assert cfg.destination_id == ""
 
-    def test_port_clamped_to_valid_range(self) -> None:
-        assert OscTransmitterConfig(port=0).port == 1
-        assert OscTransmitterConfig(port=70000).port == 65535
-        assert OscTransmitterConfig(port="bogus").port == 8000  # type: ignore[arg-type]
-
-    @pytest.mark.parametrize("good", ["udp", "tcp"])
-    def test_protocol_accepts_known_values(self, good: str) -> None:
-        assert OscTransmitterConfig(protocol=good).protocol == good
-
-    @pytest.mark.parametrize("bad", ["", "raw", None, 7])
-    def test_protocol_falls_back_to_udp_on_unknown(self, bad: object) -> None:
-        cfg = OscTransmitterConfig(protocol=bad)  # type: ignore[arg-type]
-        assert cfg.protocol == "udp"
-
-    def test_default_framing_is_slip(self) -> None:
-        """SLIP is the default framing for new bindings."""
-        cfg = OscTransmitterConfig()
-        assert cfg.framing == "slip"
-
-    @pytest.mark.parametrize("good", ["slip", "length_prefix"])
-    def test_framing_accepts_known_values(self, good: str) -> None:
-        assert OscTransmitterConfig(framing=good).framing == good
-
-    @pytest.mark.parametrize("bad", ["", "raw", None, 7, "SLIP"])
-    def test_framing_falls_back_to_slip_on_unknown(
-        self,
-        bad: object,
-    ) -> None:
-        """Hand-edited TOML or programmatic construction passing an
-        invalid value snaps to ``"slip"`` – same shape as the protocol
-        coercion. ``"SLIP"`` upper-case is intentionally rejected so
-        the on-disk format stays canonical lower-case."""
-        cfg = OscTransmitterConfig(framing=bad)  # type: ignore[arg-type]
-        assert cfg.framing == "slip"
+    def test_legacy_connection_keys_are_dropped_on_load(self) -> None:
+        """Clean break: a TOML row carrying the old inline connection keys
+        loads without them – ``_filter_known`` discards the unknown keys,
+        leaving ``destination_id`` blank."""
+        cfg = OscTransmittersConfig(
+            transmitters=[
+                {
+                    "id": "row1",
+                    "host": "10.0.0.5",
+                    "port": 9000,
+                    "protocol": "tcp",
+                    "framing": "length_prefix",
+                },
+            ],
+        )
+        row = cfg.transmitters[0]
+        assert not hasattr(row, "host")
+        assert not hasattr(row, "port")
+        assert not hasattr(row, "protocol")
+        assert not hasattr(row, "framing")
+        assert row.destination_id == ""
 
     def test_marker_id_default_is_none(self) -> None:
         """marker_id defaults to None (not yet chosen by operator)."""
@@ -3977,15 +4014,103 @@ class TestOscTransmitterConfig:
 class TestOscTransmittersConfig:
     def test_dict_entries_are_promoted_to_dataclasses(self) -> None:
         cfg = OscTransmittersConfig(
-            transmitters=[{"id": "row1", "host": "10.0.0.5"}],
+            transmitters=[{"id": "row1", "destination_id": "d1"}],
         )
         assert isinstance(cfg.transmitters[0], OscTransmitterConfig)
-        assert cfg.transmitters[0].host == "10.0.0.5"
+        assert cfg.transmitters[0].destination_id == "d1"
 
     def test_existing_dataclass_entries_pass_through(self) -> None:
-        row = OscTransmitterConfig(id="r1", host="2.2.2.2")
+        row = OscTransmitterConfig(id="r1", destination_id="d2")
         cfg = OscTransmittersConfig(transmitters=[row])
         assert cfg.transmitters[0] is row
+
+
+class TestOscDestinationConfig:
+    def test_blank_id_is_minted_as_uuid_hex(self) -> None:
+        cfg = OscDestinationConfig()
+        assert len(cfg.id) == 32
+        assert all(c in "0123456789abcdef" for c in cfg.id)
+
+    def test_existing_id_is_preserved_and_stripped(self) -> None:
+        assert OscDestinationConfig(id="  dest-1  ").id == "dest-1"
+
+    def test_non_string_name_falls_back_to_empty(self) -> None:
+        assert OscDestinationConfig(name=99).name == ""  # type: ignore[arg-type]
+
+    def test_name_is_stripped(self) -> None:
+        assert OscDestinationConfig(name="  Console  ").name == "Console"
+
+    def test_non_string_host_falls_back_to_default(self) -> None:
+        assert OscDestinationConfig(host=123).host == "127.0.0.1"  # type: ignore[arg-type]
+
+    def test_blank_host_falls_back_to_default(self) -> None:
+        assert OscDestinationConfig(host="   ").host == "127.0.0.1"
+
+    def test_host_is_stripped(self) -> None:
+        assert OscDestinationConfig(host="  10.0.0.5  ").host == "10.0.0.5"
+
+    def test_port_clamped_to_valid_range(self) -> None:
+        assert OscDestinationConfig(port=0).port == 1
+        assert OscDestinationConfig(port=70000).port == 65535
+        assert OscDestinationConfig(port="bogus").port == 8000  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("good", ["udp", "tcp"])
+    def test_protocol_accepts_known_values(self, good: str) -> None:
+        assert OscDestinationConfig(protocol=good).protocol == good
+
+    @pytest.mark.parametrize("bad", ["", "raw", None, 7])
+    def test_protocol_falls_back_to_udp_on_unknown(self, bad: object) -> None:
+        assert OscDestinationConfig(protocol=bad).protocol == "udp"  # type: ignore[arg-type]
+
+    def test_default_framing_is_slip(self) -> None:
+        assert OscDestinationConfig().framing == "slip"
+
+    @pytest.mark.parametrize("good", ["slip", "length_prefix"])
+    def test_framing_accepts_known_values(self, good: str) -> None:
+        assert OscDestinationConfig(framing=good).framing == good
+
+    @pytest.mark.parametrize("bad", ["", "raw", None, 7, "SLIP"])
+    def test_framing_falls_back_to_slip_on_unknown(self, bad: object) -> None:
+        assert OscDestinationConfig(framing=bad).framing == "slip"  # type: ignore[arg-type]
+
+
+class TestOscDestinationsConfig:
+    def test_default_seeds_one_pickable_destination(self) -> None:
+        cfg = OscDestinationsConfig()
+        assert len(cfg.destinations) == 1
+        assert cfg.destinations[0].id == "default"
+        assert cfg.destinations[0].name == "Default"
+
+    def test_default_config_compares_equal(self) -> None:
+        """The seeded destination uses a fixed id so two default configs
+        compare equal (the hot-reload diff depends on this)."""
+        assert OscDestinationsConfig() == OscDestinationsConfig()
+
+    def test_dict_entries_are_promoted_to_dataclasses(self) -> None:
+        cfg = OscDestinationsConfig(
+            destinations=[{"id": "d1", "host": "10.0.0.9"}],
+        )
+        assert isinstance(cfg.destinations[0], OscDestinationConfig)
+        assert cfg.destinations[0].host == "10.0.0.9"
+
+    def test_filter_known_drops_unknown_keys(self) -> None:
+        cfg = OscDestinationsConfig(
+            destinations=[{"id": "d1", "bogus": "x"}],
+        )
+        assert not hasattr(cfg.destinations[0], "bogus")
+
+    def test_get_returns_matching_destination(self) -> None:
+        d = OscDestinationConfig(id="d1", name="A")
+        cfg = OscDestinationsConfig(destinations=[d])
+        assert cfg.get("d1") is d
+
+    def test_get_unknown_id_returns_none(self) -> None:
+        cfg = OscDestinationsConfig(destinations=[OscDestinationConfig(id="d1")])
+        assert cfg.get("nope") is None
+
+    def test_get_blank_id_returns_none(self) -> None:
+        cfg = OscDestinationsConfig(destinations=[OscDestinationConfig(id="d1")])
+        assert cfg.get("") is None
 
 
 # ---------------------------------------------------------------------------
@@ -4460,7 +4585,7 @@ class TestOscTransmittersConfigLegacyLift:
         sees a synthesised trigger sub-table."""
         cfg = OscTransmittersConfig(
             transmitters=[
-                {"rate_hz": 60, "host": "10.0.0.5"},
+                {"rate_hz": 60, "destination_id": "d1"},
             ]
         )
         row = cfg.transmitters[0]
@@ -4498,25 +4623,13 @@ class TestOscTransmittersConfigLegacyLift:
                 transmitters=[
                     OscTransmitterConfig(
                         id="abc",
-                        host="10.0.0.5",
-                        port=9000,
+                        destination_id="d1",
                         rate_hz=20,
                         template_id="etc",
                     ),
-                    # TCP framing must round-trip correctly.
                     OscTransmitterConfig(
-                        id="tcp-slip",
-                        host="10.0.0.6",
-                        port=9001,
-                        protocol="tcp",
-                        framing="slip",
-                    ),
-                    OscTransmitterConfig(
-                        id="tcp-lp",
-                        host="10.0.0.7",
-                        port=9002,
-                        protocol="tcp",
-                        framing="length_prefix",
+                        id="row2",
+                        destination_id="d2",
                     ),
                 ],
             ),
@@ -4524,16 +4637,12 @@ class TestOscTransmittersConfigLegacyLift:
         save_config(original, str(temp_config_path))
         reloaded = load_config(str(temp_config_path))
         rows = reloaded.osc_transmitters.transmitters
-        assert len(rows) == 3
+        assert len(rows) == 2
         assert rows[0].id == "abc"
-        assert rows[0].host == "10.0.0.5"
+        assert rows[0].destination_id == "d1"
         assert rows[0].rate_hz == 20
-        # Default framing on the original (unspecified) row stays SLIP.
-        assert rows[0].framing == "slip"
-        assert rows[1].id == "tcp-slip"
-        assert rows[1].framing == "slip"
-        assert rows[2].id == "tcp-lp"
-        assert rows[2].framing == "length_prefix"
+        assert rows[1].id == "row2"
+        assert rows[1].destination_id == "d2"
 
     def test_marker_id_none_round_trips_through_toml(
         self,

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -3381,6 +3381,57 @@ def test_apply_runtime_osc_destinations_change_reapplies_both_consumers() -> Non
     assert app._web_commands.restart_requested is False
 
 
+def test_apply_runtime_osc_destinations_change_without_zone_engine() -> None:
+    """When no zone engine is wired (``getattr`` → ``None``), the destination
+    change still re-resolves the transmitter manager and updates config."""
+    from openfollow.configuration import OscDestinationConfig, OscDestinationsConfig
+
+    class _RecordingRuntimeServices(_DummyRuntimeServices):
+        def __init__(self) -> None:
+            super().__init__()
+            self.transmitter_dests: list[object] = []
+
+        def apply_osc_transmitters_change(self, new_cfg, destinations=None) -> None:  # noqa: ANN001
+            self.transmitter_dests.append(destinations)
+
+    app = _app_with()
+    app._runtime_services = _RecordingRuntimeServices()
+    # Deliberately no ``_zone_engine`` attribute → getattr returns None.
+
+    new_dests = OscDestinationsConfig(
+        destinations=[OscDestinationConfig(id="default", name="Default", host="10.0.0.9")],
+    )
+    apply_runtime_config_changes(app, AppConfig(osc_destinations=new_dests))
+
+    assert app._config.osc_destinations == new_dests
+    assert app._runtime_services.transmitter_dests == [new_dests]
+
+
+def test_apply_runtime_osc_destinations_change_failure_reverts() -> None:
+    """If the transmitter re-resolve raises, the destination change reverts and
+    the zone engine is never reloaded (the failure short-circuits the else)."""
+    from openfollow.configuration import OscDestinationConfig, OscDestinationsConfig
+
+    class _FailingRuntimeServices(_DummyRuntimeServices):
+        def apply_osc_transmitters_change(self, new_cfg, destinations=None) -> None:  # noqa: ANN001
+            raise RuntimeError("boom")
+
+    app = _app_with()
+    app._runtime_services = _FailingRuntimeServices()
+    zone_engine = _DummyZoneEngine()
+    app._runtime_services._zone_engine = zone_engine  # type: ignore[attr-defined]
+    old_dests = app._config.osc_destinations
+
+    new_dests = OscDestinationsConfig(
+        destinations=[OscDestinationConfig(id="default", name="Default", host="10.0.0.9")],
+    )
+    apply_runtime_config_changes(app, AppConfig(osc_destinations=new_dests))
+
+    # Reverted to the prior destinations; zone engine never reloaded.
+    assert app._config.osc_destinations == old_dests
+    assert zone_engine.reloaded == []
+
+
 def test_apply_runtime_reapplies_midi_devices_to_subsystem() -> None:
     """MIDI config changes reapply to live subsystem."""
     from openfollow.configuration import MidiConfig, MidiPatch

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -4150,6 +4150,20 @@ class TestOscDestinationsConfig:
         )
         assert not hasattr(cfg.destinations[0], "bogus")
 
+    def test_non_object_entries_are_dropped(self) -> None:
+        """A hand-edited TOML / crafted import with bare entries must not
+        persist a str/int/None: ``get()`` and template rendering dereference
+        ``d.id`` / ``d.host`` and would raise AttributeError otherwise. Dict
+        and already-typed entries survive; everything else is dropped."""
+        typed = OscDestinationConfig(id="keep", name="Keep")
+        cfg = OscDestinationsConfig(
+            destinations=["evil", 123, None, {"id": "d1", "host": "10.0.0.9"}, typed],  # type: ignore[list-item]
+        )
+        assert all(isinstance(d, OscDestinationConfig) for d in cfg.destinations)
+        assert [d.id for d in cfg.destinations] == ["d1", "keep"]
+        resolved = cfg.get("d1")
+        assert resolved is not None and resolved.host == "10.0.0.9"
+
     def test_get_returns_matching_destination(self) -> None:
         d = OscDestinationConfig(id="d1", name="A")
         cfg = OscDestinationsConfig(destinations=[d])

--- a/tests/test_coordinate_system_invariants.py
+++ b/tests/test_coordinate_system_invariants.py
@@ -363,12 +363,22 @@ class _StubOsc:
         host: str | None = None,
         port: int | None = None,
         protocol: str = "udp",
+        framing: str = "slip",
     ) -> None:
-        # ``args``/``protocol`` are accepted to keep the stub aligned with
-        # OscService.send. The invariants
-        # tests don't assert on args today – they only care that the right
-        # address fires for a marker-inside-zone scenario.
+        # ``args``/``protocol``/``framing`` are accepted to keep the stub
+        # aligned with OscService.send. The invariants tests don't assert on
+        # args today – they only care that the right address fires for a
+        # marker-inside-zone scenario.
         self.sent.append((address, host, port))
+
+
+# Single destination every zone in these invariants resolves to.
+class _StubDestinations:
+    @staticmethod
+    def get(destination_id: str) -> object | None:
+        if not destination_id:
+            return None
+        return SimpleNamespace(host="127.0.0.1", port=53000, protocol="udp", framing="slip")
 
 
 def _zone_square(cx: float, cy: float, half: float = 1.0) -> TriggerZoneConfig:
@@ -382,6 +392,7 @@ def _zone_square(cx: float, cy: float, half: float = 1.0) -> TriggerZoneConfig:
         ],
         trigger_source="markers",
         enabled=True,
+        destination_id="d",
         osc_address_first_entry="/z/first",
     )
 
@@ -401,7 +412,7 @@ def test_psn_marker_inside_zone_is_detected_regardless_of_offsets(offsets) -> No
         enabled=True,
         zones=[_zone_square(0.0, 3.0, half=1.0)],
     )
-    engine = ZoneEngine(zone_cfg, osc)
+    engine = ZoneEngine(zone_cfg, osc, _StubDestinations())
     engine.update(svc._collect_marker_positions(), detection_positions=[])
 
     states = engine.get_zone_states()
@@ -439,7 +450,7 @@ def test_mouse_click_inside_zone_is_detected_regardless_of_offsets(offsets) -> N
         enabled=True,
         zones=[_zone_square(wx, wy, half=2.0)],
     )
-    engine = ZoneEngine(zone_cfg, osc)
+    engine = ZoneEngine(zone_cfg, osc, _StubDestinations())
     engine.update(svc._collect_marker_positions(), detection_positions=[])
 
     assert engine.get_zone_states() == [(0, True, 1)], (

--- a/tests/test_coordinate_system_invariants.py
+++ b/tests/test_coordinate_system_invariants.py
@@ -372,13 +372,19 @@ class _StubOsc:
         self.sent.append((address, host, port))
 
 
-# Single destination every zone in these invariants resolves to.
+# Single destination every zone in these invariants resolves to (id ``"d"``).
 class _StubDestinations:
+    _DEST = SimpleNamespace(host="127.0.0.1", port=53000, protocol="udp", framing="slip")
+
     @staticmethod
     def get(destination_id: str) -> object | None:
         if not destination_id:
             return None
-        return SimpleNamespace(host="127.0.0.1", port=53000, protocol="udp", framing="slip")
+        return _StubDestinations._DEST
+
+    @staticmethod
+    def by_id() -> dict[str, object]:
+        return {"d": _StubDestinations._DEST}
 
 
 def _zone_square(cx: float, cy: float, half: float = 1.0) -> TriggerZoneConfig:

--- a/tests/test_midi_alias_hot_reload.py
+++ b/tests/test_midi_alias_hot_reload.py
@@ -28,6 +28,8 @@ import pytest
 from openfollow.configuration import (
     MidiMessageTrigger,
     MidiPatch,
+    OscDestinationConfig,
+    OscDestinationsConfig,
     OscTransmitterConfig,
     OscTransmittersConfig,
 )
@@ -80,7 +82,10 @@ def _build_stack(
         marker_provider=lambda _tid: None,
         grid_provider=lambda: (10.0, 6.0, 0.0, 0.0),
     )
-    manager.restart(OscTransmittersConfig(transmitters=triggers))
+    manager.restart(
+        OscTransmittersConfig(transmitters=triggers),
+        OscDestinationsConfig(destinations=[OscDestinationConfig(id="d1", host="127.0.0.1", port=9000)]),
+    )
     manager.attach_midi_subsystem(midi)
     return midi, manager, service
 
@@ -114,9 +119,7 @@ def test_midi_event_dispatches_through_patch_after_port_rename(
     trigger_row = OscTransmitterConfig(
         id="row-1",
         enabled=True,
-        host="127.0.0.1",
-        port=9000,
-        protocol="udp",
+        destination_id="d1",
         marker_id=None,
         address="/cc/[value]",
         args=[],
@@ -219,8 +222,7 @@ def test_late_event_on_closed_port_callback_does_not_double_dispatch(
     trigger_row = OscTransmitterConfig(
         id="row-1",
         enabled=True,
-        host="127.0.0.1",
-        port=9000,
+        destination_id="d1",
         marker_id=None,
         address="/cc/[value]",
         args=[],
@@ -310,8 +312,7 @@ def test_midi_patch_reassignment_breaks_old_trigger_row(
     trigger_row = OscTransmitterConfig(
         id="row-1",
         enabled=True,
-        host="127.0.0.1",
-        port=9000,
+        destination_id="d1",
         marker_id=None,
         address="/cc/[value]",
         args=[],
@@ -384,8 +385,7 @@ def test_concurrent_event_during_apply_config_does_not_race(
     trigger_row = OscTransmitterConfig(
         id="row-1",
         enabled=True,
-        host="127.0.0.1",
-        port=9000,
+        destination_id="d1",
         marker_id=None,
         address="/cc/[value]",
         args=[],

--- a/tests/test_osc_transmitter.py
+++ b/tests/test_osc_transmitter.py
@@ -2353,6 +2353,19 @@ class TestDiagnosticsSurface:
         assert preview["address"] == ""
         assert preview["args"] == []
 
+    def test_preview_for_unresolved_destination_surfaces_skip(self) -> None:
+        """The diagnostic preview of a row with no resolvable destination
+        surfaces a 'no destination selected' skip (the render path keeps its
+        own None guard for this, separate from the live-fire path)."""
+        manager, _svc = _manager(markers={0: _FakeMarker((0.0, 0.0, 0.0))})
+        manager.restart(OscTransmittersConfig(transmitters=[_row(destination_id="")]))
+        preview = manager.preview_for("row-1")
+        assert preview is not None
+        assert preview["skipped"] is True
+        assert preview["error"] == "no destination selected"
+        assert preview["address"] == ""
+        assert preview["args"] == []
+
     def test_preview_for_does_not_record_in_ring_buffer(self) -> None:
         """Critical contract: previewing must not pollute the ring
         buffer the operator is watching for *real* sends."""

--- a/tests/test_osc_transmitter.py
+++ b/tests/test_osc_transmitter.py
@@ -23,6 +23,8 @@ import pytest
 from openfollow.configuration import (
     ControllerButtonTrigger,
     HotkeyTrigger,
+    OscDestinationConfig,
+    OscDestinationsConfig,
     OscTransmitterConfig,
     OscTransmittersConfig,
     StreamTrigger,
@@ -70,14 +72,25 @@ class _FakeMarker:
         self.pos = pos
 
 
+# Default destination every ``_row`` resolves to. Host/port match the
+# values tests historically asserted on, now carried by the destination.
+_DEFAULT_DEST_ID = "dest-1"
+
+
+def _destinations(*dests: OscDestinationConfig) -> OscDestinationsConfig:
+    """Build an ``OscDestinationsConfig``; defaults to the single
+    ``dest-1`` profile rows reference unless explicit ones are given."""
+    if not dests:
+        dests = (OscDestinationConfig(id=_DEFAULT_DEST_ID, name="Default", host="127.0.0.1", port=9000),)
+    return OscDestinationsConfig(destinations=list(dests))
+
+
 def _row(**overrides: Any) -> OscTransmitterConfig:
     """Transmitter row with defaults; tests override only what they assert."""
     defaults: dict[str, Any] = {
         "id": "row-1",
         "enabled": True,
-        "host": "127.0.0.1",
-        "port": 9000,
-        "protocol": "udp",
+        "destination_id": _DEFAULT_DEST_ID,
         "marker_id": 0,
         "template_id": "",
         "address": "/cue/[markerid]",
@@ -95,6 +108,7 @@ def _manager(
     fader_values: dict[int, float] | None = None,
     marker_fader_values: dict[int, float] | None = None,
     controller_markers: dict[int, int] | None = None,
+    destinations: OscDestinationsConfig | None = None,
 ) -> tuple[OscTransmitterManager, _FakeOscService]:
     # grid tuple = (width, depth, max_height, z_offset). max_height=0.0
     # makes ``[z.frac]`` / ``[z.frac.inv]`` raise RenderError; fractional-Z
@@ -117,6 +131,9 @@ def _manager(
         marker_fader_provider=marker_fader_provider,
         controller_marker_provider=controller_marker_provider,
     )
+    # Seed destinations once; subsequent ``restart(cfg)`` calls (with no
+    # destinations arg) keep the staged set, mirroring a transmitter-only edit.
+    manager.restart(OscTransmittersConfig(transmitters=[]), destinations or _destinations())
     return manager, service
 
 
@@ -362,7 +379,7 @@ class TestRendering:
             marker_provider={0: _FakeMarker((2.5, 0.0, 0.0))}.get,
             grid_provider=grid_provider,
         )
-        manager.restart(OscTransmittersConfig(transmitters=[_row(args=["[x.frac]"])]))
+        manager.restart(OscTransmittersConfig(transmitters=[_row(args=["[x.frac]"])]), _destinations())
         manager._tick_once()
         assert service.calls[0][1] == [pytest.approx(0.5)]
         # Widen grid to 20 m → fraction halves on next tick.
@@ -384,7 +401,7 @@ class TestRendering:
             marker_provider={0: _FakeMarker((0.0, 0.0, 2.0))}.get,
             grid_provider=grid_provider,
         )
-        manager.restart(OscTransmittersConfig(transmitters=[_row(args=["[z.frac]"])]))
+        manager.restart(OscTransmittersConfig(transmitters=[_row(args=["[z.frac]"])]), _destinations())
         # First tick: max_height is 0, row skips with a RenderError.
         manager._tick_once()
         assert service.calls == []
@@ -395,15 +412,14 @@ class TestRendering:
 
 
 class TestTransport:
-    def test_send_passes_protocol_through(self) -> None:
-        manager, svc = _manager(markers={0: _FakeMarker((0.0, 0.0, 0.0))})
-        manager.restart(
-            OscTransmittersConfig(
-                transmitters=[
-                    _row(host="10.0.0.5", port=8000, protocol="tcp"),
-                ]
-            )
+    def test_send_resolves_destination_endpoint(self) -> None:
+        """A row's ``destination_id`` resolves to the destination's
+        host/port/protocol at send time."""
+        dests = _destinations(
+            OscDestinationConfig(id="d-tcp", host="10.0.0.5", port=8000, protocol="tcp"),
         )
+        manager, svc = _manager(markers={0: _FakeMarker((0.0, 0.0, 0.0))}, destinations=dests)
+        manager.restart(OscTransmittersConfig(transmitters=[_row(destination_id="d-tcp")]))
         manager._tick_once()
         _addr, _args, host, port, protocol, _framing = svc.calls[0]
         assert host == "10.0.0.5"
@@ -411,27 +427,19 @@ class TestTransport:
         assert protocol == "tcp"
 
     def test_send_passes_framing_through(self) -> None:
-        """Per-binding framing travels from ``OscTransmitterConfig`` through
-        the tick into ``OscService.send`` so the cached ``TcpOscSender`` uses
-        the configured wire format."""
-        manager, svc = _manager(markers={0: _FakeMarker((0.0, 0.0, 0.0))})
+        """Per-destination framing travels through the tick into
+        ``OscService.send`` so the cached ``TcpOscSender`` uses the
+        configured wire format."""
+        dests = _destinations(
+            OscDestinationConfig(id="d-slip", host="10.0.0.5", port=8001, protocol="tcp", framing="slip"),
+            OscDestinationConfig(id="d-lp", host="10.0.0.6", port=8002, protocol="tcp", framing="length_prefix"),
+        )
+        manager, svc = _manager(markers={0: _FakeMarker((0.0, 0.0, 0.0))}, destinations=dests)
         manager.restart(
             OscTransmittersConfig(
                 transmitters=[
-                    _row(
-                        id="row-slip",
-                        host="10.0.0.5",
-                        port=8001,
-                        protocol="tcp",
-                        framing="slip",
-                    ),
-                    _row(
-                        id="row-lp",
-                        host="10.0.0.6",
-                        port=8002,
-                        protocol="tcp",
-                        framing="length_prefix",
-                    ),
+                    _row(id="row-slip", destination_id="d-slip"),
+                    _row(id="row-lp", destination_id="d-lp"),
                 ]
             )
         )
@@ -439,6 +447,31 @@ class TestTransport:
         framings = {host: framing for _addr, _args, host, _port, _protocol, framing in svc.calls}
         assert framings["10.0.0.5"] == "slip"
         assert framings["10.0.0.6"] == "length_prefix"
+
+    def test_unresolved_destination_skips_send_with_reason(self) -> None:
+        """A blank / dangling ``destination_id`` sends nothing and records
+        a skip reason in the row's ring buffer."""
+        manager, svc = _manager(markers={0: _FakeMarker((0.0, 0.0, 0.0))})
+        manager.restart(OscTransmittersConfig(transmitters=[_row(id="r", destination_id="")]))
+        manager._tick_once()
+        assert svc.calls == []
+        entries = manager.ring_buffer_for("r") or []
+        assert entries[-1].status == "skipped"
+        assert entries[-1].error == "no destination selected"
+
+    def test_destination_ip_edit_repoints_next_send(self) -> None:
+        """Re-staging destinations with a new host (a live IP edit) makes the
+        next send target the new host – no row edit needed."""
+        dests = _destinations(OscDestinationConfig(id="d", host="10.0.0.5", port=9000))
+        manager, svc = _manager(markers={0: _FakeMarker((0.0, 0.0, 0.0))}, destinations=dests)
+        manager.restart(OscTransmittersConfig(transmitters=[_row(destination_id="d")]))
+        manager._tick_once()
+        assert svc.calls[0][2] == "10.0.0.5"
+        # Operator edits the destination's IP; transmitters unchanged.
+        new_dests = _destinations(OscDestinationConfig(id="d", host="10.0.0.9", port=9000))
+        manager.restart(OscTransmittersConfig(transmitters=[_row(destination_id="d")]), new_dests)
+        manager._tick_once()
+        assert svc.calls[-1][2] == "10.0.0.9"
 
 
 # ---------------------------------------------------------------------------
@@ -1061,7 +1094,7 @@ class TestOnChangeCacheLocking:
         assert "row-1" in manager._last_sent_pos
         # Cosmetic reload (same marker_id + trigger kind) reuses the object.
         same = manager._rows["row-1"]
-        manager.restart(OscTransmittersConfig(transmitters=[self._on_change_row(host="10.0.0.9")]))
+        manager.restart(OscTransmittersConfig(transmitters=[self._on_change_row(name="renamed")]))
         assert manager._rows["row-1"] is same
         assert "row-1" in manager._last_sent_pos
 
@@ -1295,14 +1328,14 @@ class TestOnChangeCacheLocking:
         manager.restart(OscTransmittersConfig(transmitters=[self._on_change_row()]))
         manager._tick_once()
         assert "row-1" in manager._last_sent_pos
-        # Edit cosmetic fields only (host/name) and the threshold –
+        # Edit cosmetic fields only (destination/name) and the threshold –
         # threshold change is read fresh per tick, doesn't affect
         # the cached position's meaning.
         manager.restart(
             OscTransmittersConfig(
                 transmitters=[
                     self._on_change_row(
-                        host="10.0.0.1",
+                        destination_id="dest-1",
                         name="renamed",
                         trigger=StreamTrigger(
                             rate_hz=60,
@@ -1551,7 +1584,8 @@ class TestDefaultMarkerLookupGated:
                         args=["My Cue"],
                     ),
                 ]
-            )
+            ),
+            _destinations(),
         )
         manager._tick_once()
         assert calls == []
@@ -1808,8 +1842,9 @@ class TestEventBusDispatch:
         rows: list[OscTransmitterConfig],
         *,
         markers: dict[int, _FakeMarker] | None = None,
+        destinations: OscDestinationsConfig | None = None,
     ) -> tuple[OscTransmitterManager, _FakeOscService, InputEventBus]:
-        manager, svc = _manager(markers=markers)
+        manager, svc = _manager(markers=markers, destinations=destinations)
         manager.restart(OscTransmittersConfig(transmitters=rows))
         bus = InputEventBus()
         manager.attach_event_bus(bus)
@@ -1899,10 +1934,14 @@ class TestEventBusDispatch:
         on the same hotkey both emit."""
         manager, svc, bus = self._attached(
             [
-                _row(id="r1", host="10.0.0.1", trigger=HotkeyTrigger(key="F1")),
-                _row(id="r2", host="10.0.0.2", trigger=HotkeyTrigger(key="F1")),
+                _row(id="r1", destination_id="d1", trigger=HotkeyTrigger(key="F1")),
+                _row(id="r2", destination_id="d2", trigger=HotkeyTrigger(key="F1")),
             ],
             markers={0: _FakeMarker((1.0, 2.0, 3.0))},
+            destinations=_destinations(
+                OscDestinationConfig(id="d1", host="10.0.0.1", port=9000),
+                OscDestinationConfig(id="d2", host="10.0.0.2", port=9000),
+            ),
         )
         bus.emit_key(KeyEvent(key="F1", edge="press"))
         manager.process_pending_events()
@@ -2281,7 +2320,7 @@ class TestDiagnosticsSurface:
             marker_provider=markers.get,
             grid_provider=lambda: (10.0, 6.0, 0.0, 0.0),
         )
-        manager.restart(OscTransmittersConfig(transmitters=[_row()]))
+        manager.restart(OscTransmittersConfig(transmitters=[_row()]), _destinations())
         manager._tick_once()  # skip
         markers[0] = _FakeMarker((1.0, 2.0, 3.0))
         manager._tick_once()  # send
@@ -2803,13 +2842,18 @@ class TestMidiMessageDispatch:
     def test_multiple_matching_rows_all_fire(self) -> None:
         """No cross-row collision rule – two rows on the same MIDI message
         both fire."""
-        manager, svc = _manager()
+        manager, svc = _manager(
+            destinations=_destinations(
+                OscDestinationConfig(id="d1", host="10.0.0.1", port=9000),
+                OscDestinationConfig(id="d2", host="10.0.0.2", port=9000),
+            ),
+        )
         manager.restart(
             OscTransmittersConfig(
                 transmitters=[
                     _row(
                         id="r1",
-                        host="10.0.0.1",
+                        destination_id="d1",
                         marker_id=None,
                         address="/cc",
                         args=[],
@@ -2821,7 +2865,7 @@ class TestMidiMessageDispatch:
                     ),
                     _row(
                         id="r2",
-                        host="10.0.0.2",
+                        destination_id="d2",
                         marker_id=None,
                         address="/cc",
                         args=[],

--- a/tests/test_services_init_and_updates.py
+++ b/tests/test_services_init_and_updates.py
@@ -1956,7 +1956,7 @@ class TestInitOscTransmitters:
             services._app._config,
             osc_transmitters=OscTransmittersConfig(
                 transmitters=[
-                    OscTransmitterConfig(id="row-a", host="127.0.0.1", port=9001),
+                    OscTransmitterConfig(id="row-a", destination_id="d1"),
                 ]
             ),
         )

--- a/tests/test_services_init_and_updates.py
+++ b/tests/test_services_init_and_updates.py
@@ -2325,6 +2325,31 @@ class TestApplyOscTransmittersChange:
             if services._osc_transmitter_manager is not None:
                 services._osc_transmitter_manager.stop()
 
+    def test_explicit_destinations_skip_app_config_fallback(
+        self,
+        services: AppRuntimeServices,
+    ) -> None:
+        """Passing an explicit destinations set bypasses the
+        ``destinations is None`` fallback to the app's current set."""
+        from openfollow.configuration import (
+            OscDestinationConfig,
+            OscDestinationsConfig,
+            OscTransmittersConfig,
+        )
+
+        dests = OscDestinationsConfig(
+            destinations=[OscDestinationConfig(id="d1", name="Console", host="10.0.0.5")],
+        )
+        services.apply_osc_transmitters_change(
+            OscTransmittersConfig(transmitters=[]),
+            destinations=dests,
+        )
+        try:
+            assert services._osc_transmitter_manager is not None
+        finally:
+            if services._osc_transmitter_manager is not None:
+                services._osc_transmitter_manager.stop()
+
     def test_reinit_reattaches_event_bus_when_input_manager_exists(
         self,
         services: AppRuntimeServices,

--- a/tests/test_services_zone_orchestration.py
+++ b/tests/test_services_zone_orchestration.py
@@ -147,6 +147,7 @@ class _FakeOscService:
         host: str,
         port: int,
         protocol: str = "udp",
+        framing: str = "slip",
     ) -> None:
         self.calls.append((address, list(args), host, port))
 
@@ -172,8 +173,6 @@ def _make_app(
         trigger_zones=TriggerZonesConfig(
             enabled=zones_enabled,
             eval_fps=eval_fps,
-            default_osc_host="127.0.0.1",
-            default_osc_port=54000,
         ),
     )
     app = SimpleNamespace(
@@ -209,7 +208,7 @@ def services(monkeypatch: pytest.MonkeyPatch) -> AppRuntimeServices:
     # services itself; tests swap it for a fake after construction.
     import openfollow.zones as zones_pkg
 
-    monkeypatch.setattr(zones_pkg, "ZoneEngine", lambda cfg, osc: _FakeZoneEngine())
+    monkeypatch.setattr(zones_pkg, "ZoneEngine", lambda cfg, osc, dests=None: _FakeZoneEngine())
 
     svc = AppRuntimeServices(_make_app())
     svc._osc_service = _FakeOscService()  # type: ignore[assignment]
@@ -485,11 +484,15 @@ class TestZoneTestSend:
     def test_test_send_dispatches_through_osc_service(self, services: AppRuntimeServices) -> None:
         """Happy path: an empty zone gets a populated ``first_entry``
         address; ``_zone_test_send`` tokenises + coerces + sends."""
+        from openfollow.configuration import OscDestinationConfig
+
         _seed_zone(services)
+        services._app._config.osc_destinations.destinations.append(
+            OscDestinationConfig(id="d1", host="10.1.2.3", port=9000),
+        )
         zone_cfg = services._app._config.trigger_zones.zones[0]
         zone_cfg.osc_address_first_entry = "/zone/enter 1.5"
-        zone_cfg.osc_host = "10.1.2.3"
-        zone_cfg.osc_port = 9000
+        zone_cfg.destination_id = "d1"
         result = services._zone_test_send(0, "first")
         assert result["success"] is True
         assert result["address"] == "/zone/enter"
@@ -501,17 +504,14 @@ class TestZoneTestSend:
         assert isinstance(fake_osc, _FakeOscService)
         assert fake_osc.calls == [("/zone/enter", [1.5], "10.1.2.3", 9000)]
 
-    def test_test_send_falls_back_to_section_default_host_port(self, services: AppRuntimeServices) -> None:
+    def test_test_send_skipped_when_no_destination_selected(self, services: AppRuntimeServices) -> None:
         _seed_zone(services)
         zone_cfg = services._app._config.trigger_zones.zones[0]
         zone_cfg.osc_address_additional_entry = "/zone/extra"
-        zone_cfg.osc_host = ""
-        zone_cfg.osc_port = 0
-        services._app._config.trigger_zones.default_osc_host = "192.0.2.1"
-        services._app._config.trigger_zones.default_osc_port = 8000
+        zone_cfg.destination_id = ""
         result = services._zone_test_send(0, "additional")
-        assert result["host"] == "192.0.2.1"
-        assert result["port"] == 8000
+        assert result.get("skipped") is True
+        assert result["reason"] == "no destination selected"
 
     def test_test_send_unknown_which_returns_error(self, services: AppRuntimeServices) -> None:
         _seed_zone(services)

--- a/tests/test_template_validation_consistency.py
+++ b/tests/test_template_validation_consistency.py
@@ -11,7 +11,9 @@ Walks every partial template and asserts that every ``<input>`` whose
 - ``hx-target`` referencing a sibling ``<span class="field-error">``
 - ``aria-describedby`` matching the same id as ``hx-target``
 
-The section is derived from the partial's filename (``grid.tpl`` → ``"grid"``).
+The section is derived from the partial's filename (``grid.tpl`` → ``"grid"``),
+with ``_SECTION_OVERRIDES`` mapping plural row-list partials to their singular
+``FIELD_RULES`` section (``osc_destinations.tpl`` → ``"osc_destination"``).
 ``type="hidden"``, ``type="checkbox"``, and ``type="radio"`` inputs are skipped
 – discrete choices don't need on-blur validation. ``<select>`` is also skipped
 (it's an HTML element distinct from ``<input>``; the consistency check is scoped
@@ -69,8 +71,15 @@ def _parse_partial(path: Path) -> list[dict[str, str]]:
     return parser.inputs
 
 
+# Some partials render a list of rows whose FIELD_RULES section is singular
+# while the filename is plural. Map the filename stem to the rules section so
+# the registered inputs are audited rather than silently skipped on a missing
+# ``FIELD_RULES.get(stem)`` lookup.
+_SECTION_OVERRIDES = {"osc_destinations": "osc_destination"}
+
+
 def _section_from_path(path: Path) -> str:
-    return path.stem
+    return _SECTION_OVERRIDES.get(path.stem, path.stem)
 
 
 def _registered_inputs() -> Iterable[tuple[Path, str, dict[str, str]]]:
@@ -94,6 +103,17 @@ def _registered_inputs() -> Iterable[tuple[Path, str, dict[str, str]]]:
 
 def test_partials_directory_exists() -> None:
     assert _PARTIALS_DIR.is_dir(), f"missing partials dir: {_PARTIALS_DIR}"
+
+
+def test_osc_destinations_partial_inputs_are_audited() -> None:
+    """The osc_destinations partial has a plural filename but a singular
+    ``osc_destination`` FIELD_RULES section. Without the override its inputs
+    would be silently skipped; assert they are actually picked up so the
+    markup audit can't regress to a no-op for this form."""
+    audited = {(path.name, attrs["name"]) for path, _section, attrs in _registered_inputs()}
+    assert ("osc_destinations.tpl", "host") in audited
+    assert ("osc_destinations.tpl", "port") in audited
+    assert ("osc_destinations.tpl", "name") in audited
 
 
 def test_every_registered_input_has_validation_markup() -> None:

--- a/tests/test_templates_unit.py
+++ b/tests/test_templates_unit.py
@@ -175,9 +175,7 @@ class TestOscOutputPayload:
             "osc_output",
             {
                 "name": "ETC stage",
-                "host": "10.0.0.5",
-                "port": 8000,
-                "protocol": "tcp",
+                "destination_id": "dest-1",
                 "address": "/cue/go",
                 "args": ["[x]"],
                 "rate_hz": 60,
@@ -185,7 +183,7 @@ class TestOscOutputPayload:
             },
         )
 
-    @pytest.mark.parametrize("field_name", ["name", "host", "protocol"])
+    @pytest.mark.parametrize("field_name", ["name", "destination_id"])
     def test_non_str_extended_string_fields_rejected(
         self,
         field_name: str,
@@ -199,30 +197,25 @@ class TestOscOutputPayload:
                 },
             )
 
-    @pytest.mark.parametrize("field_name", ["port", "rate_hz"])
-    def test_non_int_extended_int_fields_rejected(
-        self,
-        field_name: str,
-    ) -> None:
-        with pytest.raises(TemplateValidationError, match=field_name):
+    def test_non_int_rate_hz_rejected(self) -> None:
+        with pytest.raises(TemplateValidationError, match="rate_hz"):
             validate_payload(
                 "osc_output",
                 {
                     "address": "/x",
-                    field_name: "8000",
+                    "rate_hz": "8000",
                 },
             )
 
-    @pytest.mark.parametrize("field_name", ["port", "rate_hz"])
-    def test_bool_for_int_fields_rejected(self, field_name: str) -> None:
-        # ``True`` is an ``int`` subclass; rejected so ``port = true``
-        # doesn't become port 1 on apply.
-        with pytest.raises(TemplateValidationError, match=field_name):
+    def test_bool_for_rate_hz_rejected(self) -> None:
+        # ``True`` is an ``int`` subclass; rejected so ``rate_hz = true``
+        # doesn't become rate 1 on apply.
+        with pytest.raises(TemplateValidationError, match="rate_hz"):
             validate_payload(
                 "osc_output",
                 {
                     "address": "/x",
-                    field_name: True,
+                    "rate_hz": True,
                 },
             )
 
@@ -463,43 +456,18 @@ class TestOscOutputPayload:
                 },
             )
 
-    # Without range/enum checks, ``OscTransmitterConfig.__post_init__``
-    # silently coerces bad values on apply (port → default, rate
-    # snapped to nearest, protocol → ``"udp"``, ``min_change_m`` →
-    # 0.05). Reject up front instead of auto-mutating the template.
-    def test_port_out_of_range_rejected(self) -> None:
-        with pytest.raises(TemplateValidationError, match="'port' must be in 1..65535"):
-            validate_payload(
-                "osc_output",
-                {
-                    "address": "/x",
-                    "port": 70000,
-                },
-            )
+    # Connection is no longer part of the template (it lives on a shared
+    # OSC destination); a template only carries a ``destination_id`` string.
+    def test_legacy_connection_keys_rejected_as_unknown(self) -> None:
+        for bad_key in ("host", "port", "protocol", "framing"):
+            with pytest.raises(TemplateValidationError, match="unknown key"):
+                validate_payload(
+                    "osc_output",
+                    {"address": "/x", bad_key: "whatever"},
+                )
 
-    def test_port_zero_rejected(self) -> None:
-        with pytest.raises(TemplateValidationError, match="'port' must be in 1..65535"):
-            validate_payload("osc_output", {"address": "/x", "port": 0})
-
-    def test_port_negative_rejected(self) -> None:
-        with pytest.raises(TemplateValidationError, match="'port' must be in 1..65535"):
-            validate_payload("osc_output", {"address": "/x", "port": -1})
-
-    def test_port_in_range_passes(self) -> None:
-        validate_payload("osc_output", {"address": "/x", "port": 8000})
-
-    def test_protocol_unknown_rejected(self) -> None:
-        with pytest.raises(TemplateValidationError, match="'protocol' must be one of"):
-            validate_payload(
-                "osc_output",
-                {
-                    "address": "/x",
-                    "protocol": "smtp",
-                },
-            )
-
-    def test_protocol_known_passes(self) -> None:
-        validate_payload("osc_output", {"address": "/x", "protocol": "tcp"})
+    def test_destination_id_passes(self) -> None:
+        validate_payload("osc_output", {"address": "/x", "destination_id": "dest-1"})
 
     def test_top_level_rate_hz_out_of_set_rejected(self) -> None:
         # 59 isn't in (1, 5, 10, 20, 30, 60); row config silently snaps
@@ -565,9 +533,7 @@ class TestOscOutputPayload:
                 "address": "/x",
                 "args": ["[x]"],
                 "name": "Eos",
-                "host": "10.0.0.1",
-                "port": 8000,
-                "protocol": "udp",
+                "destination_id": "dest-1",
                 "rate_hz": 30,
                 "trigger": {"kind": "stream", "rate_hz": 30, "mode": "always"},
             },
@@ -687,8 +653,6 @@ class TestZonesPayload:
                 "enabled": True,
                 "show_overlay": True,
                 "eval_fps": 10,
-                "default_osc_host": "10.0.0.1",
-                "default_osc_port": 53000,
                 "debounce_ms": 200,
                 "hysteresis": 0.05,
                 "zones": [],

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -896,7 +896,7 @@ def test_osc_destination_field_rules(field: str, value: str, expect_error: bool)
 
 
 # ---------------------------------------------------------------------------
-# Per-zone OSC address fields share the OSC Output blur validator
+# Per-zone OSC address fields share the OSC Transmitters blur validator
 # ---------------------------------------------------------------------------
 
 # triggered_by blur validation: empty/valid lists pass, invalid entries reject.
@@ -938,7 +938,7 @@ class TestZoneTriggeredByRule:
 class TestZoneOscAddressRules:
     def test_empty_field_is_valid(self, field: str) -> None:
         """An unset zone OSC field is a valid "skip this transition"
-        – same lenient contract as OSC Output's empty osc_message."""
+        – same lenient contract as OSC Transmitters's empty osc_message."""
         assert validate("zone", field, "") is None
         assert validate("zone", field, "   ") is None
 
@@ -948,7 +948,7 @@ class TestZoneOscAddressRules:
         assert validate("zone", field, "/zone/enter") is None
 
     def test_address_plus_quoted_arg_is_valid(self, field: str) -> None:
-        """Quoted args alongside address allowed in zone fields like OSC Output."""
+        """Quoted args alongside address allowed in zone fields like OSC Transmitters."""
         assert validate("zone", field, '/cmd "Go Cue 1" 1.5') is None
 
     def test_address_without_leading_slash_rejected(self, field: str) -> None:
@@ -968,3 +968,14 @@ class TestZoneOscAddressRules:
         err = validate("zone", field, "/" + "a" * 2048)
         assert err is not None
         assert "2048" in err
+
+
+def test_needs_cfg_false_for_every_rule() -> None:
+    """No registered ``FieldRule`` currently reads ``AppConfig``, so
+    ``needs_cfg`` returns ``False`` for all of them – the ``/api/validate``
+    fast-path skips the per-keystroke TOML parse for every field."""
+    from openfollow.web.validation import needs_cfg
+
+    for section, rules in FIELD_RULES.items():
+        for field_name, rule in rules.items():
+            assert needs_cfg(rule) is False, f"{section}.{field_name}"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -717,7 +717,7 @@ def test_otp_source_iface_has_no_field_rule() -> None:
     "section,field",
     [
         ("rttrpm_output", "host"),
-        ("trigger_zones", "default_osc_host"),
+        ("osc_destination", "host"),
     ],
 )
 def test_validate_host_field_accepts_ip(section: str, field: str) -> None:
@@ -728,7 +728,7 @@ def test_validate_host_field_accepts_ip(section: str, field: str) -> None:
     "section,field",
     [
         ("rttrpm_output", "host"),
-        ("trigger_zones", "default_osc_host"),
+        ("osc_destination", "host"),
     ],
 )
 def test_validate_host_field_accepts_hostname(section: str, field: str) -> None:
@@ -739,7 +739,7 @@ def test_validate_host_field_accepts_hostname(section: str, field: str) -> None:
     "section,field",
     [
         ("rttrpm_output", "host"),
-        ("trigger_zones", "default_osc_host"),
+        ("osc_destination", "host"),
     ],
 )
 def test_validate_host_field_rejects_internal_whitespace(section: str, field: str) -> None:
@@ -830,18 +830,9 @@ def test_validate_osc_message_rejects_unclosed_quote(raw: str) -> None:
     [
         ("name", "Stage 1", False),
         ("name", "x" * 65, True),  # max_len 64
-        ("host", "10.0.0.1", False),
-        ("port", "9000", False),
-        ("port", "0", True),
-        ("port", "65536", True),
-        ("protocol", "udp", False),
-        ("protocol", "tcp", False),
-        ("protocol", "carrier-pigeon", True),
-        # TCP framing selector: both choices accepted, bogus values rejected.
-        ("framing", "slip", False),
-        ("framing", "length_prefix", False),
-        ("framing", "carrier-pigeon", True),
-        ("framing", "SLIP", True),  # canonical lower-case only
+        # Connection is chosen via a destination; empty is allowed (no send).
+        ("destination_id", "", False),
+        ("destination_id", "dest-1", False),
         ("marker_id", "0", False),
         ("marker_id", "-1", True),
         # marker_id can be empty (no default marker).
@@ -875,6 +866,33 @@ def test_osc_binding_field_rules(field: str, value: str, expect_error: bool) -> 
         assert err is not None, f"osc_binding.{field}={value!r} should have failed validation"
     else:
         assert err is None, f"osc_binding.{field}={value!r} unexpectedly failed: {err}"
+
+
+@pytest.mark.parametrize(
+    "field,value,expect_error",
+    [
+        ("name", "Console", False),
+        ("name", "x" * 65, True),  # max_len 64
+        ("host", "10.0.0.1", False),
+        ("host", "192.168 .1.1", True),
+        ("port", "9000", False),
+        ("port", "0", True),
+        ("port", "65536", True),
+        ("protocol", "udp", False),
+        ("protocol", "tcp", False),
+        ("protocol", "carrier-pigeon", True),
+        ("framing", "slip", False),
+        ("framing", "length_prefix", False),
+        ("framing", "carrier-pigeon", True),
+        ("framing", "SLIP", True),  # canonical lower-case only
+    ],
+)
+def test_osc_destination_field_rules(field: str, value: str, expect_error: bool) -> None:
+    err = validate("osc_destination", field, value)
+    if expect_error:
+        assert err is not None, f"osc_destination.{field}={value!r} should have failed validation"
+    else:
+        assert err is None, f"osc_destination.{field}={value!r} unexpectedly failed: {err}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_web_helpers.py
+++ b/tests/test_web_helpers.py
@@ -12,7 +12,7 @@ from dataclasses import asdict
 import pytest
 
 import openfollow.video.inputs as inputs_module
-from openfollow.configuration import AppConfig
+from openfollow.configuration import AppConfig, OscDestinationConfig, OscDestinationsConfig
 from openfollow.web.routes import (
     _as_int_list,
     _as_ip_list,
@@ -22,6 +22,8 @@ from openfollow.web.routes import (
     _is_valid_web_pin,
     apply_section_data,
     get_section_data,
+    osc_destinations_client_list,
+    osc_destinations_script_json,
     strip_device_local_fields,
 )
 
@@ -2449,3 +2451,63 @@ def test_allowed_request_hosts_blank_hostname_falls_back(monkeypatch) -> None:
     assert "127.0.0.1" in hosts and "localhost" in hosts and "::1" in hosts
     assert "" not in hosts
     assert not any(h.endswith(".local") for h in hosts)
+
+
+# ---------------------------------------------------------------------------
+# OSC destinations: client list + <script>-safe JSON embedding
+# ---------------------------------------------------------------------------
+
+
+def test_osc_destinations_client_list_shape() -> None:
+    cfg = AppConfig(
+        osc_destinations=OscDestinationsConfig(
+            destinations=[
+                OscDestinationConfig(
+                    id="d1",
+                    name="A",
+                    host="10.0.0.9",
+                    port=9000,
+                    protocol="tcp",
+                    framing="length_prefix",
+                )
+            ]
+        )
+    )
+    assert osc_destinations_client_list(cfg) == [
+        {
+            "id": "d1",
+            "name": "A",
+            "host": "10.0.0.9",
+            "port": 9000,
+            "protocol": "tcp",
+            "framing": "length_prefix",
+        }
+    ]
+
+
+def test_osc_destinations_script_json_escapes_script_breakout() -> None:
+    """A destination name/host with ``</script>`` or ``&`` must not break out of
+    the ``<script>`` block it is embedded in via ``{{! ... }}``."""
+    import json
+
+    cfg = AppConfig(
+        osc_destinations=OscDestinationsConfig(
+            destinations=[
+                OscDestinationConfig(
+                    id="d1",
+                    name="</script><img src=x onerror=alert(1)>",
+                    host="a&b",
+                )
+            ]
+        )
+    )
+    out = osc_destinations_script_json(cfg)
+    # No raw HTML-significant characters survive: a script element cannot be
+    # closed, no tag can open, no entity is introduced.
+    assert "</script>" not in out
+    assert "<" not in out and ">" not in out and "&" not in out
+    assert "\\u003c/script\\u003e" in out
+    # The payload still round-trips: a JSON/JS parser decodes the escapes back.
+    restored = json.loads(out)
+    assert restored[0]["name"] == "</script><img src=x onerror=alert(1)>"
+    assert restored[0]["host"] == "a&b"

--- a/tests/test_web_helpers.py
+++ b/tests/test_web_helpers.py
@@ -596,7 +596,7 @@ def test_apply_zone_fields_parses_types_and_defaults_vertices() -> None:
             "name": "Stage Left",
             "color": "#FF0000",
             "enabled": "true",
-            "osc_port": "9001",
+            "destination_id": "d1",
             "vertices": [[0, 0], [10, 0], [10, 10]],
             "ignored_unknown_field": "dropped-silently",
         },
@@ -605,7 +605,7 @@ def test_apply_zone_fields_parses_types_and_defaults_vertices() -> None:
     assert zone.name == "Stage Left"
     assert zone.color == "#FF0000"
     assert zone.enabled is True
-    assert zone.osc_port == 9001
+    assert zone.destination_id == "d1"
     assert zone.vertices == [[0.0, 0.0], [10.0, 0.0], [10.0, 10.0]]
     # Unknown keys must not create attributes on the dataclass.
     assert not hasattr(zone, "ignored_unknown_field")
@@ -751,6 +751,81 @@ def test_apply_import_data_replaces_trigger_zones_list() -> None:
     assert new.trigger_zones.enabled is True
     assert [z.name for z in new.trigger_zones.zones] == ["New 1", "New 2"]
     assert new.trigger_zones.zones[0].vertices == [[0.0, 0.0], [1.0, 1.0]]
+
+
+def test_apply_import_data_round_trips_osc_transmitters_and_destinations() -> None:
+    """Destinations + transmitters + zones travel through the config file so a
+    ``destination_id`` and its target arrive together with references intact."""
+    from openfollow.web.routes import _apply_import_data
+
+    current = AppConfig()
+    imported = {
+        "osc_destinations": {
+            "destinations": [
+                {"id": "console", "name": "Console", "host": "10.0.0.9", "port": 8000},
+            ],
+        },
+        "osc_transmitters": {
+            "transmitters": [
+                {"id": "row1", "name": "Cue", "destination_id": "console"},
+            ],
+        },
+        "trigger_zones": {
+            "zones": [{"name": "Z", "destination_id": "console"}],
+        },
+    }
+    new = _apply_import_data(current, imported)
+
+    dests = new.osc_destinations.destinations
+    assert any(d.id == "console" and d.host == "10.0.0.9" for d in dests)
+    rows = new.osc_transmitters.transmitters
+    assert rows[0].destination_id == "console"
+    assert new.trigger_zones.zones[0].destination_id == "console"
+    # The reference resolves on the importing device.
+    assert new.osc_destinations.get(rows[0].destination_id) is not None
+
+
+def test_strip_broadcast_excluded_drops_routing_sections() -> None:
+    """OSC destinations / transmitters / zones export via file but are never
+    real-time shared – the broadcast body omits them."""
+    from openfollow.web.routes import _config_dict_redacted, _strip_broadcast_excluded
+
+    full = _config_dict_redacted(AppConfig())
+    # Sanity: the full export dict carries them.
+    assert "osc_destinations" in full
+    assert "osc_transmitters" in full
+    assert "trigger_zones" in full
+
+    broadcast = _strip_broadcast_excluded(full)
+    assert "osc_destinations" not in broadcast
+    assert "osc_transmitters" not in broadcast
+    assert "trigger_zones" not in broadcast
+    # A non-excluded section still travels.
+    assert "camera" in broadcast
+
+
+def test_apply_osc_destination_fields_coerces_and_normalises() -> None:
+    from openfollow.configuration import OscDestinationConfig
+    from openfollow.web.routes import _apply_osc_destination_fields
+
+    dest = OscDestinationConfig(id="d1")
+    _apply_osc_destination_fields(
+        dest,
+        {
+            "name": "  Console  ",
+            "host": "  10.0.0.5  ",
+            "port": "70000",  # clamps to 65535
+            "protocol": "tcp",
+            "framing": "carrier-pigeon",  # snaps back to slip
+        },
+    )
+    assert dest.name == "Console"
+    assert dest.host == "10.0.0.5"
+    assert dest.port == 65535
+    assert dest.protocol == "tcp"
+    assert dest.framing == "slip"
+    # id is preserved (not minted).
+    assert dest.id == "d1"
 
 
 def test_apply_import_data_window_dims_and_pin_pass_through() -> None:

--- a/tests/test_web_osc_bindings.py
+++ b/tests/test_web_osc_bindings.py
@@ -27,6 +27,7 @@ from openfollow.configuration import (
     MidiConfig,
     MidiMessageTrigger,
     MidiPatch,
+    OscDestinationConfig,
     OscTransmitterConfig,
     StreamTrigger,
     VirtualFaderConfig,
@@ -156,8 +157,11 @@ def test_section_renders_empty_state(live_server) -> None:
 def test_section_renders_existing_rows(live_server) -> None:
     _, base, cfg_path = live_server
     cfg = load_config(cfg_path)
+    cfg.osc_destinations.destinations.append(
+        OscDestinationConfig(id="d1", name="Console", host="10.0.0.1", port=8001),
+    )
     cfg.osc_transmitters.transmitters.append(
-        OscTransmitterConfig(name="Stage 1", host="10.0.0.1", port=8001),
+        OscTransmitterConfig(name="Stage 1", destination_id="d1"),
     )
     save_config(cfg, cfg_path)
     status, body = _get(base, "/section/osc_bindings")
@@ -172,10 +176,10 @@ def test_section_focus_query_reopens_row(live_server) -> None:
     _, base, cfg_path = live_server
     cfg = load_config(cfg_path)
     cfg.osc_transmitters.transmitters.append(
-        OscTransmitterConfig(name="A", host="10.0.0.1", port=8001),
+        OscTransmitterConfig(name="A", destination_id="d1"),
     )
     cfg.osc_transmitters.transmitters.append(
-        OscTransmitterConfig(name="B", host="10.0.0.2", port=8002),
+        OscTransmitterConfig(name="B", destination_id="d2"),
     )
     save_config(cfg, cfg_path)
     target_id = cfg.osc_transmitters.transmitters[1].id
@@ -204,7 +208,7 @@ def test_section_renders_per_row_discard_button(live_server) -> None:
     _, base, cfg_path = live_server
     cfg = load_config(cfg_path)
     cfg.osc_transmitters.transmitters.append(
-        OscTransmitterConfig(name="Stage 1", host="10.0.0.1", port=8001),
+        OscTransmitterConfig(name="Stage 1", destination_id="d1"),
     )
     save_config(cfg, cfg_path)
     row_id = cfg.osc_transmitters.transmitters[0].id
@@ -250,10 +254,7 @@ def test_save_updates_basics(live_server) -> None:
         {
             "enabled": "on",
             "name": "Edited",
-            "host": "192.168.1.10",
-            "port": "9000",
-            "protocol": "tcp",
-            "framing": "length_prefix",
+            "destination_id": "dest-7",
             "marker_id": "2",
             "trigger.type": "stream",
             "trigger.rate_hz": "60",
@@ -264,69 +265,10 @@ def test_save_updates_basics(live_server) -> None:
     row = cfg.osc_transmitters.transmitters[0]
     assert row.enabled is True
     assert row.name == "Edited"
-    assert row.host == "192.168.1.10"
-    assert row.port == 9000
-    assert row.protocol == "tcp"
-    assert row.framing == "length_prefix"
+    assert row.destination_id == "dest-7"
     assert row.marker_id == 2
     assert isinstance(row.trigger, StreamTrigger)
     assert row.trigger.rate_hz == 60
-
-
-def test_save_with_tcp_slip_framing_round_trips(live_server) -> None:
-    """SLIP is the default for new TCP rows; the form must persist
-    whichever framing the operator picked through one save + reload
-    cycle."""
-    _, base, cfg_path = live_server
-    _post_form(base, "/section/osc_bindings/add", {})
-    cfg = load_config(cfg_path)
-    row_id = cfg.osc_transmitters.transmitters[0].id
-    status, _ = _post_form(
-        base,
-        f"/section/osc_binding/{row_id}",
-        {
-            "enabled": "on",
-            "name": "Slip",
-            "host": "1.2.3.4",
-            "port": "9000",
-            "protocol": "tcp",
-            "framing": "slip",
-            "marker_id": "1",
-            "trigger.type": "stream",
-            "trigger.rate_hz": "30",
-        },
-    )
-    assert status == 200
-    row = load_config(cfg_path).osc_transmitters.transmitters[0]
-    assert row.protocol == "tcp"
-    assert row.framing == "slip"
-
-
-def test_save_with_invalid_framing_falls_back_to_default(live_server) -> None:
-    """A POST with an invalid framing value: the configuration-layer
-    ``_coerce_choice`` snaps it back to ``"slip"`` so the row persists
-    with the default rather than a value the runtime can't dispatch."""
-    _, base, cfg_path = live_server
-    _post_form(base, "/section/osc_bindings/add", {})
-    cfg = load_config(cfg_path)
-    row_id = cfg.osc_transmitters.transmitters[0].id
-    _post_form(
-        base,
-        f"/section/osc_binding/{row_id}",
-        {
-            "enabled": "on",
-            "name": "X",
-            "host": "h",
-            "port": "9000",
-            "protocol": "tcp",
-            "framing": "carrier-pigeon",
-            "marker_id": "1",
-            "trigger.type": "stream",
-            "trigger.rate_hz": "30",
-        },
-    )
-    row = load_config(cfg_path).osc_transmitters.transmitters[0]
-    assert row.framing == "slip"
 
 
 def test_save_round_trips_non_ascii_form_bytes(live_server) -> None:
@@ -389,9 +331,7 @@ def test_save_partial_form_keeps_unsent_fields(live_server) -> None:
         {
             "enabled": "on",
             "name": "Stage",
-            "host": "1.2.3.4",
-            "port": "8000",
-            "protocol": "udp",
+            "destination_id": "dest-3",
             "marker_id": "1",
             "trigger.type": "stream",
             "trigger.rate_hz": "30",
@@ -403,7 +343,7 @@ def test_save_partial_form_keeps_unsent_fields(live_server) -> None:
     row = cfg.osc_transmitters.transmitters[0]
     assert row.enabled is False
     assert row.name == "Stage"
-    assert row.host == "1.2.3.4"
+    assert row.destination_id == "dest-3"
 
 
 def test_save_404_for_unknown_id(live_server) -> None:
@@ -1426,9 +1366,9 @@ def test_initial_page_render_includes_disk_user_templates(live_server) -> None:
 
 def test_add_with_file_template_copies_extended_fields(live_server) -> None:
     """Dropdown apply via ``add_osc_binding`` must restore
-    host/port/protocol/rate/trigger from a file template, not just
+    destination_id/rate/trigger from a file template, not just
     ``name``/``address``/``args``; otherwise applying a saved template
-    silently drops the saved port + trigger.
+    silently drops the saved destination + trigger.
 
     Dropdown values for user templates are ``file:<filename>`` rather
     than the envelope id, so the add request keys on the
@@ -1445,9 +1385,7 @@ def test_add_with_file_template_copies_extended_fields(live_server) -> None:
         "Stage Preset",
         {
             "name": "ETC Stage Left",
-            "host": "10.0.0.5",
-            "port": 9001,
-            "protocol": "tcp",
+            "destination_id": "dest-5",
             "address": "/eos/go",
             "args": ["[x]", "[y]"],
             "rate_hz": 60,
@@ -1463,9 +1401,7 @@ def test_add_with_file_template_copies_extended_fields(live_server) -> None:
     cfg = load_config(cfg_path)
     row = cfg.osc_transmitters.transmitters[-1]
     assert row.name == "ETC Stage Left"
-    assert row.host == "10.0.0.5"
-    assert row.port == 9001
-    assert row.protocol == "tcp"
+    assert row.destination_id == "dest-5"
     assert row.address == "/eos/go"
     assert row.args == ["[x]", "[y]"]
     assert row.rate_hz == 60
@@ -2123,9 +2059,7 @@ def test_apply_osc_binding_fields_top_level_and_trigger() -> None:
         {
             "enabled": "on",
             "name": "X",
-            "host": "h",
-            "port": "9",
-            "protocol": "tcp",
+            "destination_id": "dest-9",
             "marker_id": "3",
             "osc_message": "/foo [x] [y]",
             "trigger.type": "stream",
@@ -2134,9 +2068,7 @@ def test_apply_osc_binding_fields_top_level_and_trigger() -> None:
     )
     assert row.name == "X"
     assert row.enabled is True
-    assert row.host == "h"
-    assert row.port == 9
-    assert row.protocol == "tcp"
+    assert row.destination_id == "dest-9"
     assert row.marker_id == 3
     assert row.address == "/foo"
     assert row.args == ["[x]", "[y]"]
@@ -2154,11 +2086,11 @@ def test_apply_osc_binding_fields_without_osc_message_keeps_address_and_args() -
 
 
 def test_apply_osc_binding_fields_skips_missing_fields() -> None:
-    row = OscTransmitterConfig(name="seed", host="seed.host")
-    _apply_osc_binding_fields(row, {"port": "1234"})
+    row = OscTransmitterConfig(name="seed", destination_id="seed-dest")
+    _apply_osc_binding_fields(row, {"marker_id": "3"})
     assert row.name == "seed"
-    assert row.host == "seed.host"
-    assert row.port == 1234
+    assert row.destination_id == "seed-dest"
+    assert row.marker_id == 3
 
 
 def test_apply_osc_binding_fields_no_trigger_keys_keeps_trigger() -> None:
@@ -2755,15 +2687,14 @@ class TestDefaultFaderField:
     pattern – empty input → ``None``, valid 1..8 preserved."""
 
     def test_apply_default_fader_from_form(self) -> None:
-        row = OscTransmitterConfig(id="r1", host="127.0.0.1", port=9000)
+        row = OscTransmitterConfig(id="r1", destination_id="d1")
         _apply_osc_binding_fields(row, {"default_fader": "3"})
         assert row.default_fader == 3
 
     def test_blank_default_fader_collapses_to_none(self) -> None:
         row = OscTransmitterConfig(
             id="r1",
-            host="127.0.0.1",
-            port=9000,
+            destination_id="d1",
             default_fader=3,
         )
         _apply_osc_binding_fields(row, {"default_fader": ""})
@@ -2774,7 +2705,7 @@ class TestDefaultFaderField:
         ``_coerce_optional_int`` so a ``default_fader=9`` lands on
         ``None`` instead of silently routing to fader 8 (valid range
         1..8)."""
-        row = OscTransmitterConfig(id="r1", host="127.0.0.1", port=9000)
+        row = OscTransmitterConfig(id="r1", destination_id="d1")
         _apply_osc_binding_fields(row, {"default_fader": "99"})
         assert row.default_fader is None
 

--- a/tests/test_web_osc_bindings.py
+++ b/tests/test_web_osc_bindings.py
@@ -150,8 +150,8 @@ def test_section_renders_empty_state(live_server) -> None:
     _, base, _ = live_server
     status, body = _get(base, "/section/osc_bindings")
     assert status == 200
-    assert "OSC Output" in body
-    assert "No OSC outputs configured" in body
+    assert "OSC Transmitters" in body
+    assert "No transmitters configured" in body
 
 
 def test_section_renders_existing_rows(live_server) -> None:
@@ -236,7 +236,7 @@ def test_add_creates_row(live_server) -> None:
     cfg = load_config(cfg_path)
     assert len(cfg.osc_transmitters.transmitters) == 1
     row = cfg.osc_transmitters.transmitters[0]
-    assert row.name == "New OSC output"
+    assert row.name == "New transmitter"
     assert row.enabled is False
     # ``focus_id`` opens the row in the rendered partial.
     assert f'data-row-id="{row.id}"' in body
@@ -514,7 +514,7 @@ def test_duplicate_clones_row(live_server) -> None:
     cfg = load_config(cfg_path)
     assert len(cfg.osc_transmitters.transmitters) == 2
     assert cfg.osc_transmitters.transmitters[1].id != row_id
-    assert cfg.osc_transmitters.transmitters[1].name == "New OSC output (copy)"
+    assert cfg.osc_transmitters.transmitters[1].name == "New transmitter (copy)"
 
 
 def test_duplicate_404_for_unknown_id(live_server) -> None:
@@ -542,7 +542,7 @@ def test_delete_unknown_id_is_noop(live_server) -> None:
         {},
     )
     assert status == 200
-    assert "OSC Output" in body  # partial still renders cleanly
+    assert "OSC Transmitters" in body  # partial still renders cleanly
 
 
 def test_move_up_swaps_with_predecessor(live_server) -> None:
@@ -1339,7 +1339,7 @@ def test_add_with_unknown_template_id_falls_back_to_blank_row(live_server) -> No
     )
     cfg = load_config(cfg_path)
     row = cfg.osc_transmitters.transmitters[0]
-    assert row.name == "New OSC output"
+    assert row.name == "New transmitter"
     assert row.address == ""
     assert row.args == []
 
@@ -1458,7 +1458,7 @@ def test_add_with_empty_template_id_yields_blank_row(live_server) -> None:
     _post_form(base, "/section/osc_bindings/add", {"template_id": ""})
     cfg = load_config(cfg_path)
     row = cfg.osc_transmitters.transmitters[0]
-    assert row.name == "New OSC output"
+    assert row.name == "New transmitter"
     assert row.address == ""
     assert row.args == []
 
@@ -1476,7 +1476,7 @@ def test_add_with_unknown_template_id_yields_blank_row(live_server) -> None:
     )
     cfg = load_config(cfg_path)
     row = cfg.osc_transmitters.transmitters[0]
-    assert row.name == "New OSC output"
+    assert row.name == "New transmitter"
     assert row.address == ""
     assert row.args == []
 
@@ -1494,7 +1494,7 @@ def test_add_with_unsafe_file_template_id_yields_blank_row(live_server) -> None:
     )
     cfg = load_config(cfg_path)
     row = cfg.osc_transmitters.transmitters[0]
-    assert row.name == "New OSC output"
+    assert row.name == "New transmitter"
     assert row.address == ""
 
 
@@ -3075,7 +3075,7 @@ def test_save_rejects_address_without_leading_slash(live_server) -> None:
     # Nothing persisted – the whole save was rejected before apply.
     row = load_config(cfg_path).osc_transmitters.transmitters[0]
     assert row.address != "cue/go"
-    assert row.name == "New OSC output"
+    assert row.name == "New transmitter"
 
 
 def test_save_as_template_rejects_address_without_leading_slash(live_server) -> None:

--- a/tests/test_web_routes_unit.py
+++ b/tests/test_web_routes_unit.py
@@ -610,6 +610,20 @@ class TestApplyImportDataSkipRestart:
         assert len(out.trigger_zones.zones) == 1
         assert out.trigger_zones.zones[0].name == "Valid"
 
+    def test_osc_routing_blocks_without_inner_lists_are_skipped(self) -> None:
+        """An ``osc_transmitters`` / ``osc_destinations`` block whose inner
+        list key is absent or non-list is skipped, not applied – a crafted
+        payload can't crash the import or wipe the existing rows."""
+        current = AppConfig()
+        out = _apply_import_data(
+            current,
+            {
+                "osc_transmitters": {},  # no "transmitters" list → skipped
+                "osc_destinations": {"destinations": "nope"},  # not a list → skipped
+            },
+        )
+        assert out.osc_transmitters.transmitters == []
+
     def test_window_dimensions_imported_as_ints(self) -> None:
         current = AppConfig()
         out = _apply_import_data(current, {"window_width": 1920, "window_height": 1080})

--- a/tests/test_web_routes_unit.py
+++ b/tests/test_web_routes_unit.py
@@ -59,14 +59,68 @@ from openfollow.web.routes import (
     _as_optional_float,
     _as_positive_int,
     _config_to_toml,
+    _find_by_id,
     _import_needs_restart,
     _parse_vertices,
+    _swap_for_direction,
     _wizard_camera_params,
     apply_section_data,
     strip_device_local_fields,
 )
 
 pytestmark = pytest.mark.unit
+
+
+class _Item:
+    """Minimal ``.id``-bearing stand-in for the id-keyed config rows."""
+
+    def __init__(self, item_id: str) -> None:
+        self.id = item_id
+
+
+class TestFindById:
+    def test_returns_index_and_item_on_match(self) -> None:
+        items = [_Item("a"), _Item("b"), _Item("c")]
+        found = _find_by_id(items, "b")
+        assert found is not None
+        idx, item = found
+        assert idx == 1
+        assert item is items[1]
+
+    def test_returns_none_when_missing(self) -> None:
+        assert _find_by_id([_Item("a")], "z") is None
+
+    def test_returns_first_match(self) -> None:
+        items = [_Item("dup"), _Item("dup")]
+        found = _find_by_id(items, "dup")
+        assert found is not None and found[0] == 0
+
+
+class TestSwapForDirection:
+    def test_up_swaps_with_predecessor(self) -> None:
+        items = ["a", "b", "c"]
+        assert _swap_for_direction(items, 1, "up") is True
+        assert items == ["b", "a", "c"]
+
+    def test_down_swaps_with_successor(self) -> None:
+        items = ["a", "b", "c"]
+        assert _swap_for_direction(items, 1, "down") is True
+        assert items == ["a", "c", "b"]
+
+    def test_top_up_is_noop_returns_false(self) -> None:
+        items = ["a", "b"]
+        assert _swap_for_direction(items, 0, "up") is False
+        assert items == ["a", "b"]
+
+    def test_bottom_down_is_noop_returns_false(self) -> None:
+        items = ["a", "b"]
+        assert _swap_for_direction(items, 1, "down") is False
+        assert items == ["a", "b"]
+
+    def test_unknown_direction_is_noop_returns_false(self) -> None:
+        items = ["a", "b"]
+        assert _swap_for_direction(items, 0, "sideways") is False
+        assert items == ["a", "b"]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -3926,6 +3926,99 @@ def test_osc_destination_move_reorders_and_guards_edges(live_server) -> None:
     assert status == 404
 
 
+def test_osc_destination_noop_move_does_not_flash_saved(live_server) -> None:
+    """A boundary move (top row up) changes nothing, so the re-render must NOT
+    carry the 'saved' state – an operator shouldn't see a saved flash for an
+    action that did nothing. A real move does flash saved."""
+    server, base = live_server
+    first_id = load_config(server.config_path).osc_destinations.destinations[0].id
+    _post_form(base, "/section/osc_destinations/add", {})
+    second_id = load_config(server.config_path).osc_destinations.destinations[-1].id
+
+    # No-op: top row up → no swap, no 'saved'.
+    _status, body = _post_form(base, f"/section/osc_destination/{first_id}/move", {"direction": "up"})
+    assert "osc-destinations-section" in body
+    assert "section saved" not in body
+
+    # Real move: second row up → flashes saved.
+    _status, body = _post_form(base, f"/section/osc_destination/{second_id}/move", {"direction": "up"})
+    assert "section saved" in body
+
+
+def test_osc_binding_dangling_destination_shows_missing_option(live_server) -> None:
+    """A row whose ``destination_id`` points at a deleted destination renders a
+    selected '(missing destination)' option, so the dropdown reflects the
+    stored dangling id instead of silently falling back to '(none)'."""
+    server, base = live_server
+    _post_form(base, "/section/osc_bindings/add", {})
+    row_id = load_config(server.config_path).osc_transmitters.transmitters[0].id
+    _post_form(base, f"/section/osc_binding/{row_id}", {"destination_id": "ghost-id"})
+
+    status, body = _get(base, "/section/osc_bindings")
+    assert status == 200
+    assert "(missing destination)" in body
+
+
+def test_osc_destinations_use_drag_handle_not_arrow_buttons(live_server) -> None:
+    """Destinations reorder via the same ⋮⋮ drag handle as transmitters; the
+    per-row ↑/↓ arrow buttons are gone from the UI (the /move route stays as a
+    stable JSON-API surface)."""
+    _, base = live_server
+    status, body = _get(base, "/section/osc_destinations")
+    assert status == 200
+    assert "osc-destination-drag-handle" in body
+    assert 'data-reorder-url="/section/osc_destinations/reorder"' in body
+    assert "↑" not in body
+    assert "↓" not in body
+
+
+def test_osc_destinations_reorder_applies_full_ordering(live_server) -> None:
+    """The drag-handle UI POSTs the complete id ordering: [A,B,C] -> [C,A,B]."""
+    server, base = live_server
+    _post_form(base, "/section/osc_destinations/add", {})
+    _post_form(base, "/section/osc_destinations/add", {})
+    a, b, c = (d.id for d in load_config(server.config_path).osc_destinations.destinations)
+    status, _ = _post_form(base, "/section/osc_destinations/reorder", {"order": f"{c},{a},{b}"})
+    assert status == 200
+    after = [d.id for d in load_config(server.config_path).osc_destinations.destinations]
+    assert after == [c, a, b]
+
+
+def test_osc_destinations_reorder_drops_unknown_keeps_missing(live_server) -> None:
+    """A stale post with a phantom id and an omitted real id: phantom dropped,
+    omitted destination appended so nothing is lost."""
+    server, base = live_server
+    _post_form(base, "/section/osc_destinations/add", {})
+    _post_form(base, "/section/osc_destinations/add", {})
+    a, b, c = (d.id for d in load_config(server.config_path).osc_destinations.destinations)
+    _post_form(base, "/section/osc_destinations/reorder", {"order": f"{c},ghost-id,{a}"})
+    after = [d.id for d in load_config(server.config_path).osc_destinations.destinations]
+    assert after == [c, a, b]
+
+
+def test_osc_destinations_reorder_empty_order_is_noop(live_server) -> None:
+    """Empty / whitespace ``order`` must not drop destinations."""
+    server, base = live_server
+    _post_form(base, "/section/osc_destinations/add", {})
+    before = [d.id for d in load_config(server.config_path).osc_destinations.destinations]
+    status, _ = _post_form(base, "/section/osc_destinations/reorder", {"order": "  "})
+    assert status == 200
+    after = [d.id for d in load_config(server.config_path).osc_destinations.destinations]
+    assert after == before
+
+
+def test_osc_destinations_reorder_no_change_is_idempotent(live_server) -> None:
+    """Posting the existing order is a no-op (the permutation matches what's on
+    disk, so no save) while still re-rendering successfully."""
+    server, base = live_server
+    _post_form(base, "/section/osc_destinations/add", {})
+    before = [d.id for d in load_config(server.config_path).osc_destinations.destinations]
+    status, _ = _post_form(base, "/section/osc_destinations/reorder", {"order": ",".join(before)})
+    assert status == 200
+    after = [d.id for d in load_config(server.config_path).osc_destinations.destinations]
+    assert after == before
+
+
 def test_osc_destinations_collapsed_summary_shows_host_port(live_server) -> None:
     """The collapsed destination row shows host:port right after the name plus a
     protocol badge, so a folded destination stays identifiable at a glance."""

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -3818,6 +3818,110 @@ def test_osc_destinations_crud_round_trip(live_server) -> None:
     assert after.get(new_id) is None
 
 
+def test_osc_destinations_section_get_renders(live_server) -> None:
+    """``GET /section/osc_destinations`` renders the destinations partial."""
+    _, base = live_server
+    status, body = _get(base, "/section/osc_destinations")
+    assert status == 200
+    assert "OSC Destinations" in body
+
+
+def test_osc_destination_save_partial_form_leaves_absent_fields_untouched(
+    live_server,
+) -> None:
+    """A save that omits fields updates only what's posted – the parser loop
+    skips absent fields rather than clobbering them with defaults."""
+    server, base = live_server
+    seeded = load_config(server.config_path).osc_destinations.destinations[0]
+    original_name = seeded.name
+    status, _ = _post_form(
+        base,
+        f"/section/osc_destination/{seeded.id}",
+        {"host": "10.1.2.3"},  # only host – name/port/protocol/framing absent
+    )
+    assert status == 200
+    saved = load_config(server.config_path).osc_destinations.get(seeded.id)
+    assert saved is not None
+    assert saved.host == "10.1.2.3"
+    assert saved.name == original_name
+
+
+def test_osc_destination_save_unknown_id_404(live_server) -> None:
+    _, base = live_server
+    status, _ = _post_form(base, "/section/osc_destination/no-such", {"host": "1.2.3.4"})
+    assert status == 404
+
+
+def test_osc_destination_duplicate_unknown_id_404(live_server) -> None:
+    _, base = live_server
+    status, _ = _post_form(base, "/section/osc_destination/no-such/duplicate", {})
+    assert status == 404
+
+
+def test_osc_destination_delete_unknown_id_is_noop(live_server) -> None:
+    server, base = live_server
+    before = len(load_config(server.config_path).osc_destinations.destinations)
+    status, body = _post_form(base, "/section/osc_destination/no-such/delete", {})
+    assert status == 200
+    assert "OSC Destinations" in body
+    after = len(load_config(server.config_path).osc_destinations.destinations)
+    assert after == before
+
+
+def test_osc_destination_move_reorders_and_guards_edges(live_server) -> None:
+    """move up/down swaps neighbours; edge moves and an unknown direction are
+    no-ops; an unknown id is a 404."""
+    server, base = live_server
+    # Seeded "Default" sits at index 0; add two more for a clear ordering.
+    _post_form(base, "/section/osc_destinations/add", {})
+    _post_form(base, "/section/osc_destinations/add", {})
+    dests = load_config(server.config_path).osc_destinations.destinations
+    assert len(dests) == 3
+    first_id, second_id, third_id = (d.id for d in dests)
+
+    def _order() -> list[str]:
+        return [d.id for d in load_config(server.config_path).osc_destinations.destinations]
+
+    _post_form(base, f"/section/osc_destination/{second_id}/move", {"direction": "up"})
+    assert _order()[:2] == [second_id, first_id]
+
+    _post_form(base, f"/section/osc_destination/{second_id}/move", {"direction": "down"})
+    assert _order()[:2] == [first_id, second_id]
+
+    # Top-up and bottom-down: target == idx → no swap, no save.
+    _post_form(base, f"/section/osc_destination/{first_id}/move", {"direction": "up"})
+    _post_form(base, f"/section/osc_destination/{third_id}/move", {"direction": "down"})
+    assert _order() == [first_id, second_id, third_id]
+
+    # Unknown direction → no-op.
+    _post_form(base, f"/section/osc_destination/{first_id}/move", {"direction": "sideways"})
+    assert _order() == [first_id, second_id, third_id]
+
+    status, _ = _post_form(
+        base,
+        "/section/osc_destination/no-such/move",
+        {"direction": "up"},
+    )
+    assert status == 404
+
+
+def test_osc_destinations_collapsed_summary_shows_host_port(live_server) -> None:
+    """The collapsed destination row shows host:port right after the name plus a
+    protocol badge, so a folded destination stays identifiable at a glance."""
+    server, base = live_server
+    seeded = load_config(server.config_path).osc_destinations.destinations[0]
+    _post_form(
+        base,
+        f"/section/osc_destination/{seeded.id}",
+        {"name": "Console", "host": "10.5.5.5", "port": "9001", "protocol": "udp", "framing": "slip"},
+    )
+    _, body = _get(base, "/section/osc_destinations")
+    assert "osc-destination-addr" in body
+    assert "10.5.5.5:9001" in body
+    assert "osc-destination-proto-badge" in body
+    assert "UDP" in body
+
+
 def test_broadcast_section_rejects_non_shareable_sections(live_server) -> None:
     """OSC routing + zones travel by file only – a section broadcast of them
     is refused with 403, never pushed to peers."""

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -3771,7 +3771,7 @@ def test_update_trigger_zones_post_renders_partial(live_server) -> None:
     status, _ = _post_form(
         base,
         "/section/trigger_zones",
-        {"enabled": "on", "default_osc_port": "9001"},
+        {"enabled": "on", "debounce_ms": "150"},
     )
     assert status == 200
 
@@ -3780,7 +3780,52 @@ def test_update_trigger_zones_post_renders_partial(live_server) -> None:
     # ``show_overlay`` was not in the form, so the bool-fields treatment
     # must clear it to False rather than leave it stale.
     assert saved.trigger_zones.show_overlay is False
-    assert saved.trigger_zones.default_osc_port == 9001
+    assert saved.trigger_zones.debounce_ms == 150
+
+
+def test_osc_destinations_crud_round_trip(live_server) -> None:
+    """Add → save → duplicate → delete a destination through the web routes."""
+    server, base = live_server
+
+    # Add: a fresh destination lands on top of the seeded "Default".
+    status, body = _post_form(base, "/section/osc_destinations/add", {})
+    assert status == 200
+    cfg = load_config(server.config_path)
+    assert len(cfg.osc_destinations.destinations) == 2
+    new_id = cfg.osc_destinations.destinations[-1].id
+
+    # Save: edit the new destination's connection.
+    status, _ = _post_form(
+        base,
+        f"/section/osc_destination/{new_id}",
+        {"name": "Console", "host": "10.0.0.9", "port": "9001", "protocol": "tcp", "framing": "slip"},
+    )
+    assert status == 200
+    saved = load_config(server.config_path).osc_destinations.get(new_id)
+    assert saved is not None
+    assert saved.name == "Console"
+    assert saved.host == "10.0.0.9"
+    assert saved.port == 9001
+    assert saved.protocol == "tcp"
+
+    # Duplicate then delete.
+    status, _ = _post_form(base, f"/section/osc_destination/{new_id}/duplicate", {})
+    assert status == 200
+    assert len(load_config(server.config_path).osc_destinations.destinations) == 3
+    status, _ = _post_form(base, f"/section/osc_destination/{new_id}/delete", {})
+    assert status == 200
+    after = load_config(server.config_path).osc_destinations
+    assert after.get(new_id) is None
+
+
+def test_broadcast_section_rejects_non_shareable_sections(live_server) -> None:
+    """OSC routing + zones travel by file only – a section broadcast of them
+    is refused with 403, never pushed to peers."""
+    _, base = live_server
+    for section in ("osc_destinations", "osc_transmitters", "trigger_zones"):
+        status, payload = _post_json(base, f"/api/config/{section}/broadcast", {"enabled": True})
+        assert status == 403, f"{section} should not be broadcastable"
+        assert "not shareable" in payload.get("error", "").lower()
 
 
 def test_update_detection_inference_renders_partial_with_install_state(live_server) -> None:

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -3818,6 +3818,27 @@ def test_osc_destinations_crud_round_trip(live_server) -> None:
     assert after.get(new_id) is None
 
 
+def test_api_zones_includes_live_destinations(live_server) -> None:
+    """The zone-editor poll carries the shared destinations, so adding one in
+    the OSC Destinations section reaches the zone dropdown without a reload."""
+    server, base = live_server
+
+    # The seeded "Default" destination is present from the start, with the
+    # endpoint fields the dropdown renders.
+    status, body = _get_json(base, "/api/zones")
+    assert status == 200
+    default = next(d for d in body["destinations"] if d["id"] == "default")
+    assert set(default) == {"id", "name", "host", "port", "protocol", "framing"}
+
+    # Add a destination via the section route; the next poll reflects it.
+    status, _ = _post_form(base, "/section/osc_destinations/add", {})
+    assert status == 200
+    new_id = load_config(server.config_path).osc_destinations.destinations[-1].id
+    status, body2 = _get_json(base, "/api/zones")
+    assert status == 200
+    assert new_id in [d["id"] for d in body2["destinations"]]
+
+
 def test_osc_destinations_section_get_renders(live_server) -> None:
     """``GET /section/osc_destinations`` renders the destinations partial."""
     _, base = live_server

--- a/tests/test_web_templates.py
+++ b/tests/test_web_templates.py
@@ -485,9 +485,7 @@ class TestApplyOscOutput:
             "ETC Stage",
             {
                 "name": "ETC Stage Left",
-                "host": "10.0.0.5",
-                "port": 9001,
-                "protocol": "tcp",
+                "destination_id": "dest-5",
                 "address": "/eos/go",
                 "args": ["[x]", "[y]"],
                 "rate_hz": 60,
@@ -504,9 +502,7 @@ class TestApplyOscOutput:
         assert len(rows) == 1
         row = rows[0]
         assert row.name == "ETC Stage Left"
-        assert row.host == "10.0.0.5"
-        assert row.port == 9001
-        assert row.protocol == "tcp"
+        assert row.destination_id == "dest-5"
         assert row.address == "/eos/go"
         assert row.args == ["[x]", "[y]"]
         assert row.rate_hz == 60
@@ -574,9 +570,7 @@ class TestSaveOscBindingAsTemplate:
             {
                 "template_name": "Stage Cue",
                 "name": "Stage Cue (live)",
-                "host": "192.168.10.5",
-                "port": "9001",
-                "protocol": "tcp",
+                "destination_id": "dest-99",
                 "marker_id": "0",
                 "trigger.type": "stream",
                 "trigger.rate_hz": "60",
@@ -594,9 +588,7 @@ class TestSaveOscBindingAsTemplate:
         assert entry is not None and entry.template is not None
         p = entry.template.payload
         assert p["name"] == "Stage Cue (live)"
-        assert p["host"] == "192.168.10.5"
-        assert p["port"] == 9001
-        assert p["protocol"] == "tcp"
+        assert p["destination_id"] == "dest-99"
         assert p["address"] == "/cue/[markerid]/go"
         assert p["args"] == ["[x]"]
         assert p["rate_hz"] == 60
@@ -646,9 +638,7 @@ class TestSaveOscBindingAsTemplate:
             {
                 "template_name": "OnChangeStage",
                 "name": "On-change stage",
-                "host": "10.0.0.1",
-                "port": "9000",
-                "protocol": "udp",
+                "destination_id": "dest-1",
                 "trigger.type": "stream",
                 "trigger.rate_hz": "60",
                 "trigger.mode": "on_change",
@@ -724,9 +714,7 @@ class TestSaveOscBindingAsTemplate:
             {
                 "template_name": "RoundTrip",
                 "name": "Source row",
-                "host": "10.10.10.10",
-                "port": "5005",
-                "protocol": "udp",
+                "destination_id": "dest-7",
                 "trigger.type": "stream",
                 "trigger.rate_hz": "20",
                 "osc_message": "/round/[markerid] [x]",
@@ -740,9 +728,7 @@ class TestSaveOscBindingAsTemplate:
         cfg = load_config(cfg_path)
         applied = cfg.osc_transmitters.transmitters[-1]  # the apply row
         assert applied.name == "Source row"
-        assert applied.host == "10.10.10.10"
-        assert applied.port == 5005
-        assert applied.protocol == "udp"
+        assert applied.destination_id == "dest-7"
         assert applied.address == "/round/[markerid]"
         assert applied.args == ["[x]"]
         assert applied.rate_hz == 20

--- a/tests/test_web_templates.py
+++ b/tests/test_web_templates.py
@@ -578,7 +578,7 @@ class TestSaveOscBindingAsTemplate:
             },
         )
         assert status == 200
-        assert "OSC Output" in body
+        assert "OSC Transmitters" in body
         from openfollow.templates.loader import find_template
 
         entry = find_template(

--- a/tests/test_zone_engine.py
+++ b/tests/test_zone_engine.py
@@ -31,8 +31,8 @@ class _ZoneCfg:
     osc_address_additional_entry: str = "/additional"
     osc_address_partial_exit: str = "/partial"
     osc_address_final_exit: str = "/final"
-    osc_host: str = ""
-    osc_port: int = 0
+    # The default destination ``_DESTS`` resolves to 127.0.0.1:53000.
+    destination_id: str = "d"
     enabled: bool = True
 
 
@@ -41,29 +41,51 @@ class _ZonesCfg:
     enabled: bool = True
     show_overlay: bool = True
     eval_fps: int = 10
-    default_osc_host: str = "127.0.0.1"
-    default_osc_port: int = 53000
     debounce_ms: int = 0
     hysteresis: float = 0.0
     zones: list[_ZoneCfg] = field(default_factory=list)
 
 
+@dataclass
+class _DestCfg:
+    id: str = "d"
+    name: str = "Default"
+    host: str = "127.0.0.1"
+    port: int = 53000
+    protocol: str = "udp"
+    framing: str = "slip"
+
+
+@dataclass
+class _DestsCfg:
+    """Stand-in for ``OscDestinationsConfig`` – just the ``get`` surface."""
+
+    destinations: list[_DestCfg] = field(default_factory=lambda: [_DestCfg()])
+
+    def get(self, destination_id: str) -> _DestCfg | None:
+        if not destination_id:
+            return None
+        for d in self.destinations:
+            if d.id == destination_id:
+                return d
+        return None
+
+
 class _RecordingOsc:
     """Stand-in for the ``OscService`` zone-engine consumer.
 
-    The engine resolves per-zone host/port (or falls back to the
-    section's ``default_osc_*``) and calls ``send`` with explicit
-    keyword args. The recorder normalises the call into an
-    ``(address, host, port)`` triple. The engine resolves the
-    fallback up front, so the resolved defaults (``"127.0.0.1"`` /
-    ``53000`` per ``_ZonesCfg``) appear in ``sends`` rather than the
-    empty / zero placeholders.
+    The engine resolves a zone's ``destination_id`` to an endpoint and
+    calls ``send`` with explicit keyword args. The recorder normalises the
+    call into an ``(address, host, port)`` triple. The default destination
+    (``127.0.0.1`` / ``53000`` per ``_DestCfg``) appears in ``sends``.
     """
 
     def __init__(self) -> None:
         self.sends: list[tuple[str, str, int]] = []
         # Parallel record that captures typed args list.
         self.sends_full: list[tuple[str, list, str, int]] = []
+        # Endpoint detail incl. transport, for protocol/framing assertions.
+        self.sends_transport: list[tuple[str, str, int, str, str]] = []
 
     def send(
         self,
@@ -73,9 +95,11 @@ class _RecordingOsc:
         host: str,
         port: int,
         protocol: str = "udp",
+        framing: str = "slip",
     ) -> None:
         self.sends.append((address, host, port))
         self.sends_full.append((address, list(args), host, port))
+        self.sends_transport.append((address, host, port, protocol, framing))
 
 
 SQUARE_CORNERS = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0]]
@@ -94,10 +118,15 @@ def _zone(**kwargs) -> _ZoneCfg:
     return _ZoneCfg(**kwargs)
 
 
-def _engine(zones: list[_ZoneCfg], **cfg_kwargs) -> tuple[ZoneEngine, _RecordingOsc]:
+def _engine(
+    zones: list[_ZoneCfg],
+    *,
+    destinations: _DestsCfg | None = None,
+    **cfg_kwargs,
+) -> tuple[ZoneEngine, _RecordingOsc]:
     cfg = _ZonesCfg(zones=zones, **cfg_kwargs)
     osc = _RecordingOsc()
-    return ZoneEngine(cfg, osc), osc  # type: ignore[arg-type]
+    return ZoneEngine(cfg, osc, destinations or _DestsCfg()), osc  # type: ignore[arg-type]
 
 
 def test_get_zone_diagnostics_reads_snapshot_once() -> None:
@@ -467,7 +496,7 @@ class TestMutationTargetedEdgeCases:
             debounce_ms=10_000,  # 10 s – far longer than the test run
         )
         osc = _RecordingOsc()
-        engine = ZoneEngine(cfg, osc)  # type: ignore[arg-type]
+        engine = ZoneEngine(cfg, osc, _DestsCfg())  # type: ignore[arg-type]
         engine.update([_marker(0, 2.0, 2.0)], [])
         assert osc.sends == [("/first", "127.0.0.1", 53000)]
         # Hot-reload with a structurally identical zones list – the
@@ -493,7 +522,7 @@ class TestMutationTargetedEdgeCases:
         # original skips the out-of-range occupancy entry.
         initial = _ZonesCfg(zones=[_zone(), _zone()])
         osc = _RecordingOsc()
-        engine = ZoneEngine(initial, osc)  # type: ignore[arg-type]
+        engine = ZoneEngine(initial, osc, _DestsCfg())  # type: ignore[arg-type]
         engine.update([_marker(0, 2.0, 2.0)], [])
         # Drop one zone – the trailing occupancy entry now points past
         # the new zones list and must be filtered out without raising.
@@ -555,8 +584,9 @@ class TestMutationTargetedEdgeCases:
         # send SOMETHING so they go unkilled by "sends is not empty"
         # assertions – a test that pins the full (address, host, port)
         # triple catches them.
-        zone = _zone(osc_host="10.0.0.1", osc_port=9000)
-        engine, osc = _engine([zone])
+        zone = _zone(destination_id="d2")
+        dests = _DestsCfg(destinations=[_DestCfg(id="d2", host="10.0.0.1", port=9000)])
+        engine, osc = _engine([zone], destinations=dests)
         engine.update([_marker(0, 2.0, 2.0)], [])
         assert osc.sends == [("/first", "10.0.0.1", 9000)]
         engine.update([], [])
@@ -569,8 +599,9 @@ class TestMutationTargetedEdgeCases:
         # Companion to the port-forwarding test above – covers the
         # ``osc_address_additional_entry`` emit site, which is a
         # separate call that mutmut mutates independently.
-        zone = _zone(osc_host="10.0.0.1", osc_port=9000)
-        engine, osc = _engine([zone])
+        zone = _zone(destination_id="d2")
+        dests = _DestsCfg(destinations=[_DestCfg(id="d2", host="10.0.0.1", port=9000)])
+        engine, osc = _engine([zone], destinations=dests)
         engine.update([_marker(0, 2.0, 2.0)], [])
         engine.update([_marker(0, 2.0, 2.0), _marker(1, 3.0, 3.0)], [])
         assert osc.sends == [
@@ -580,8 +611,9 @@ class TestMutationTargetedEdgeCases:
 
     def test_partial_exit_forwards_port(self) -> None:
         # Covers the partial-exit emit site.
-        zone = _zone(osc_host="10.0.0.1", osc_port=9000)
-        engine, osc = _engine([zone])
+        zone = _zone(destination_id="d2")
+        dests = _DestsCfg(destinations=[_DestCfg(id="d2", host="10.0.0.1", port=9000)])
+        engine, osc = _engine([zone], destinations=dests)
         engine.update([_marker(0, 2.0, 2.0)], [])
         engine.update([_marker(0, 2.0, 2.0), _marker(1, 3.0, 3.0)], [])
         engine.update([_marker(1, 3.0, 3.0)], [])
@@ -590,6 +622,35 @@ class TestMutationTargetedEdgeCases:
             ("/additional", "10.0.0.1", 9000),
             ("/partial", "10.0.0.1", 9000),
         ]
+
+    def test_destination_protocol_and_framing_forwarded(self) -> None:
+        # A TCP/length-prefix destination flows its transport through to
+        # ``OscService.send`` so zones get TCP framing, not just UDP.
+        zone = _zone(destination_id="d2")
+        dests = _DestsCfg(
+            destinations=[_DestCfg(id="d2", host="10.0.0.1", port=9000, protocol="tcp", framing="length_prefix")],
+        )
+        engine, osc = _engine([zone], destinations=dests)
+        engine.update([_marker(0, 2.0, 2.0)], [])
+        assert osc.sends_transport == [("/first", "10.0.0.1", 9000, "tcp", "length_prefix")]
+
+    def test_blank_destination_emits_nothing(self) -> None:
+        # An unselected destination tracks membership (overlay) but sends
+        # nothing – never to a bogus endpoint.
+        zone = _zone(destination_id="")
+        engine, osc = _engine([zone])
+        engine.update([_marker(0, 2.0, 2.0)], [])
+        engine.update([], [])
+        assert osc.sends == []
+        # Membership still advanced so the overlay count is correct mid-run.
+        engine.update([_marker(0, 2.0, 2.0)], [])
+        assert osc.sends == []
+
+    def test_unknown_destination_id_emits_nothing(self) -> None:
+        zone = _zone(destination_id="ghost")
+        engine, osc = _engine([zone])
+        engine.update([_marker(0, 2.0, 2.0)], [])
+        assert osc.sends == []
 
     def test_disabled_zone_resets_debounce_to_numeric_zero(self) -> None:
         # Kills the update() mutant that sets ``occ.last_event_time =
@@ -601,7 +662,7 @@ class TestMutationTargetedEdgeCases:
         zone = _zone()
         zones_cfg = _ZonesCfg(zones=[zone], debounce_ms=1000)
         osc = _RecordingOsc()
-        engine = ZoneEngine(zones_cfg, osc)  # type: ignore[arg-type]
+        engine = ZoneEngine(zones_cfg, osc, _DestsCfg())  # type: ignore[arg-type]
         engine.update([_marker(0, 2.0, 2.0)], [])
         # Disable the zone; update() clears occupancy and resets debounce.
         zone.enabled = False
@@ -673,7 +734,7 @@ class TestMutationTargetedEdgeCases:
         # ``= None`` could slip through the vertices-too-few path.
         zones_cfg = _ZonesCfg(zones=[_zone()], debounce_ms=1000)
         osc = _RecordingOsc()
-        engine = ZoneEngine(zones_cfg, osc)  # type: ignore[arg-type]
+        engine = ZoneEngine(zones_cfg, osc, _DestsCfg())  # type: ignore[arg-type]
         engine.update([_marker(0, 2.0, 2.0)], [])
         # Mutate the zone's vertices in-place to a degenerate 2-vertex
         # shape so the update() degenerate branch fires.
@@ -937,7 +998,7 @@ class TestZoneDiagnostics:
     def test_disabled_zone_clears_last_event_address(self) -> None:
         """Disabled zones clear last_event_address from diagnostics."""
         zones_cfg = _ZonesCfg(zones=[_zone(osc_address_first_entry="/zone/enter")])
-        engine = ZoneEngine(zones_cfg, _RecordingOsc())  # type: ignore[arg-type]
+        engine = ZoneEngine(zones_cfg, _RecordingOsc(), _DestsCfg())  # type: ignore[arg-type]
         engine.update([_marker(0, 2.0, 2.0)], [])
         # Sanity: the address was recorded.
         diag = engine.get_zone_diagnostics(0)
@@ -955,7 +1016,7 @@ class TestZoneDiagnostics:
     def test_degenerate_vertex_list_clears_last_event_address(self) -> None:
         """Degenerate zones clear last_event_address on config reload."""
         zones_cfg = _ZonesCfg(zones=[_zone(osc_address_first_entry="/zone/enter")])
-        engine = ZoneEngine(zones_cfg, _RecordingOsc())  # type: ignore[arg-type]
+        engine = ZoneEngine(zones_cfg, _RecordingOsc(), _DestsCfg())  # type: ignore[arg-type]
         engine.update([_marker(0, 2.0, 2.0)], [])
         # New config instance with a degenerate (<3 vertex) polygon, as a
         # real hot-reload would deliver – distinct from the installed config
@@ -995,7 +1056,7 @@ class TestTriggeredByResetsOccupancyOnReload:
 
     def test_reload_with_narrowed_filter_resets_occupancy(self) -> None:
         zones_cfg = _ZonesCfg(zones=[_zone(triggered_by=[0, 1])])
-        engine = ZoneEngine(zones_cfg, _RecordingOsc())  # type: ignore[arg-type]
+        engine = ZoneEngine(zones_cfg, _RecordingOsc(), _DestsCfg())  # type: ignore[arg-type]
         engine.update(
             [_marker(0, 2.0, 2.0), _marker(1, 2.5, 2.5)],
             [],

--- a/tests/test_zone_engine.py
+++ b/tests/test_zone_engine.py
@@ -58,7 +58,8 @@ class _DestCfg:
 
 @dataclass
 class _DestsCfg:
-    """Stand-in for ``OscDestinationsConfig`` – just the ``get`` surface."""
+    """Stand-in for ``OscDestinationsConfig`` – the ``get`` + ``by_id`` surface
+    the engine resolves against."""
 
     destinations: list[_DestCfg] = field(default_factory=lambda: [_DestCfg()])
 
@@ -69,6 +70,9 @@ class _DestsCfg:
             if d.id == destination_id:
                 return d
         return None
+
+    def by_id(self) -> dict[str, _DestCfg]:
+        return {d.id: d for d in self.destinations}
 
 
 class _RecordingOsc:

--- a/tests/test_zones_properties.py
+++ b/tests/test_zones_properties.py
@@ -253,8 +253,7 @@ class _ZoneCfg:
     osc_address_additional_entry: str = "/additional"
     osc_address_partial_exit: str = "/partial"
     osc_address_final_exit: str = "/final"
-    osc_host: str = ""
-    osc_port: int = 0
+    destination_id: str = "d"
     enabled: bool = True
 
 
@@ -263,11 +262,29 @@ class _ZonesCfg:
     enabled: bool = True
     show_overlay: bool = True
     eval_fps: int = 10
-    default_osc_host: str = "127.0.0.1"
-    default_osc_port: int = 53000
     debounce_ms: int = 0
     hysteresis: float = 0.0
     zones: list[_ZoneCfg] = field(default_factory=list)
+
+
+@dataclass
+class _DestCfg:
+    id: str = "d"
+    host: str = "127.0.0.1"
+    port: int = 53000
+    protocol: str = "udp"
+    framing: str = "slip"
+
+
+@dataclass
+class _DestsCfg:
+    destinations: list[_DestCfg] = field(default_factory=lambda: [_DestCfg()])
+
+    def get(self, destination_id: str) -> _DestCfg | None:
+        for d in self.destinations:
+            if d.id == destination_id:
+                return d
+        return None
 
 
 class _RecordingOsc:
@@ -282,6 +299,7 @@ class _RecordingOsc:
         host: str,
         port: int,
         protocol: str = "udp",
+        framing: str = "slip",
     ) -> None:
         self.addresses.append(address)
 
@@ -293,7 +311,7 @@ def _engine(
     zone = _ZoneCfg(vertices=[[float(x), float(y)] for x, y in verts])
     osc = _RecordingOsc()
     cfg = _ZonesCfg(zones=[zone], hysteresis=hysteresis)
-    return ZoneEngine(cfg, osc), osc  # type: ignore[arg-type]
+    return ZoneEngine(cfg, osc, _DestsCfg()), osc  # type: ignore[arg-type]
 
 
 def _marker(x: float, y: float) -> tuple[tuple[str, int], float, float]:

--- a/tests/test_zones_properties.py
+++ b/tests/test_zones_properties.py
@@ -286,6 +286,9 @@ class _DestsCfg:
                 return d
         return None
 
+    def by_id(self) -> dict[str, _DestCfg]:
+        return {d.id: d for d in self.destinations}
+
 
 class _RecordingOsc:
     def __init__(self) -> None:


### PR DESCRIPTION
**Problem**
  
Operators re-typed the full OSC connection (host, port, protocol, framing) on every transmitter row, and a host/port on every trigger zone. When the show network changed, every reference had to be hand-edited one by one.

**What this adds**

A named, reusable OSC Destination — name + host + port + protocol + framing. Transmitters and trigger zones now reference a destination by id and resolve the endpoint at send time:

- Edit once, repoint everywhere, live. Change a destination's host and every referencing transmitter and zone follows immediately — no restart.
- Fails safe. A blank or dangling destination_id skips the send with a surfaced reason instead of blasting a bogus endpoint.
- Zones gain TCP/SLIP — previously they could only send UDP via the service defaults.

New config dataclass OscDestinationConfig (id, name, host=127.0.0.1, port=8000, protocol=udp, framing=slip); OscTransmitterConfig and zones carry a destination_id.

**Clean break**

The old inline host/port/protocol/framing keys and the zone default_osc_* fields are dropped on load via the existing  _filter_known. Operators create destinations and re-point once — no migration shim, no legacy fallbacks in the code.

**Transfer semantics**

Destinations, transmitters, and zones travel together through the config export/import file, so a destination_id and its target stay consistent across a saved show. They are deliberately never real-time shared between peers.