### PR TITLE
Multi-marker OSC transmitters

### DIFF
--- a/openfollow/configuration.py
+++ b/openfollow/configuration.py
@@ -202,6 +202,85 @@ def _coerce_optional_marker_id(value: Any) -> int | None:
     return out
 
 
+# Marker-token grammar for an OSC transmitter row's ``markers`` field. Each
+# token is one of: a non-negative integer marker id, a controller alias
+# ``cN`` (1-based, no leading zero – mirrors the ``:cN`` reference grammar in
+# ``osc/template.py``), or the keyword ``all`` (every id in
+# ``controlled_marker_ids``). ``all`` and the aliases resolve dynamically, so
+# they're stored verbatim and only mapped to concrete ids by the transmitter
+# manager at render time.
+MARKER_TOKEN_ALL = "all"
+_CONTROLLER_ALIAS_RE = re.compile(r"^c[1-9][0-9]*$")
+
+
+def _canonical_marker_token(raw: Any) -> str | None:
+    """Canonicalise one ``markers`` entry, or ``None`` when invalid.
+
+    Accepts an int (non-negative) or a string token (``"all"`` / ``"cN"`` /
+    a decimal id). Invalid entries – floats, ``True``, negatives, ``c0`` /
+    ``c01``, junk – return ``None`` so the caller drops them (the field
+    ignores invalid ids by spec).
+    """
+    if isinstance(raw, str):
+        s = raw.strip().lower()
+        if not s:
+            return None
+        if s == MARKER_TOKEN_ALL:
+            return MARKER_TOKEN_ALL
+        if _CONTROLLER_ALIAS_RE.match(s):
+            return s
+        # Fall through to the numeric coercer (rejects bool / float / junk).
+        mid = _coerce_optional_marker_id(s)
+        return None if mid is None else str(mid)
+    mid = _coerce_optional_marker_id(raw)
+    return None if mid is None else str(mid)
+
+
+def _marker_token_sort_key(token: str) -> tuple[int, int]:
+    """Display order: numeric ids ascending, then controller aliases by
+    index. ``all`` collapses the list so it never reaches here."""
+    if _CONTROLLER_ALIAS_RE.match(token):
+        return (1, int(token[1:]))
+    return (0, int(token))
+
+
+def _coerce_marker_tokens(value: Any) -> list[str]:
+    """Normalise an OSC transmitter row's ``markers`` field to a sorted,
+    de-duplicated list of canonical tokens.
+
+    Accepts a list (TOML array), a comma-separated string (hand-edited TOML
+    / web form), or a bare int (legacy single ``marker_id`` lift). ``all``
+    subsumes every other entry, so its presence collapses the result to
+    ``["all"]``. Numeric tokens sort ascending ahead of controller aliases.
+    """
+    if value is None or isinstance(value, bool):
+        return []
+    if isinstance(value, str):
+        raw_items: list[Any] = value.split(",")
+    elif isinstance(value, (list, tuple)):
+        raw_items = list(value)
+    else:
+        # Bare int (legacy lift) or anything else the canonicaliser vets.
+        raw_items = [value]
+    canonical: list[str] = []
+    seen: set[str] = set()
+    has_all = False
+    for item in raw_items:
+        token = _canonical_marker_token(item)
+        if token is None:
+            continue
+        if token == MARKER_TOKEN_ALL:
+            has_all = True
+            continue
+        if token not in seen:
+            seen.add(token)
+            canonical.append(token)
+    if has_all:
+        return [MARKER_TOKEN_ALL]
+    canonical.sort(key=_marker_token_sort_key)
+    return canonical
+
+
 def _coerce_choice(value: Any, choices: tuple[str, ...], default: str) -> str:
     """Return ``value`` when it matches one of ``choices``, else ``default``."""
     if isinstance(value, str) and value in choices:
@@ -1234,11 +1313,14 @@ class OscTransmitterConfig:
     # Reference to an :class:`OscDestinationConfig` (host/port/protocol/framing
     # live there). Empty = no destination selected → the row skips sending.
     destination_id: str = ""
-    # ``None`` = no default marker picked. Rows using only literals or
-    # explicit-marker refs (``[x:markerN]``) still dispatch; rows using a
-    # default-marker placeholder (``[x]`` / ``[fy]`` / ``[markerId]``) skip
-    # with "no default marker configured" until set.
-    marker_id: int | None = None
+    # Default markers driving ``[x]`` / ``[markerid]`` / ``[markerfader]``.
+    # Each token is a marker id, a controller alias ``cN``, or ``all`` (every
+    # controlled marker). Multiple tokens fan the row out into one
+    # independent send per resolved marker. Empty list = no default marker:
+    # rows using only literals or explicit refs (``[x:markerN]``) still
+    # dispatch; rows using a default-marker placeholder skip with "no default
+    # marker configured" until a token is set.
+    markers: list[str] = field(default_factory=list)
     # Optional default virtual fader. Bare placeholders (``[fader]``,
     # ``[float]``, ``[int:min-max]``) resolve through this; explicit refs
     # (``[fader:3]``) ignore it. ``None`` = unset; ``0`` is rejected at
@@ -1267,7 +1349,7 @@ class OscTransmitterConfig:
         if not isinstance(self.destination_id, str):
             self.destination_id = ""
         self.destination_id = self.destination_id.strip()
-        self.marker_id = _coerce_optional_marker_id(self.marker_id)
+        self.markers = _coerce_marker_tokens(self.markers)
         # ``None`` for unset, else 1..VIRTUAL_FADER_COUNT; out-of-range/junk
         # collapses to ``None`` rather than routing to a valid-but-wrong fader.
         self.default_fader = _coerce_optional_int(
@@ -1336,6 +1418,12 @@ class OscTransmittersConfig:
                         "kind": "stream",
                         "rate_hz": row_data["rate_hz"],
                     }
+                # Legacy lift: a single ``marker_id`` becomes the one-token
+                # ``markers`` list (``_coerce_marker_tokens`` handles the
+                # scalar). ``_filter_known`` would otherwise drop the unknown
+                # key and lose the operator's default marker.
+                if "markers" not in row_data and "marker_id" in row_data:
+                    row_data["markers"] = row_data["marker_id"]
                 coerced_transmitters.append(
                     OscTransmitterConfig(
                         **_filter_known(OscTransmitterConfig, row_data),

--- a/openfollow/osc/transmitter.py
+++ b/openfollow/osc/transmitter.py
@@ -38,11 +38,12 @@ import logging
 import threading
 import time
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 from openfollow.configuration import (
+    MARKER_TOKEN_ALL,
     ControllerButtonTrigger,
     FaderOnChangeTrigger,
     HotkeyTrigger,
@@ -226,6 +227,12 @@ MarkerFaderProvider = Callable[[int], float | None]
 # index to the marker id it currently drives for the ``:cN`` reference, or
 # ``None`` when the controller isn't connected / drives no marker.
 ControllerMarkerProvider = Callable[[int], int | None]
+# ``controlled_markers_provider()`` returns the current
+# ``controlled_marker_ids`` snapshot. Drives the ``markers`` field's ``all``
+# token (fan-out to every controlled marker) and the controlled-only validity
+# filter on numeric tokens. Read live each tick so a hot-reload of the
+# controlled set takes effect on the next send without a manager restart.
+ControlledMarkersProvider = Callable[[], Sequence[int]]
 
 
 @dataclass(frozen=True)
@@ -355,6 +362,7 @@ class OscTransmitterManager:
         fader_provider: FaderProvider | None = None,
         marker_fader_provider: MarkerFaderProvider | None = None,
         controller_marker_provider: ControllerMarkerProvider | None = None,
+        controlled_markers_provider: ControlledMarkersProvider | None = None,
     ) -> None:
         self._service = osc_service
         self._marker_provider = marker_provider
@@ -368,6 +376,11 @@ class OscTransmitterManager:
         # ``:cN`` controller-reference provider; optional. A ``[markerid:c1]``
         # row without it raises :class:`RenderError` and skips.
         self._controller_marker_provider = controller_marker_provider
+        # ``controlled_marker_ids`` snapshot provider for the ``markers``
+        # field's ``all`` token + controlled-only validity filter. Optional:
+        # when unwired, numeric tokens pass through unfiltered and ``all``
+        # yields nothing (it can't enumerate the controlled set).
+        self._controlled_markers_provider = controlled_markers_provider
         self._lock = threading.Lock()
         self._rows: dict[str, OscTransmitter] = {}
         # Shared OSC destination profiles, staged under ``_lock``. A row's
@@ -379,12 +392,14 @@ class OscTransmitterManager:
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self._tick: int = 0
-        # Per-row last-sent default-marker position for ``mode ==
-        # "on_change"``. Keyed by row id so a hot-reload keeps the cache
-        # (no spurious extra send after reload). Cleared on ``restart()``
-        # when the id is dropped or its ``marker_id`` (the gate signal)
-        # changes. The gate watches only the default marker.
-        self._last_sent_pos: dict[str, tuple[float, float, float]] = {}
+        # Last-sent default-marker position for ``mode == "on_change"``.
+        # Keyed by ``(row_id, marker_id)`` so a row fanned out across several
+        # markers tracks each marker's movement independently (one marker
+        # moving doesn't suppress another's send). A hot-reload keeps the
+        # cache (no spurious extra send after reload); ``restart()`` drops
+        # entries whose row id is gone or whose ``markers`` (the gate signal)
+        # changed. The gate watches only the default marker.
+        self._last_sent_pos: dict[tuple[str, int | None], tuple[float, float, float]] = {}
         # Event-driven dispatch queue. Event handlers append plans here
         # under ``_lock``; the scheduler drains it each ``_tick_once``.
         # Keeps network I/O off the input thread.
@@ -492,7 +507,7 @@ class OscTransmitterManager:
             for row_cfg in cfg.transmitters:
                 existing = self._rows.get(row_cfg.id)
                 if existing is not None:
-                    # Editing a surviving row's ``marker_id`` (gate
+                    # Editing a surviving row's ``markers`` (gate
                     # signal) or trigger kind changes the cache entry's
                     # semantic basis – comparing the new marker position
                     # against the old cached value could wrongly skip the
@@ -503,7 +518,7 @@ class OscTransmitterManager:
                     old_cfg = existing.cfg
                     old_kind = type(old_cfg.trigger).__name__
                     new_kind = type(row_cfg.trigger).__name__
-                    if old_cfg.marker_id != row_cfg.marker_id or old_kind != new_kind:
+                    if old_cfg.markers != row_cfg.markers or old_kind != new_kind:
                         invalidate_cache.add(row_cfg.id)
                     existing.update_config(row_cfg)
                     new_rows[row_cfg.id] = existing
@@ -515,7 +530,9 @@ class OscTransmitterManager:
             # spurious next-tick send. Also drop entries flagged above
             # whose semantic basis changed.
             self._last_sent_pos = {
-                rid: pos for rid, pos in self._last_sent_pos.items() if rid in new_rows and rid not in invalidate_cache
+                key: pos
+                for key, pos in self._last_sent_pos.items()
+                if key[0] in new_rows and key[0] not in invalidate_cache
             }
             # Same pattern for the event-driven throttle cache. Rows whose
             # trigger kind or discriminator changed are also dropped
@@ -652,14 +669,19 @@ class OscTransmitterManager:
         }
 
     def _snapshot_plan_for(self, row_id: str) -> _TickPlan | None:
-        """Build a tick plan for ``row_id`` under the manager lock so the
-        diagnostics endpoints see the same atomic config snapshot the
-        scheduler does. ``None`` for an unknown row id."""
+        """Build the primary tick plan for ``row_id`` under the manager
+        lock so the diagnostics endpoints see the same atomic config
+        snapshot the scheduler does. ``None`` for an unknown row id.
+
+        A fanned-out row (multiple ``markers``) previews / test-sends its
+        primary (lowest) marker only; the live tick path still fires every
+        resolved marker."""
         with self._lock:
             row = self._rows.get(row_id)
             if row is None:
                 return None
-            return self._plan_for_row(row)
+            plans = self._plans_for_row(row)
+            return plans[0] if plans else None
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -795,7 +817,7 @@ class OscTransmitterManager:
                 ticks_per_send = max(1, _SCHEDULER_HZ // trigger.rate_hz)
                 if tick % ticks_per_send != 0:
                     continue
-                plans.append(self._plan_for_row(row))
+                plans.extend(self._plans_for_row(row))
             # Drain queued event-driven plans onto this tick so they
             # render + send on the scheduler thread, not the emitting
             # input thread. The list swap under the lock is atomic.
@@ -817,19 +839,105 @@ class OscTransmitterManager:
         for plan in plans:
             self._fire_plan(plan)
 
-    def _plan_for_row(
+    def _resolve_marker_ids(self, cfg: OscTransmitterConfig) -> list[int]:
+        """Resolve a row's ``markers`` tokens to concrete marker ids.
+
+        ``all`` expands to the current ``controlled_marker_ids``; ``cN``
+        resolves via the controller-marker provider to the id that pad
+        currently drives; a numeric token is kept only when it's in the
+        controlled set. Unresolvable tokens (controller drives nothing, a
+        numeric id this station doesn't control) are dropped – the spec
+        ignores invalid ids. The result is de-duplicated and sorted
+        ascending so a fanned-out row sends lowest-id first.
+
+        When ``controlled_markers_provider`` is unwired (e.g. a bare-bones
+        test manager), numeric tokens pass through unfiltered so the
+        manager still functions; ``all`` yields nothing (it can't enumerate
+        the controlled set).
+        """
+        controlled: list[int] | None = None
+        if self._controlled_markers_provider is not None:
+            controlled = list(self._controlled_markers_provider())
+        controlled_set = set(controlled) if controlled is not None else None
+        ids: list[int] = []
+        seen: set[int] = set()
+
+        def _add(mid: int) -> None:
+            if mid not in seen:
+                seen.add(mid)
+                ids.append(mid)
+
+        for token in cfg.markers:
+            if token == MARKER_TOKEN_ALL:
+                if controlled is not None:
+                    for mid in controlled:
+                        _add(mid)
+                continue
+            if token.startswith("c"):
+                if self._controller_marker_provider is None:
+                    continue
+                resolved = self._controller_marker_provider(int(token[1:]) - 1)
+                if resolved is not None:
+                    _add(resolved)
+                continue
+            # Numeric token: keep only when controlled (or when the filter
+            # is unavailable).
+            mid = int(token)
+            if controlled_set is None or mid in controlled_set:
+                _add(mid)
+        ids.sort()
+        return ids
+
+    def _plans_for_row(
         self,
         row: OscTransmitter,
         *,
         event_value: int | None = None,
         event_velocity: int | None = None,
         event_note: int | None = None,
+    ) -> list[_TickPlan]:
+        """Fan a row out into one :class:`_TickPlan` per resolved default
+        marker. Caller holds the manager lock.
+
+        A row whose output doesn't depend on the default marker
+        (``needs_default_marker`` is False – no ``[x]`` / ``[markerid]`` /
+        ``[markerfader]``) yields a single plan regardless of how many
+        markers it names, so a constant / hotkey row doesn't emit N
+        identical packets; its plan still carries the primary (lowest)
+        marker so an ``on_change`` gate keyed to a marker keeps working. A
+        marker-dependent row with no resolvable markers yields a single
+        ``marker_id=None`` plan so the renderer surfaces the existing "no
+        default marker configured" skip.
+        """
+        ids = self._resolve_marker_ids(row.cfg)
+        if not row.needs_default_marker:
+            marker_ids: list[int | None] = [ids[0] if ids else None]
+        else:
+            marker_ids = list(ids) if ids else [None]
+        return [
+            self._build_plan(
+                row,
+                marker_id=mid,
+                event_value=event_value,
+                event_velocity=event_velocity,
+                event_note=event_note,
+            )
+            for mid in marker_ids
+        ]
+
+    def _build_plan(
+        self,
+        row: OscTransmitter,
+        *,
+        marker_id: int | None,
+        event_value: int | None = None,
+        event_velocity: int | None = None,
+        event_note: int | None = None,
     ) -> _TickPlan:
-        """Build a :class:`_TickPlan` from a row's current config and
-        compiled templates. Caller holds the manager lock – the plan
-        captures everything the renderer + service.send need so the fire
-        happens outside the lock without tearing on a concurrent
-        ``restart``.
+        """Build a :class:`_TickPlan` for ``row`` against one resolved
+        ``marker_id``. Caller holds the manager lock – the plan captures
+        everything the renderer + service.send need so the fire happens
+        outside the lock without tearing on a concurrent ``restart``.
 
         The MIDI dispatch path populates ``event_value`` /
         ``event_velocity`` / ``event_note``; other plans pass ``None``,
@@ -855,7 +963,7 @@ class OscTransmitterManager:
         # staged index is an O(1) dict lookup, not a per-row linear scan.
         dest = self._dest_index.get(cfg.destination_id)
         return _TickPlan(
-            marker_id=cfg.marker_id,
+            marker_id=marker_id,
             destination=dest,
             compiled_address=row.compiled_address,
             compiled_args=row.compiled_args,
@@ -911,7 +1019,7 @@ class OscTransmitterManager:
                     continue
                 if frozenset(trigger.modifiers) != event.modifiers:
                     continue
-                self._event_plans.append(self._plan_for_row(row))
+                self._event_plans.extend(self._plans_for_row(row))
 
     def _handle_button_event(self, event: ButtonEvent) -> None:
         """Enqueue a plan for every :class:`ControllerButtonTrigger` row
@@ -934,7 +1042,7 @@ class OscTransmitterManager:
                     continue
                 if trigger.edge != event.edge:
                     continue
-                self._event_plans.append(self._plan_for_row(row))
+                self._event_plans.extend(self._plans_for_row(row))
 
     # ------------------------------------------------------------------
     # MIDI / fader event dispatch
@@ -992,8 +1100,8 @@ class OscTransmitterManager:
                 # ``[note]`` = ``event.number``, ``[velocity]`` =
                 # ``event.value``; both ``None`` for non-note events.
                 is_note = event.type in ("note_on", "note_off")
-                self._event_plans.append(
-                    self._plan_for_row(
+                self._event_plans.extend(
+                    self._plans_for_row(
                         row,
                         event_value=event.value,
                         event_velocity=event.value if is_note else None,
@@ -1045,7 +1153,7 @@ class OscTransmitterManager:
                 if now - last < 1.0 / trigger.rate_hz:
                     continue
                 self._last_event_fire_ts[cfg.id] = now
-                self._event_plans.append(self._plan_for_row(row))
+                self._event_plans.extend(self._plans_for_row(row))
 
     def _handle_marker_fader_change(
         self,
@@ -1079,7 +1187,7 @@ class OscTransmitterManager:
                 if now - last < 1.0 / trigger.rate_hz:
                     continue
                 self._last_event_fire_ts[cfg.id] = now
-                self._event_plans.append(self._plan_for_row(row))
+                self._event_plans.extend(self._plans_for_row(row))
 
     def _explicit_marker_resolver(
         self,
@@ -1348,8 +1456,9 @@ class OscTransmitterManager:
             # Cache read under the manager lock serialises against
             # ``restart()``; released before ``service.send()`` keeps
             # network I/O off the critical path.
+            cache_key = (plan.row_id, plan.marker_id)
             with self._lock:
-                last = self._last_sent_pos.get(plan.row_id)
+                last = self._last_sent_pos.get(cache_key)
             if last is not None:
                 cur = result.default_marker_pos
                 dx = abs(cur[0] - last[0])
@@ -1390,5 +1499,5 @@ class OscTransmitterManager:
         if not is_test and result.default_marker_pos is not None:
             with self._lock:
                 if self._rows.get(plan.row_id) is plan.source_row:
-                    self._last_sent_pos[plan.row_id] = result.default_marker_pos
+                    self._last_sent_pos[(plan.row_id, plan.marker_id)] = result.default_marker_pos
         plan.ring_buffer.record_sent(result.address, list(result.args))

--- a/openfollow/services.py
+++ b/openfollow/services.py
@@ -1047,6 +1047,11 @@ class AppRuntimeServices:
             # :meth:`init_input_manager`), so the closure tolerates ``None``
             # until it's populated, long before any 60 Hz render.
             controller_marker_provider=self._controller_marker_provider,
+            # ``markers`` field's ``all`` token + controlled-only validity
+            # filter. Reads the live controlled-id list each tick so a
+            # hot-reload of ``controlled_marker_ids`` re-expands ``all``
+            # without a manager restart.
+            controlled_markers_provider=self._controlled_markers_provider,
         )
         manager.restart(
             self._app._config.osc_transmitters,
@@ -1150,6 +1155,15 @@ class AppRuntimeServices:
         if im is None:
             return None
         return im.controller_marker_id(controller_idx)
+
+    def _controlled_markers_provider(self) -> list[int]:
+        """Snapshot of ``controlled_marker_ids`` for the OSC transmitter
+        ``markers`` field's ``all`` token + controlled-only validity filter.
+
+        Reads ``app._controlled_ids`` (the same list the gamepad routing and
+        marker-fader provisioning use), copied so a concurrent hot-reload
+        swapping the list can't tear a mid-tick read."""
+        return list(self._app._controlled_ids)
 
     def _marker_fader_values_provider(self) -> list[dict[str, Any]]:
         """Snapshot of the per-controlled-marker faders for the MIDI

--- a/openfollow/web/help/osc_bindings.md
+++ b/openfollow/web/help/osc_bindings.md
@@ -10,9 +10,14 @@ Identity, destination, and transport.
 
 - **Enabled** – master toggle for this transmitter; disabled transmitters do not transmit. If a placeholder's dependency isn't satisfied (e.g. no Default marker for a bare `[x]`), the toggle turns red and the transmitter is forced off until resolved.
 - **Name** – a label for your own reference. Appears in the Diagnostics tab and the Overview live counters.
-- **Default marker** – marker ID that bare position placeholders (`[x]`, `[y]`, `[markerid]`, etc.) resolve against when no `:N` index is given. Leave blank if every placeholder names its marker explicitly; the default must be an existing marker (IDs start at 1).
+- **Default markers** – the marker(s) that bare position placeholders (`[x]`, `[y]`, `[markerid]`, etc.) resolve against when no `:N` index is given. Enter a comma-separated list to drive several markers from one transmitter: `1, 3, 7` behaves exactly like three separate transmitters sending to markers 1, 3 and 7, each rendered against its own position. The lowest ID is the *primary* (shown in the row header); the rest appear as read-only chips nested under it, ordered by ID. Each entry is one of:
+  - a **marker ID** – sends to that marker when this station controls it. An id it doesn't control isn't an error: that entry is skipped at send time and shown with a red dot.
+  - a **controller alias** `cN` (`c1` = first controller) – the marker that controller is currently driving, resolved live.
+  - **`all`** – every marker this station controls (re-evaluated live as you change which markers are controlled).
+
+  Leave blank if every placeholder names its marker explicitly. An ID this station doesn't control is ignored at send time and shown with a red status dot (in the row header and its nested chip) so you can spot it; a malformed entry is flagged on blur so you can correct it.
 - **Default fader** – virtual fader that bare fader placeholders (`[fader]`, including transform forms like `[fader.pct]`) resolve against. Leave as `(none)` if you use only explicit `[fader:N]` references or have no fader placeholders.
-- **Destination** – the shared OSC connection (host, port, transport) this transmitter sends to, picked from the list you maintain under **OSC Destinations**. A transmitter with no destination selected sends nothing. Edit a destination's IP once and every transmitter and zone pointing at it repoints live – no per-row editing, no restart. The read-only line under the dropdown shows the destination's resolved `host:port`.
+- **Destination** – the shared OSC connection (host, port, transport) this transmitter sends to, picked from the list you maintain under **OSC Destinations**. A transmitter with no destination selected sends nothing. Edit a destination's IP once and every transmitter and zone pointing at it repoints live – no per-row editing, no restart. Each dropdown option shows the destination's resolved `host:port`.
 
 ## Trigger
 
@@ -20,7 +25,7 @@ When the transmitter sends. Pick one **Trigger type** from the dropdown; the fie
 
 - **Stream** – sends continuously at the chosen **Rate (Hz)** (1, 5, 10, 20, 30, or 60 Hz). Set **Send** to:
   - *Send always* – fire every tick regardless of movement.
-  - *Send only on change* – fire only when the transmitter's Default marker has moved at least **Min change (m)** along any axis since the last send. The gate always watches the Default marker, even if the body references other markers via `[x:N]`. Transmitters with no Default marker fire every tick.
+  - *Send only on change* – fire only when the Default marker has moved at least **Min change (m)** along any axis since the last send. The gate always watches the Default marker, even if the body references other markers via `[x:N]`. When several Default markers are named, each marker's send is gated by that marker's own movement. Transmitters with no Default marker fire every tick.
 
 - **Hotkey** – fires on a keyboard combination. Set the **Key**, any **Modifiers** (Ctrl, Shift, Alt, Cmd), and the **Edge** (Press or Release). Movement keys are reserved and cannot be assigned.
 

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -49,11 +49,13 @@ if TYPE_CHECKING:
 
 from openfollow.configuration import (
     DEFAULT_UPDATE_SERVICE_NAME,
+    MARKER_TOKEN_ALL,
     VALID_BUTTON_NAMES,
     AppConfig,
     OscDestinationConfig,
     OscTransmitterConfig,
     TriggerZoneConfig,
+    _coerce_marker_tokens,
     config_write_lock,
     load_config,
     save_config,
@@ -1492,11 +1494,12 @@ _OSC_BINDING_FIELD_PARSERS: dict[str, _FieldParser] = {
     # Connection is chosen via a shared OSC destination; empty = no
     # destination selected (the row skips sending).
     "destination_id": _as_str,
-    # ``marker_id`` is :class:`int | None`; clearing means "no default
-    # marker", not "marker 0".
-    "marker_id": _as_optional_int,
-    # Default virtual fader, same shape as ``marker_id``: empty → ``None``,
-    # 1..8 preserved, junk collapses to ``None`` in ``__post_init__``.
+    # ``markers`` is a comma-separated list of marker ids / ``cN`` aliases /
+    # ``all``; empty means "no default marker". ``_coerce_marker_tokens``
+    # vets + canonicalises (``__post_init__`` re-runs it on save).
+    "markers": lambda value, _default: _coerce_marker_tokens(value),
+    # Default virtual fader: empty → ``None``, 1..8 preserved, junk collapses
+    # to ``None`` in ``__post_init__``.
     "default_fader": _as_optional_int,
 }
 
@@ -1642,6 +1645,98 @@ def _parse_trigger_subtable(
     return out
 
 
+def _effective_default_marker_id(
+    markers: list[str],
+    registered: frozenset[int],
+) -> int | None:
+    """Pick a representative default-marker id for the unresolved-pill
+    heuristic from a row's ``markers`` tokens.
+
+    A bare ``[x]`` resolves at runtime when the row names *any* usable
+    default marker. ``all`` / ``cN`` are dynamic – treated as resolvable
+    whenever the station controls at least one marker (the controller
+    drives a controlled marker; ``all`` enumerates them). Numeric tokens
+    count only when controlled. Returns the lowest candidate id, or
+    ``None`` when nothing usable is named (so ``[x]`` shows unresolved)."""
+    candidates: set[int] = set()
+    has_dynamic = False
+    for token in markers:
+        if token == MARKER_TOKEN_ALL or token.startswith("c"):
+            has_dynamic = True
+            continue
+        mid = int(token)
+        if mid in registered:
+            candidates.add(mid)
+    if has_dynamic and registered:
+        candidates.update(registered)
+    return min(candidates) if candidates else None
+
+
+def _osc_binding_marker_label(token: str, catalog: Any) -> str:
+    """Human label for one resolved ``markers`` token, shown in the row
+    summary badge + the nested secondary chips.
+
+    Numeric ids render as ``"<catalog name> (<id>)"`` (falling back to
+    ``"Marker <id>"``); controller aliases render as ``"Controller cN"``."""
+    if token.startswith("c"):
+        return f"Controller {token}"
+    mid = int(token)
+    entry = catalog.get(mid) if catalog is not None else None
+    name = (entry.name.strip() if entry is not None and entry.name else "") or f"Marker {mid}"
+    return f"{name} ({mid})"
+
+
+def _osc_binding_marker_entry(
+    token: str,
+    catalog: Any,
+    controlled_set: set[int],
+) -> dict[str, Any]:
+    """One marker chip: its label plus whether this station controls it.
+
+    Controller aliases (``cN``) resolve to a controlled marker at runtime, so
+    they're always reported controlled; only an explicit numeric id can be
+    uncontrolled (its send is dropped at runtime → the chip is marked)."""
+    controlled = True if token.startswith("c") else int(token) in controlled_set
+    return {"label": _osc_binding_marker_label(token, catalog), "controlled": controlled}
+
+
+def _osc_binding_marker_display(
+    cfg: AppConfig,
+    catalog: Any,
+) -> dict[str, dict[str, Any]]:
+    """Per-row marker display data for the bindings partial.
+
+    Each entry is ``{"header": <str|None>, "nested": [<chip>, …],
+    "markers_unusable": <bool>}`` where a chip is ``{"label",
+    "controlled"}``:
+
+    - **0 markers** → no header, no nested.
+    - **1 marker** → shown inline in the header badge (no nested list);
+      there's no "primary vs secondary" to confuse.
+    - **>1 markers** → *every* marker (primary included) renders as a nested
+      chip so they read uniformly; no header badge.
+
+    ``all`` expands to one chip per controlled marker. ``markers_unusable``
+    is ``True`` when the row names markers but this station controls none of
+    them (it can't send any) – the template reddens the row's status dot
+    from it, and each nested chip carries its own flag."""
+    controlled = sorted(cfg.controlled_marker_ids)
+    controlled_set = set(controlled)
+    out: dict[str, dict[str, Any]] = {}
+    for row in cfg.osc_transmitters.transmitters:
+        markers = row.markers
+        if markers == [MARKER_TOKEN_ALL]:
+            chips = [{"label": _osc_binding_marker_label(str(mid), catalog), "controlled": True} for mid in controlled]
+        else:
+            chips = [_osc_binding_marker_entry(t, catalog, controlled_set) for t in markers]
+        out[row.id] = {
+            "header": chips[0]["label"] if len(chips) == 1 else None,
+            "nested": chips if len(chips) > 1 else [],
+            "markers_unusable": bool(chips) and not any(c["controlled"] for c in chips),
+        }
+    return out
+
+
 def _osc_binding_unresolved_blur_error(
     query: Mapping[str, Any],
     cfg: AppConfig,
@@ -1664,17 +1759,9 @@ def _osc_binding_unresolved_blur_error(
     address, args = parsed
     if not address and not args:
         return None
-    raw_marker_id = query.get("marker_id", "")
-    # An invalid typed value (``"abc"``, ``"-1"``, ``"1.5"``) is already
-    # flagged by the field-level numeric blur; suppress the cross-field
-    # "needs a default marker" warning here so it doesn't read as "empty".
-    # The explicit-marker arm is independent of ``marker_id`` and still
-    # surfaces.
-    raw_marker_id_str = raw_marker_id.strip() if isinstance(raw_marker_id, str) else str(raw_marker_id)
-    parsed_marker_id = _as_optional_int(raw_marker_id, default=None)
-    marker_id_invalid_input = bool(raw_marker_id_str) and (parsed_marker_id is None or parsed_marker_id < 0)
-    marker_id = parsed_marker_id if parsed_marker_id is not None and parsed_marker_id >= 0 else None
     registered = frozenset(cfg.controlled_marker_ids)
+    markers = _coerce_marker_tokens(query.get("markers", ""))
+    marker_id = _effective_default_marker_id(markers, registered)
     from openfollow.osc.template import (
         compile_template,
         token_has_explicit_index,
@@ -1699,15 +1786,20 @@ def _osc_binding_unresolved_blur_error(
     # message names the actionable fix per category. ``unresolved`` is
     # already the operator-facing token form (``"[x]"`` / ``"[x:7]"``).
     # Classify via the grammar, not a ``:`` sniff – a transform can carry
-    # a colon. Suppress the default-marker arm when ``marker_id`` is
-    # invalid input – the field-level validator handles that case.
-    default_tokens = [] if marker_id_invalid_input else [t for t in unresolved if not token_has_explicit_index(t)]
+    # a colon. Per-token validity (malformed / non-controlled entries) is
+    # surfaced by the field-level ``markers`` validator; this arm only flags
+    # the cross-field "you use [x] but name no usable default marker".
+    # Every unresolved token is either explicit-index or not, so the two
+    # lists partition the (non-empty) ``unresolved`` set: at least one is
+    # non-empty here, so ``parts`` below is never empty.
+    default_tokens = [t for t in unresolved if not token_has_explicit_index(t)]
     explicit_tokens = [t for t in unresolved if token_has_explicit_index(t)]
-    if not default_tokens and not explicit_tokens:
-        return None
     parts: list[str] = []
     if default_tokens:
-        parts.append(f"{', '.join(default_tokens)} needs a default marker. Set 'Default marker' to a registered id.")
+        parts.append(
+            f"{', '.join(default_tokens)} needs a default marker. Set 'Default markers' to a controlled id, "
+            "a controller alias (c1, c2, …), or 'all'."
+        )
     if explicit_tokens:
         parts.append(f"{', '.join(explicit_tokens)} references a marker that isn't registered.")
     return " ".join(parts)
@@ -1817,7 +1909,7 @@ def _row_unresolved_placeholders(
     grid_max_height: float = 0.0,
 ) -> tuple[str, ...]:
     """Bracketed placeholder tokens in ``row``'s address + args that can't
-    resolve given the row's ``marker_id`` and the registered-marker registry.
+    resolve given the row's ``markers`` and the registered-marker registry.
 
     The web bindings partial uses this to:
 
@@ -1837,12 +1929,13 @@ def _row_unresolved_placeholders(
         unresolved_placeholders,
     )
 
+    effective_marker_id = _effective_default_marker_id(row.markers, registered_marker_ids)
     out: list[str] = []
     seen: set[str] = set()
     for tpl in (row.address, *row.args):
         for token in unresolved_placeholders(
             compile_template(tpl),
-            default_marker_id=row.marker_id,
+            default_marker_id=effective_marker_id,
             registered_marker_ids=registered_marker_ids,
             grid_max_height=grid_max_height,
         ):
@@ -3616,6 +3709,10 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
             detection_storage_info=_detection_storage_info(config.detection.storage_path),
             osc_user_templates=osc_user_templates,
             osc_system_templates=osc_system_templates,
+            # Marker chips / unresolved pills / status dots must render at
+            # first paint, not only after a save – same context the section
+            # render builds.
+            **_osc_bindings_marker_context(config),
             # MIDI Devices table needs the live discovered-devices list so
             # it renders connected ports at first paint, not after the first
             # HTMX refresh.
@@ -5034,6 +5131,24 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
     # (the move route depends on it) stays consistent and a stale form on a
     # different row can't ship an out-of-date trigger sub-form.
 
+    def _osc_bindings_marker_context(cfg: AppConfig) -> dict[str, Any]:
+        """Marker-aware template vars for the OSC bindings partial: the
+        registered-id list, each row's unresolved-placeholder tokens, and the
+        per-row marker display (header / nested chips / dot state).
+
+        Shared by the section render and the index render so the nested
+        chips, unresolved pills, and status dots appear at first paint, not
+        only after the operator saves a row."""
+        registered = frozenset(cfg.controlled_marker_ids)
+        return {
+            "registered_marker_ids": sorted(registered),
+            "unresolved_by_row": {
+                row.id: _row_unresolved_placeholders(row, registered, grid_max_height=cfg.grid.max_height)
+                for row in cfg.osc_transmitters.transmitters
+            },
+            "marker_display_by_row": _osc_binding_marker_display(cfg, server.get_marker_catalog()),
+        }
+
     def _render_osc_bindings_section(
         cfg: AppConfig,
         *,
@@ -5065,15 +5180,6 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         )
         from openfollow.osc.template import PLACEHOLDERS
 
-        registered = frozenset(cfg.controlled_marker_ids)
-        unresolved_by_row = {
-            row.id: _row_unresolved_placeholders(
-                row,
-                registered,
-                grid_max_height=cfg.grid.max_height,
-            )
-            for row in cfg.osc_transmitters.transmitters
-        }
         # Form-source data for the trigger forms + ``default_fader`` field.
         # Computed here (config already loaded) so the per-row partial
         # render and the trigger-swap render see identical lists.
@@ -5098,8 +5204,7 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
             builtin_templates=system_templates,
             user_templates=user_templates,
             placeholders=sorted(PLACEHOLDERS),
-            registered_marker_ids=sorted(registered),
-            unresolved_by_row=unresolved_by_row,
+            **_osc_bindings_marker_context(cfg),
             valid_midi_types=VALID_MIDI_MESSAGE_TYPES,
             virtual_fader_names=virtual_fader_names,
             marker_fader_names=_marker_fader_names_for_form(server),
@@ -5153,8 +5258,8 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
                 # Copy every persistable field the template carries (host /
                 # port / protocol / rate_hz / trigger), not just name /
                 # address / args, so applying restores full row state.
-                # ``enabled`` and ``marker_id`` are NOT copied (apply lands
-                # rows inert; default marker is per-binding).
+                # ``enabled`` and ``markers`` are NOT copied (apply lands
+                # rows inert; default markers are per-binding).
                 entry = None
                 if template_id.startswith("file:"):
                     bare = template_id[len("file:") :]
@@ -5810,7 +5915,7 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
             )
         # Build the template payload: every persistable field except
         # ``id`` (per-row uuid), ``enabled`` (apply-time False), and
-        # ``marker_id`` (per-binding operator choice). ``template_id``
+        # ``markers`` (per-binding operator choice). ``template_id``
         # is also dropped – it's row metadata pointing at the *source*
         # template, not part of the saved-template content.
         trigger_dict = asdict(transient.trigger) if transient.trigger is not None else {"kind": "stream", "rate_hz": 30}
@@ -6066,7 +6171,7 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
             )
         if tpl.type == "osc_output":
             # Restore every persistable row field the template carries.
-            # ``enabled`` and ``marker_id`` are ignored even if a template
+            # ``enabled`` and ``markers`` are ignored even if a template
             # carries them – apply always lands the row inert with no default
             # marker. ``name`` falls back to the envelope name so a minimal
             # ``{address, args}`` template still gets a readable label.
@@ -6090,10 +6195,10 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
                     kwargs["trigger"] = dict(tpl.payload["trigger"])
                 row = OscTransmitterConfig(**kwargs)
                 # Defence in depth: even if a malformed template
-                # bypassed validation and carries enabled/marker_id
+                # bypassed validation and carries enabled/markers
                 # fields, we still strip them after construction.
                 row.enabled = False
-                row.marker_id = None
+                row.markers = []
                 cfg.osc_transmitters.transmitters.append(row)
                 save_config(cfg, server.config_path)
             return json.dumps({"ok": True, "row_id": row.id})
@@ -6243,9 +6348,9 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
                 )
         # Cross-field unresolved-placeholder check for OSC bindings, at blur
         # time on the message field – surfaces the same condition the partial
-        # paints as red pills. Reads sibling ``marker_id`` from the form and
+        # paints as red pills. Reads sibling ``markers`` from the form and
         # the registered-marker registry from the live config.
-        if section == "osc_binding" and field_name in ("osc_message", "marker_id"):
+        if section == "osc_binding" and field_name in ("osc_message", "markers"):
             err_msg = _osc_binding_unresolved_blur_error(
                 request.query,
                 _request_scoped_config(),

--- a/openfollow/web/templates/base.tpl
+++ b/openfollow/web/templates/base.tpl
@@ -1324,10 +1324,21 @@
  .osc-binding-drag-handle:active, .osc-destination-drag-handle:active { cursor: grabbing; }
  .osc-binding-row.dragging, .osc-destination-row.dragging { opacity: 0.55; }
  .osc-binding-row.drop-target, .osc-destination-row.drop-target { outline: 2px dashed var(--accent); outline-offset: 2px; }
- .osc-binding-enabled-dot { width: 0.55rem; height: 0.55rem; border-radius: 999px; background: var(--muted); }
+ .osc-binding-enabled-dot { width: 0.55rem; height: 0.55rem; border-radius: 999px; background: var(--muted); flex: none; }
  .osc-binding-enabled-dot.on { background: var(--accent); }
+ .osc-binding-enabled-dot.invalid { background: var(--danger); }
  .osc-binding-kind-badge, .osc-destination-proto-badge { font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 0.4rem; background: rgba(255,255,255,0.05); color: var(--muted); }
+ .osc-binding-marker-badge { font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 0.4rem; background: rgba(255,255,255,0.05); color: var(--muted); }
  .osc-binding-target { color: var(--muted); font-size: 0.8rem; margin-left: auto; }
+ /* Secondary markers nested under a fanned-out transmitter row: read-only
+ chips sharing the parent's destination / message / trigger. */
+ /* Negative top pulls the chips up under their parent row (the row's
+    0.6rem bottom margin otherwise floats them); the bottom margin keeps a
+    clear gap before the next transmitter so they don't touch. */
+ .osc-binding-nested { display: flex; flex-direction: column; gap: 0.4rem; margin: -0.2rem 0 0.7rem 1.4rem; }
+ .osc-binding-nested-row { display: flex; align-items: center; gap: 0.5rem; font-size: 0.85rem; color: var(--muted); padding: 0.45rem 0.8rem; border: 1px solid var(--border-soft); border-radius: 0.5rem; background: rgba(255,255,255,0.02); }
+ /* The red dot alone marks an uncontrolled marker – no red border. */
+ .osc-binding-nested-row.is-invalid { color: var(--danger); }
  /* Destination collapsed summary: host:port sits right after the name; the
  protocol badge anchors to the right. */
  .osc-destination-addr { color: var(--muted); font-size: 0.8rem; }
@@ -3512,7 +3523,7 @@
  // client-side mirror of Python's
  // ``unresolved_placeholders``. Rebuilds the unresolved-set from the
  // editor's current text + the live marker registry + the row's
- // ``marker_id`` so the operator sees red pills update as they edit,
+ // ``markers`` so the operator sees red pills update as they edit,
  // without a server round-trip. Only position + ``markerid`` slots
  // surface here (mirrors the server's ``_EDIT_TIME_SOURCES``); fader /
  // ``markerfader`` slots surface as runtime skips. This parse regex
@@ -3528,8 +3539,20 @@
  oscEditorParseJsonAttr(editor, 'oscRegisteredMarkerIds', [])
  .map(v => Number(v)),
  );
- const markerIdRaw = (editor.dataset.oscRowMarkerId || '').trim();
- const markerId = markerIdRaw === '' ? null : Number(markerIdRaw);
+ // Mirror of Python's ``_effective_default_marker_id``: a bare ``[x]``
+ // resolves when the row names any usable default marker. ``all`` / ``cN``
+ // are dynamic – treated as resolvable whenever at least one marker is
+ // controlled; a numeric token counts only when controlled.
+ const markerTokens = (editor.dataset.oscRowMarkers || '')
+ .split(',').map(s => s.trim().toLowerCase()).filter(Boolean);
+ let hasDefaultMarker = false;
+ for (const tok of markerTokens) {
+ if (tok === 'all' || /^c[1-9][0-9]*$/.test(tok)) {
+ if (registered.size > 0) { hasDefaultMarker = true; break; }
+ } else if (/^[0-9]+$/.test(tok) && registered.has(Number(tok))) {
+ hasDefaultMarker = true; break;
+ }
+ }
  const gridMaxHeightRaw = (editor.dataset.oscGridMaxHeight || '').trim();
  const gridMaxHeight = gridMaxHeightRaw === ''
  ? 0
@@ -3554,7 +3577,7 @@
  const isZFrac = source === 'z' && chain.indexOf('.frac') !== -1;
  let unresolved = false;
  if (index === undefined) {
- unresolved = markerId === null || !registered.has(markerId);
+ unresolved = !hasDefaultMarker;
  if (!unresolved && isZFrac && gridUnset) {
  unresolved = true;
  }
@@ -3629,7 +3652,7 @@
  const messageError = form.querySelector(
  '[id$="-error"][id^="osc-message-"]',
  );
- const markerInput = form.querySelector('input[name="marker_id"]');
+ const markerInput = form.querySelector('input[name="markers"]');
  const markerError = markerInput
  ? document.getElementById(
  markerInput.getAttribute('aria-describedby') || '',
@@ -3676,16 +3699,16 @@
  // Fire the HTMX validation we wired with ``hx-trigger="osc-validate"``.
  window.htmx.trigger(editor, 'osc-validate');
  }, true); // capture: ``blur`` doesn't bubble.
- // Re-evaluate unresolved pills as operator edits Default marker field.
+ // Re-evaluate unresolved pills as operator edits the Default markers field.
  // Mirrors Python's ``_row_unresolved_placeholders`` for real-time pill state.
  document.addEventListener('input', (event) => {
- const input = event.target.closest('input[name="marker_id"]');
+ const input = event.target.closest('input[name="markers"]');
  if (!input) return;
  const form = input.closest('form');
  if (!form) return;
  const editor = form.querySelector('[data-osc-message-editor]');
  if (!editor) return;
- editor.dataset.oscRowMarkerId = (input.value || '').trim();
+ editor.dataset.oscRowMarkers = (input.value || '').trim();
  oscEditorRecomputeUnresolved(editor);
  oscEditorRenderPills(editor);
  oscEditorSyncEnabledUnresolved(editor);
@@ -3775,7 +3798,7 @@
  editor.dispatchEvent(new Event('input', { bubbles: true }));
  });
  // "Save as template…" button captures the whole row form to endpoint.
- // Template carries all operator-tunable fields; ``enabled`` and ``marker_id`` dropped server-side.
+ // Template carries all operator-tunable fields; ``enabled`` and ``markers`` dropped server-side.
  //
  // We use ``FormData`` to gather the live form state (matches
  // what the row's normal Save POST would send), then append the

--- a/openfollow/web/templates/index.tpl
+++ b/openfollow/web/templates/index.tpl
@@ -133,7 +133,10 @@
     %     midi_patches=midi_patches,
     %     builtin_templates=osc_system_templates,
     %     user_templates=osc_user_templates,
-    %     placeholders=sorted(PLACEHOLDERS))
+    %     placeholders=sorted(PLACEHOLDERS),
+    %     registered_marker_ids=registered_marker_ids,
+    %     unresolved_by_row=unresolved_by_row,
+    %     marker_display_by_row=marker_display_by_row)
 </div>
 
 <!-- Person Detection -->

--- a/openfollow/web/templates/partials/osc_bindings.tpl
+++ b/openfollow/web/templates/partials/osc_bindings.tpl
@@ -21,6 +21,10 @@
 % # round-trip to the server.
 % _unresolved_by_row = defined('unresolved_by_row') and unresolved_by_row or {}
 % _registered_marker_ids = defined('registered_marker_ids') and registered_marker_ids or []
+% # per-row marker display: {row_id: {"header": <single-marker label|None>,
+% #   "nested": [<chip>...], "markers_unusable": <bool>}}. Built server-side
+% # from each row's resolved ``markers`` tokens (catalog names).
+% _marker_display_by_row = defined('marker_display_by_row') and marker_display_by_row or {}
 % # Shared OSC destinations the rows reference. Build an id→profile map so the
 % # collapsed summary + read-only endpoint display resolve without a per-row scan.
 % _destinations = config.osc_destinations.destinations
@@ -47,6 +51,20 @@
  % trigger_kind = getattr(row.trigger, 'kind', 'stream')
  % row_unresolved = _unresolved_by_row.get(row.id, ())
  % has_unresolved = bool(row_unresolved)
+ % _row_marker = _marker_display_by_row.get(row.id, {})
+ % _marker_header = _row_marker.get('header')
+ % _marker_nested = _row_marker.get('nested', [])
+ % _markers_unusable = _row_marker.get('markers_unusable', False)
+ % # The row's status dot is red when this transmitter can never fire: no
+ % # destination (or a dangling one), no controlled marker among those it
+ % # names, or an invalid address/arg (an unresolvable placeholder).
+ % # Otherwise amber when enabled, grey when off. An uncontrolled *secondary*
+ % # marker (with at least one controlled) reddens its own nested chip, not
+ % # this dot.
+ % _dest_missing = (not row.destination_id) or (row.destination_id not in _dest_by_id)
+ % _dot_broken = _dest_missing or _markers_unusable or has_unresolved
+ % _dot_state = 'invalid' if _dot_broken else ('on' if row.enabled else 'off')
+ % _dot_label = 'No destination' if _dest_missing else ('No controlled marker' if _markers_unusable else ('Invalid OSC message' if has_unresolved else ('Enabled' if row.enabled else 'Disabled')))
  <details class="osc-binding-row" data-row-id="{{row.id}}" data-trigger-kind="{{trigger_kind}}"
  data-reorder-url="/section/osc_bindings/reorder" data-reorder-target="osc-bindings-section" {{'open' if is_focus else ''}}>
  <summary class="osc-binding-summary">
@@ -67,9 +85,12 @@
  title="Drag to reorder"
  onpointerdown="event.stopPropagation()"
  onclick="event.preventDefault(); event.stopPropagation();">⋮⋮</span>
- <span class="osc-binding-enabled-dot {{'on' if row.enabled else 'off'}}" aria-label="{{'Enabled' if row.enabled else 'Disabled'}}"></span>
+ <span class="osc-binding-enabled-dot {{_dot_state}}" aria-label="{{_dot_label}}"></span>
  <span class="osc-binding-title">{{row.name or '(unnamed)'}}</span>
  <span class="osc-binding-kind-badge">{{pretty_label(trigger_kind)}}</span>
+ % if _marker_header:
+ <span class="osc-binding-marker-badge">{{_marker_header}}</span>
+ % end
  <span class="osc-binding-target">{{_dest_label(row.destination_id)}}</span>
  </summary>
 
@@ -118,21 +139,23 @@
  <input type="text" name="name" value="{{row.name}}" maxlength="64">
  </div>
  <div class="field">
- % # Default marker now optional. No min="0" (avoids
- % # stepper vs empty value). Render empty when None.
- % # Wire to validate endpoint; blur surfaces error
- % # if default-marker placeholder has no satisfying
- % # marker. hx-include pulls hidden osc_message for
- % # cross-field check.
- <label for="marker-id-{{row.id}}">Default marker</label>
- <input id="marker-id-{{row.id}}" type="number" name="marker_id" value="{{'' if row.marker_id is None else row.marker_id}}" step="1" placeholder="(none)"
- hx-get="/api/validate/osc_binding/marker_id"
+ % # Default markers: comma-separated ids / controller
+ % # aliases (cN) / ``all``. Multiple markers fan the row
+ % # out into one independent send each. Blur validates
+ % # token syntax + surfaces the cross-field "uses [x] but
+ % # names no usable default marker" warning; hx-include
+ % # pulls the hidden osc_message for that check.
+ <label for="markers-{{row.id}}">Default markers</label>
+ <input id="markers-{{row.id}}" type="text" name="markers" value="{{', '.join(row.markers)}}" placeholder="(none)"
+ maxlength="256"
+ hx-get="/api/validate/osc_binding/markers"
  hx-trigger="blur changed delay:200ms"
- hx-target="#marker-id-{{row.id}}-error"
+ hx-target="#markers-{{row.id}}-error"
  hx-swap="innerHTML"
  hx-include="closest form"
- aria-describedby="marker-id-{{row.id}}-error">
- <span id="marker-id-{{row.id}}-error" class="field-error"></span>
+ aria-describedby="markers-{{row.id}}-error"
+ aria-invalid="false">
+ <span id="markers-{{row.id}}-error" class="field-error"></span>
  </div>
  <div class="field">
  % # default
@@ -177,11 +200,10 @@
  <option value="{{row.destination_id}}" selected disabled>(missing destination)</option>
  % end
  % for d in _destinations:
- <option value="{{d.id}}" {{'selected' if d.id == row.destination_id else ''}}>{{d.name or '(unnamed)'}}</option>
+ <option value="{{d.id}}" {{'selected' if d.id == row.destination_id else ''}}>{{d.name or '(unnamed)'}} – {{d.protocol}}://{{d.host}}:{{d.port}}</option>
  % end
  </select>
  <span id="destination-id-{{row.id}}-error" class="field-error"></span>
- <span class="field-note">{{_dest_label(row.destination_id)}} – manage in OSC Destinations</span>
  </div>
  </div>
  </div>
@@ -238,7 +260,7 @@
  % # list of unmet dependencies (server-side).
  % # Pill JS applies data-unresolved="true" for CSS.
  % # data-osc-registered-marker-ids for re-eval as
- % # operator edits marker_id. data-osc-placeholder-names:
+ % # operator edits markers. data-osc-placeholder-names:
  % # full set so client mirror doesn't drift vs server.
  <div id="osc-message-{{row.id}}"
  class="osc-message-editor"
@@ -249,13 +271,13 @@
  data-osc-unresolved-placeholders="{{json.dumps(list(row_unresolved))}}"
  data-osc-placeholder-names="{{json.dumps(list(placeholders))}}"
  data-osc-registered-marker-ids="{{json.dumps(list(_registered_marker_ids))}}"
- data-osc-row-marker-id="{{'' if row.marker_id is None else row.marker_id}}"
+ data-osc-row-markers="{{', '.join(row.markers)}}"
  data-osc-grid-max-height="{{config.grid.max_height}}"
  hx-get="/api/validate/osc_binding/osc_message"
  hx-trigger="osc-validate"
  hx-target="#osc-message-{{row.id}}-error"
  hx-swap="innerHTML"
- hx-vals='js:{"osc_message": (document.getElementById("osc-message-{{row.id}}-hidden") || {}).value, "marker_id": (document.getElementById("marker-id-{{row.id}}") || {}).value}'
+ hx-vals='js:{"osc_message": (document.getElementById("osc-message-{{row.id}}-hidden") || {}).value, "markers": (document.getElementById("markers-{{row.id}}") || {}).value}'
  aria-labelledby="osc-message-{{row.id}}-label"
  aria-describedby="osc-message-{{row.id}}-error"
  aria-multiline="false"
@@ -411,6 +433,21 @@
  </div>
  </form>
  </details>
+ % # Secondary markers from this row's ``markers`` field, shown as
+ % # read-only chips nested under the primary row. They share the row's
+ % # destination / message / trigger; edit the set via "Default markers".
+ % # Each carries the same status dot as a transmitter row: red when the id
+ % # isn't controlled by this station (its send is dropped at runtime).
+ % if _marker_nested:
+ <div class="osc-binding-nested" aria-label="Additional markers">
+ % for _entry in _marker_nested:
+ <span class="osc-binding-nested-row{{'' if _entry['controlled'] else ' is-invalid'}}"{{!'' if _entry['controlled'] else ' title=\"Not controlled by this station (ignored)\"'}}>
+ <span class="osc-binding-enabled-dot {{'on' if _entry['controlled'] else 'invalid'}}" aria-label="{{'Controlled' if _entry['controlled'] else 'Not controlled'}}"></span>
+ <span>{{_entry['label']}}</span>
+ </span>
+ % end
+ </div>
+ % end
  % end
  </div>
 

--- a/openfollow/web/validation.py
+++ b/openfollow/web/validation.py
@@ -30,6 +30,7 @@ from openfollow.configuration import (
     VALID_TRIGGER_KINDS,
     VALID_ZONE_EVAL_FPS,
     AppConfig,
+    _canonical_marker_token,
 )
 from openfollow.web.routes import (
     _as_bool,
@@ -238,6 +239,23 @@ def _validate_int_list(value: str, _cfg: AppConfig | None) -> str | None:
             int(entry)
         except ValueError:
             return f"Entry {idx} ({entry!r}) is not a whole number."
+    return None
+
+
+def _validate_markers(value: str, _cfg: AppConfig | None) -> str | None:
+    """Per-entry syntax check for the OSC transmitter ``markers`` field.
+
+    Each entry must be a non-negative marker id, a controller alias
+    (``c1``, ``c2``, …), or ``all``. A syntactically-valid id this station
+    doesn't currently control is NOT flagged – it's silently ignored at
+    send time (the station may gain control of it later, and OSC routing
+    never crosses machines). Only malformed tokens block Save."""
+    if not value:
+        return None
+    entries = [e.strip() for e in value.split(",") if e.strip()]
+    for idx, entry in enumerate(entries, start=1):
+        if _canonical_marker_token(entry) is None:
+            return f"Entry {idx} ({entry!r}) must be a marker id, a controller alias (c1, c2, …), or 'all'."
     return None
 
 
@@ -604,8 +622,15 @@ FIELD_RULES: dict[str, dict[str, FieldRule]] = {
         # Connection chosen via a shared OSC destination; empty allowed –
         # an unselected enabled row is a soft "no send", not a blur error.
         "destination_id": FieldRule(_as_str, max_len=64),
-        # marker_id is int | None; empty input means "no default marker".
-        "marker_id": FieldRule(_as_optional_int, lo=0, human_error="Marker id must be ≥ 0."),
+        # ``markers``: comma-separated marker ids / controller aliases (cN) /
+        # ``all``; empty = no default marker. Malformed tokens block; a valid
+        # but non-controlled id is ignored at send time, not flagged here.
+        "markers": FieldRule(
+            _as_str,
+            max_len=256,
+            custom=_validate_markers,
+            human_error="Comma-separated marker ids, controller aliases (c1, c2, …), or 'all'.",
+        ),
         # address + args input; template picker handles choice at row creation time.
         "osc_message": FieldRule(
             _as_str,

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -584,7 +584,7 @@ def test_fader_on_change_marker_source_survives_save_reload(
             transmitters=[
                 OscTransmitterConfig(
                     id="r1",
-                    marker_id=4,
+                    markers=["4"],
                     trigger=FaderOnChangeTrigger(marker_id=4, rate_hz=30),
                 ),
             ]
@@ -4119,70 +4119,48 @@ class TestOscTransmitterConfig:
         assert not hasattr(row, "framing")
         assert row.destination_id == ""
 
-    def test_marker_id_default_is_none(self) -> None:
-        """marker_id defaults to None (not yet chosen by operator)."""
-        assert OscTransmitterConfig().marker_id is None
+    def test_markers_default_is_empty(self) -> None:
+        """markers defaults to [] (no default marker chosen yet)."""
+        assert OscTransmitterConfig().markers == []
 
-    def test_marker_id_explicit_zero_preserved(self) -> None:
+    def test_markers_explicit_zero_preserved(self) -> None:
         """An operator who deliberately picks marker 0 must see that
-        choice round-trip through the schema – distinct from
-        "unset" (``None``)."""
-        assert OscTransmitterConfig(marker_id=0).marker_id == 0
+        choice round-trip through the schema – distinct from "unset"."""
+        assert OscTransmitterConfig(markers=["0"]).markers == ["0"]
 
-    def test_marker_id_explicit_int_preserved(self) -> None:
-        assert OscTransmitterConfig(marker_id=5).marker_id == 5
+    def test_markers_explicit_int_preserved(self) -> None:
+        assert OscTransmitterConfig(markers=["5"]).markers == ["5"]
 
-    def test_marker_id_negative_collapses_to_none(self) -> None:
-        """Invalid input collapses to None so the runtime surfaces
-        "no default marker configured" instead of using marker 0."""
-        assert OscTransmitterConfig(marker_id=-3).marker_id is None
+    def test_markers_csv_string_parses_sorts_and_dedupes(self) -> None:
+        """A hand-edited comma-separated string canonicalises: numeric ids
+        sort ascending, duplicates drop."""
+        assert OscTransmitterConfig(markers="7, 3, 1, 3").markers == ["1", "3", "7"]  # type: ignore[arg-type]
 
-    def test_marker_id_bogus_string_collapses_to_none(self) -> None:
-        assert (
-            OscTransmitterConfig(
-                marker_id="bogus",  # type: ignore[arg-type]
-            ).marker_id
-            is None
-        )
+    def test_markers_controller_alias_preserved(self) -> None:
+        assert OscTransmitterConfig(markers="c2, 1").markers == ["1", "c2"]  # type: ignore[arg-type]
 
-    def test_marker_id_empty_string_collapses_to_none(self) -> None:
-        """Web form posts an empty string when the operator clears
-        the input; that must mean ``None``, not "marker 0"."""
-        assert (
-            OscTransmitterConfig(
-                marker_id="",  # type: ignore[arg-type]
-            ).marker_id
-            is None
-        )
+    def test_markers_all_keyword_collapses_list(self) -> None:
+        """``all`` subsumes every other entry."""
+        assert OscTransmitterConfig(markers="1, all, c3").markers == ["all"]  # type: ignore[arg-type]
 
-    def test_marker_id_whitespace_string_collapses_to_none(self) -> None:
-        assert (
-            OscTransmitterConfig(
-                marker_id="   ",  # type: ignore[arg-type]
-            ).marker_id
-            is None
-        )
+    def test_markers_invalid_entries_are_dropped(self) -> None:
+        """Negatives, floats, bad aliases (c0 / c01), and junk are ignored
+        rather than collapsing the whole field."""
+        assert OscTransmitterConfig(markers="1, -3, bogus, 1.5, c0, c01, 4").markers == ["1", "4"]  # type: ignore[arg-type]
 
-    def test_marker_id_bool_collapses_to_none(self) -> None:
-        """``True`` is an ``int`` subclass – accepting it would silently
-        promote a hand-edited ``marker_id = true`` to marker 1.
-        Mirrors the bool guard in :func:`_coerce_int`."""
-        assert (
-            OscTransmitterConfig(
-                marker_id=True,  # type: ignore[arg-type]
-            ).marker_id
-            is None
-        )
+    def test_markers_empty_string_is_empty_list(self) -> None:
+        assert OscTransmitterConfig(markers="   ").markers == []  # type: ignore[arg-type]
 
-    def test_marker_id_float_collapses_to_none(self) -> None:
-        """Float marker_id must reject (could silently truncate to wrong marker)."""
-        for bad in (1.5, 0.1, -0.5, 1.0, float("inf"), float("nan")):
-            assert (
-                OscTransmitterConfig(
-                    marker_id=bad,  # type: ignore[arg-type]
-                ).marker_id
-                is None
-            ), f"expected None for marker_id={bad!r}"
+    def test_markers_bool_collapses_to_empty(self) -> None:
+        """``True`` is an ``int`` subclass – a hand-edited ``markers = true``
+        must not become marker 1."""
+        assert OscTransmitterConfig(markers=True).markers == []  # type: ignore[arg-type]
+
+    def test_markers_legacy_int_lift(self) -> None:
+        """A bare int (the legacy single ``marker_id``) lifts to a one-token
+        list; a negative lifts to empty."""
+        assert OscTransmitterConfig(markers=5).markers == ["5"]  # type: ignore[arg-type]
+        assert OscTransmitterConfig(markers=-3).markers == []  # type: ignore[arg-type]
 
     def test_non_string_template_id_collapses_to_empty(self) -> None:
         cfg = OscTransmitterConfig(template_id=99)  # type: ignore[arg-type]
@@ -4928,40 +4906,31 @@ class TestOscTransmittersConfigLegacyLift:
         assert rows[1].id == "row2"
         assert rows[1].destination_id == "d2"
 
-    def test_marker_id_none_round_trips_through_toml(
+    def test_markers_empty_round_trips_through_toml(
         self,
         temp_config_path,  # noqa: ANN001
     ) -> None:
         original = AppConfig(
             osc_transmitters=OscTransmittersConfig(
                 transmitters=[
-                    OscTransmitterConfig(id="r1", marker_id=None),
+                    OscTransmitterConfig(id="r1", markers=[]),
                 ],
             ),
         )
         save_config(original, str(temp_config_path))
-        # Confirm the dump didn't write a ``marker_id`` key for the
-        # row – otherwise a future reader that *does* coerce the
-        # absent-value branch differently could disagree with us.
-        with open(temp_config_path, "rb") as f:
-            raw = tomllib.load(f)
-        row = raw["osc_transmitters"]["transmitters"][0]
-        assert "marker_id" not in row
         reloaded = load_config(str(temp_config_path))
-        assert reloaded.osc_transmitters.transmitters[0].marker_id is None
+        assert reloaded.osc_transmitters.transmitters[0].markers == []
 
-    def test_marker_id_explicit_zero_round_trips_through_toml(
+    def test_markers_multi_round_trips_through_toml(
         self,
         temp_config_path,  # noqa: ANN001
     ) -> None:
-        """An operator who deliberately set marker 0 must see that
-        choice survive a save / reload cycle – distinct from
-        "unset" (``None``). ``0`` is not stripped by
-        :func:`_strip_none` because it isn't ``None``."""
+        """A multi-marker row (ids + alias) survives a save / reload cycle
+        in canonical order."""
         original = AppConfig(
             osc_transmitters=OscTransmittersConfig(
                 transmitters=[
-                    OscTransmitterConfig(id="r1", marker_id=0),
+                    OscTransmitterConfig(id="r1", markers=["7", "0", "c1"]),
                 ],
             ),
         )
@@ -4969,24 +4938,22 @@ class TestOscTransmittersConfigLegacyLift:
         with open(temp_config_path, "rb") as f:
             raw = tomllib.load(f)
         row = raw["osc_transmitters"]["transmitters"][0]
-        assert row["marker_id"] == 0
+        assert row["markers"] == ["0", "7", "c1"]
         reloaded = load_config(str(temp_config_path))
-        assert reloaded.osc_transmitters.transmitters[0].marker_id == 0
+        assert reloaded.osc_transmitters.transmitters[0].markers == ["0", "7", "c1"]
 
-    def test_marker_id_explicit_int_round_trips_through_toml(
+    def test_legacy_marker_id_lifts_into_markers(
         self,
         temp_config_path,  # noqa: ANN001
     ) -> None:
-        original = AppConfig(
-            osc_transmitters=OscTransmittersConfig(
-                transmitters=[
-                    OscTransmitterConfig(id="r1", marker_id=7),
-                ],
-            ),
+        """A hand-edited TOML row carrying the legacy single ``marker_id``
+        key lifts into the one-token ``markers`` list on load."""
+        temp_config_path.write_text(
+            "[[osc_transmitters.transmitters]]\nid = 'r1'\nmarker_id = 4\n",
+            encoding="utf-8",
         )
-        save_config(original, str(temp_config_path))
         reloaded = load_config(str(temp_config_path))
-        assert reloaded.osc_transmitters.transmitters[0].marker_id == 7
+        assert reloaded.osc_transmitters.transmitters[0].markers == ["4"]
 
 
 def test_new_uuid_hex_returns_unique_strings_each_call() -> None:

--- a/tests/test_midi_alias_hot_reload.py
+++ b/tests/test_midi_alias_hot_reload.py
@@ -120,7 +120,7 @@ def test_midi_event_dispatches_through_patch_after_port_rename(
         id="row-1",
         enabled=True,
         destination_id="d1",
-        marker_id=None,
+        markers=[],
         address="/cc/[value]",
         args=[],
         trigger=MidiMessageTrigger(
@@ -223,7 +223,7 @@ def test_late_event_on_closed_port_callback_does_not_double_dispatch(
         id="row-1",
         enabled=True,
         destination_id="d1",
-        marker_id=None,
+        markers=[],
         address="/cc/[value]",
         args=[],
         trigger=MidiMessageTrigger(
@@ -313,7 +313,7 @@ def test_midi_patch_reassignment_breaks_old_trigger_row(
         id="row-1",
         enabled=True,
         destination_id="d1",
-        marker_id=None,
+        markers=[],
         address="/cc/[value]",
         args=[],
         trigger=MidiMessageTrigger(
@@ -386,7 +386,7 @@ def test_concurrent_event_during_apply_config_does_not_race(
         id="row-1",
         enabled=True,
         destination_id="d1",
-        marker_id=None,
+        markers=[],
         address="/cc/[value]",
         args=[],
         trigger=MidiMessageTrigger(

--- a/tests/test_osc_transmitter.py
+++ b/tests/test_osc_transmitter.py
@@ -86,17 +86,25 @@ def _destinations(*dests: OscDestinationConfig) -> OscDestinationsConfig:
 
 
 def _row(**overrides: Any) -> OscTransmitterConfig:
-    """Transmitter row with defaults; tests override only what they assert."""
+    """Transmitter row with defaults; tests override only what they assert.
+
+    ``marker_id=<id|None>`` is accepted as shorthand for the single
+    default-marker case and mapped onto the ``markers`` list (``None`` →
+    no default marker); pass ``markers=[...]`` directly to exercise the
+    multi-marker fan-out."""
     defaults: dict[str, Any] = {
         "id": "row-1",
         "enabled": True,
         "destination_id": _DEFAULT_DEST_ID,
-        "marker_id": 0,
+        "markers": ["0"],
         "template_id": "",
         "address": "/cue/[markerid]",
         "args": ["[x]", "[y]", "[z]"],
         "rate_hz": 60,
     }
+    if "marker_id" in overrides:
+        mid = overrides.pop("marker_id")
+        overrides["markers"] = [] if mid is None else [str(mid)]
     defaults.update(overrides)
     return OscTransmitterConfig(**defaults)
 
@@ -108,6 +116,7 @@ def _manager(
     fader_values: dict[int, float] | None = None,
     marker_fader_values: dict[int, float] | None = None,
     controller_markers: dict[int, int] | None = None,
+    controlled_markers: list[int] | None = None,
     destinations: OscDestinationsConfig | None = None,
 ) -> tuple[OscTransmitterManager, _FakeOscService]:
     # grid tuple = (width, depth, max_height, z_offset). max_height=0.0
@@ -123,6 +132,10 @@ def _manager(
         fader_provider = fader_values.get
     marker_fader_provider = marker_fader_values.get if marker_fader_values is not None else None
     controller_marker_provider = controller_markers.get if controller_markers is not None else None
+    # ``controlled_markers`` (list of ids) → provider for the ``all`` token +
+    # controlled-only validity filter; None leaves it unwired (numeric tokens
+    # pass through unfiltered, ``all`` yields nothing).
+    controlled_markers_provider = (lambda: list(controlled_markers)) if controlled_markers is not None else None
     manager = OscTransmitterManager(
         osc_service=service,  # type: ignore[arg-type]
         marker_provider=marker_map.get,
@@ -130,6 +143,7 @@ def _manager(
         fader_provider=fader_provider,
         marker_fader_provider=marker_fader_provider,
         controller_marker_provider=controller_marker_provider,
+        controlled_markers_provider=controlled_markers_provider,
     )
     # Seed destinations once; subsequent ``restart(cfg)`` calls (with no
     # destinations arg) keep the staged set, mirroring a transmitter-only edit.
@@ -980,12 +994,12 @@ class TestStreamOnChangeGate:
         manager, _svc = _manager(markers={0: marker})
         manager.restart(OscTransmittersConfig(transmitters=[self._on_change_row()]))
         # Sanity: cache empty before any tick.
-        assert "row-1" not in manager._last_sent_pos
+        assert not any(k[0] == "row-1" for k in manager._last_sent_pos)
         # Diagnostics test packet – must NOT prime the cache.
         result = manager.test_send("row-1")
         assert result is not None
         assert result["sent"] is True
-        assert "row-1" not in manager._last_sent_pos
+        assert not any(k[0] == "row-1" for k in manager._last_sent_pos)
 
     def test_test_send_does_not_skip_against_live_cache(self) -> None:
         # A live tick primed the cache. A subsequent test packet
@@ -1060,7 +1074,7 @@ class TestOnChangeCacheLocking:
         send_release.set()
         tick_thread.join(timeout=2.0)
         assert not tick_thread.is_alive()
-        assert "row-1" not in manager._last_sent_pos
+        assert not any(k[0] == "row-1" for k in manager._last_sent_pos)
 
     def test_recreating_same_id_mid_send_does_not_prime_new_rows_cache(self) -> None:
         # A row dropped then re-created under the SAME id while
@@ -1073,7 +1087,7 @@ class TestOnChangeCacheLocking:
         manager.restart(OscTransmittersConfig(transmitters=[self._on_change_row()]))
         # Snapshot a plan from the original row (plan.source_row = object A).
         original = manager._rows["row-1"]
-        plan = manager._plan_for_row(original)
+        plan = manager._plans_for_row(original)[0]
         # Drop then re-create row-1 → a fresh object B under the same id.
         manager.restart(OscTransmittersConfig(transmitters=[]))
         manager.restart(OscTransmittersConfig(transmitters=[self._on_change_row()]))
@@ -1081,7 +1095,7 @@ class TestOnChangeCacheLocking:
         # The old plan's in-flight send completes and tries to write.
         manager._fire_plan(plan)
         # Identity guard refuses to prime the new row's cache.
-        assert "row-1" not in manager._last_sent_pos
+        assert not any(k[0] == "row-1" for k in manager._last_sent_pos)
 
     def test_in_place_reload_keeps_cache_via_object_identity(self) -> None:
         # The flip side: a cosmetic in-place reload reuses the same row
@@ -1091,12 +1105,12 @@ class TestOnChangeCacheLocking:
         manager, _svc = _manager(markers={0: marker})
         manager.restart(OscTransmittersConfig(transmitters=[self._on_change_row()]))
         manager._tick_once()  # primes cache
-        assert "row-1" in manager._last_sent_pos
+        assert any(k[0] == "row-1" for k in manager._last_sent_pos)
         # Cosmetic reload (same marker_id + trigger kind) reuses the object.
         same = manager._rows["row-1"]
         manager.restart(OscTransmittersConfig(transmitters=[self._on_change_row(name="renamed")]))
         assert manager._rows["row-1"] is same
-        assert "row-1" in manager._last_sent_pos
+        assert any(k[0] == "row-1" for k in manager._last_sent_pos)
 
     def test_per_axis_compare_not_euclidean(self) -> None:
         # 4cm on three axes is ~6.93cm Euclidean (above 5cm), but the
@@ -1231,9 +1245,9 @@ class TestOnChangeCacheLocking:
         manager, _svc = _manager(markers={0: marker})
         manager.restart(OscTransmittersConfig(transmitters=[self._on_change_row()]))
         manager._tick_once()
-        assert "row-1" in manager._last_sent_pos
+        assert any(k[0] == "row-1" for k in manager._last_sent_pos)
         manager.restart(OscTransmittersConfig(transmitters=[]))
-        assert "row-1" not in manager._last_sent_pos
+        assert not any(k[0] == "row-1" for k in manager._last_sent_pos)
 
     # A surviving row whose effective on-change input (default marker)
     # changes must drop its cache entry, else the next tick compares the
@@ -1251,7 +1265,7 @@ class TestOnChangeCacheLocking:
             )
         )
         manager._tick_once()
-        assert "row-1" in manager._last_sent_pos
+        assert any(k[0] == "row-1" for k in manager._last_sent_pos)
         # Swap default marker. New config's cache key is the same
         # ("row-1") but the cached position was marker 0's, not
         # marker 1's. Without invalidation, the next tick would
@@ -1263,7 +1277,7 @@ class TestOnChangeCacheLocking:
                 ]
             )
         )
-        assert "row-1" not in manager._last_sent_pos
+        assert not any(k[0] == "row-1" for k in manager._last_sent_pos)
 
     def test_cache_kept_when_address_template_changes(self) -> None:
         # The gate watches only the default marker, so address / args
@@ -1272,7 +1286,7 @@ class TestOnChangeCacheLocking:
         manager, _svc = _manager(markers={0: marker})
         manager.restart(OscTransmittersConfig(transmitters=[self._on_change_row()]))
         manager._tick_once()
-        assert "row-1" in manager._last_sent_pos
+        assert any(k[0] == "row-1" for k in manager._last_sent_pos)
         manager.restart(
             OscTransmittersConfig(
                 transmitters=[
@@ -1280,7 +1294,7 @@ class TestOnChangeCacheLocking:
                 ]
             )
         )
-        assert "row-1" in manager._last_sent_pos
+        assert any(k[0] == "row-1" for k in manager._last_sent_pos)
 
     def test_cache_kept_when_args_change(self) -> None:
         # Same reasoning as the address-edit case.
@@ -1288,7 +1302,7 @@ class TestOnChangeCacheLocking:
         manager, _svc = _manager(markers={0: marker})
         manager.restart(OscTransmittersConfig(transmitters=[self._on_change_row()]))
         manager._tick_once()
-        assert "row-1" in manager._last_sent_pos
+        assert any(k[0] == "row-1" for k in manager._last_sent_pos)
         manager.restart(
             OscTransmittersConfig(
                 transmitters=[
@@ -1296,7 +1310,7 @@ class TestOnChangeCacheLocking:
                 ]
             )
         )
-        assert "row-1" in manager._last_sent_pos
+        assert any(k[0] == "row-1" for k in manager._last_sent_pos)
 
     def test_cache_dropped_when_trigger_kind_changes(self) -> None:
         from openfollow.configuration import HotkeyTrigger
@@ -1305,7 +1319,7 @@ class TestOnChangeCacheLocking:
         manager, _svc = _manager(markers={0: marker})
         manager.restart(OscTransmittersConfig(transmitters=[self._on_change_row()]))
         manager._tick_once()
-        assert "row-1" in manager._last_sent_pos
+        assert any(k[0] == "row-1" for k in manager._last_sent_pos)
         # Switch trigger kind from Stream to Hotkey – flipping back
         # to Stream later would otherwise resurrect a stale cache.
         manager.restart(
@@ -1315,7 +1329,7 @@ class TestOnChangeCacheLocking:
                 ]
             )
         )
-        assert "row-1" not in manager._last_sent_pos
+        assert not any(k[0] == "row-1" for k in manager._last_sent_pos)
 
     def test_cache_kept_on_cosmetic_edits(self) -> None:
         # Editing only host / port / name / rate_hz / threshold
@@ -1327,7 +1341,7 @@ class TestOnChangeCacheLocking:
         manager, _svc = _manager(markers={0: marker})
         manager.restart(OscTransmittersConfig(transmitters=[self._on_change_row()]))
         manager._tick_once()
-        assert "row-1" in manager._last_sent_pos
+        assert any(k[0] == "row-1" for k in manager._last_sent_pos)
         # Edit cosmetic fields only (destination/name) and the threshold –
         # threshold change is read fresh per tick, doesn't affect
         # the cached position's meaning.
@@ -1346,7 +1360,7 @@ class TestOnChangeCacheLocking:
                 ]
             )
         )
-        assert "row-1" in manager._last_sent_pos
+        assert any(k[0] == "row-1" for k in manager._last_sent_pos)
 
 
 class TestRingBufferIntegration:
@@ -3579,4 +3593,183 @@ class TestResolverGuards:
         manager._tick_once()  # must not raise
         assert svc.calls == []
         entries = manager.ring_buffer_for("row-c") or []
+        assert entries and entries[-1].status == "skipped"
+
+
+class TestMultiMarkerFanOut:
+    """A row whose ``markers`` field names several markers fans out into one
+    independent send per resolved marker, each rendered against its own
+    marker context."""
+
+    def test_fans_out_one_send_per_marker(self) -> None:
+        manager, svc = _manager(
+            markers={
+                1: _FakeMarker((1.0, 0.0, 0.0)),
+                3: _FakeMarker((3.0, 0.0, 0.0)),
+                7: _FakeMarker((7.0, 0.0, 0.0)),
+            },
+        )
+        manager.restart(
+            OscTransmittersConfig(
+                transmitters=[_row(markers=["7", "3", "1"], address="/m/[markerid]", args=["[x]"])],
+            )
+        )
+        manager._tick_once()
+        # One send per marker, lowest id first, each carrying its own id + x.
+        assert [(c[0], c[1]) for c in svc.calls] == [
+            ("/m/1", [1.0]),
+            ("/m/3", [3.0]),
+            ("/m/7", [7.0]),
+        ]
+
+    def test_non_marker_dependent_row_sends_once(self) -> None:
+        """A row whose message doesn't reference the default marker emits a
+        single packet even when it names several markers – no duplicates."""
+        manager, svc = _manager(markers={1: _FakeMarker((0.0, 0.0, 0.0)), 3: _FakeMarker((0.0, 0.0, 0.0))})
+        manager.restart(
+            OscTransmittersConfig(
+                transmitters=[_row(markers=["1", "3"], address="/go", args=["1"])],
+            )
+        )
+        manager._tick_once()
+        assert [c[0] for c in svc.calls] == ["/go"]
+
+    def test_on_change_gate_is_per_marker(self) -> None:
+        from openfollow.configuration import StreamTrigger
+
+        m1 = _FakeMarker((0.0, 0.0, 0.0))
+        m3 = _FakeMarker((0.0, 0.0, 0.0))
+        manager, svc = _manager(markers={1: m1, 3: m3})
+        row = _row(
+            markers=["1", "3"],
+            address="/m/[markerid]",
+            args=["[x]"],
+            trigger=StreamTrigger(rate_hz=60, mode="on_change", min_change_m=0.05),
+        )
+        manager.restart(OscTransmittersConfig(transmitters=[row]))
+        manager._tick_once()  # primes both markers
+        assert len(svc.calls) == 2
+        svc.calls.clear()
+        # Move only marker 3 → only its send fires; marker 1 is gated.
+        m3.pos = (5.0, 0.0, 0.0)
+        manager._tick_once()
+        assert [(c[0], c[1]) for c in svc.calls] == [("/m/3", [5.0])]
+
+    def test_all_token_expands_to_controlled_markers(self) -> None:
+        manager, svc = _manager(
+            markers={2: _FakeMarker((2.0, 0.0, 0.0)), 5: _FakeMarker((5.0, 0.0, 0.0))},
+            controlled_markers=[5, 2],
+        )
+        manager.restart(
+            OscTransmittersConfig(
+                transmitters=[_row(markers=["all"], address="/m/[markerid]", args=[])],
+            )
+        )
+        manager._tick_once()
+        # Sorted ascending regardless of controlled-list order.
+        assert [c[0] for c in svc.calls] == ["/m/2", "/m/5"]
+
+    def test_all_token_reexpands_after_controlled_change(self) -> None:
+        controlled = [2]
+        markers = {2: _FakeMarker((2.0, 0.0, 0.0)), 5: _FakeMarker((5.0, 0.0, 0.0))}
+        service = _FakeOscService()
+        manager = OscTransmitterManager(
+            osc_service=service,  # type: ignore[arg-type]
+            marker_provider=markers.get,
+            grid_provider=lambda: (10.0, 6.0, 0.0, 0.0),
+            controlled_markers_provider=lambda: list(controlled),
+        )
+        manager.restart(
+            OscTransmittersConfig(transmitters=[_row(markers=["all"], address="/m/[markerid]", args=[])]),
+            _destinations(),
+        )
+        manager._tick_once()
+        assert [c[0] for c in service.calls] == ["/m/2"]
+        service.calls.clear()
+        # Operator adds marker 5 to the controlled set – no manager restart.
+        controlled.append(5)
+        manager._tick_once()
+        assert [c[0] for c in service.calls] == ["/m/2", "/m/5"]
+
+    def test_non_controlled_numeric_token_dropped(self) -> None:
+        manager, svc = _manager(
+            markers={2: _FakeMarker((2.0, 0.0, 0.0)), 5: _FakeMarker((5.0, 0.0, 0.0))},
+            controlled_markers=[2],
+        )
+        manager.restart(
+            OscTransmittersConfig(
+                transmitters=[_row(markers=["2", "5"], address="/m/[markerid]", args=[])],
+            )
+        )
+        manager._tick_once()
+        # Marker 5 isn't controlled → dropped; only marker 2 sends.
+        assert [c[0] for c in svc.calls] == ["/m/2"]
+
+    def test_controller_alias_resolves_to_driven_marker(self) -> None:
+        manager, svc = _manager(
+            markers={4: _FakeMarker((4.0, 0.0, 0.0))},
+            controller_markers={0: 4},  # controller c1 drives marker 4
+        )
+        manager.restart(
+            OscTransmittersConfig(
+                transmitters=[_row(markers=["c1"], address="/m/[markerid]", args=[])],
+            )
+        )
+        manager._tick_once()
+        assert [c[0] for c in svc.calls] == ["/m/4"]
+
+    def test_all_token_without_controlled_provider_yields_nothing(self) -> None:
+        # No controlled-markers provider wired → ``all`` can't enumerate the
+        # controlled set, so the marker-dependent row skips.
+        manager, svc = _manager(markers={1: _FakeMarker((1.0, 0.0, 0.0))})
+        manager.restart(
+            OscTransmittersConfig(
+                transmitters=[_row(markers=["all"], address="/m/[markerid]", args=[])],
+            )
+        )
+        manager._tick_once()
+        assert svc.calls == []
+
+    def test_controller_alias_without_provider_yields_nothing(self) -> None:
+        # No controller-marker provider wired → ``cN`` resolves to nothing.
+        manager, svc = _manager(markers={4: _FakeMarker((4.0, 0.0, 0.0))})
+        manager.restart(
+            OscTransmittersConfig(
+                transmitters=[_row(markers=["c1"], address="/m/[markerid]", args=[])],
+            )
+        )
+        manager._tick_once()
+        assert svc.calls == []
+
+    def test_duplicate_resolved_marker_is_deduped(self) -> None:
+        # ``c1`` resolves to marker 3, which is also named explicitly → the
+        # two tokens collapse to a single send.
+        manager, svc = _manager(
+            markers={3: _FakeMarker((3.0, 0.0, 0.0))},
+            controlled_markers=[3],
+            controller_markers={0: 3},
+        )
+        manager.restart(
+            OscTransmittersConfig(
+                transmitters=[_row(markers=["3", "c1"], address="/m/[markerid]", args=[])],
+            )
+        )
+        manager._tick_once()
+        assert [c[0] for c in svc.calls] == ["/m/3"]
+
+    def test_controller_alias_skips_when_unconnected(self) -> None:
+        manager, svc = _manager(
+            markers={4: _FakeMarker((4.0, 0.0, 0.0))},
+            controller_markers={},  # c1 drives nothing
+        )
+        manager.restart(
+            OscTransmittersConfig(
+                transmitters=[_row(markers=["c1"], address="/m/[markerid]", args=["[x]"])],
+            )
+        )
+        manager._tick_once()
+        # No resolvable marker → marker-dependent row skips with the
+        # "no default marker configured" reason.
+        assert svc.calls == []
+        entries = manager.ring_buffer_for("row-1") or []
         assert entries and entries[-1].status == "skipped"

--- a/tests/test_services_init_and_updates.py
+++ b/tests/test_services_init_and_updates.py
@@ -333,6 +333,16 @@ def services(monkeypatch: pytest.MonkeyPatch) -> AppRuntimeServices:
     return AppRuntimeServices(_dummy_app())
 
 
+def test_controlled_markers_provider_returns_copy(services: AppRuntimeServices) -> None:
+    """The OSC ``markers`` provider (drives the ``all`` token + controlled
+    filter) returns the live controlled-id list as a fresh copy, so a
+    concurrent reload swapping the list can't tear a mid-tick read."""
+    services._app._controlled_ids = [3, 7]
+    snapshot = services._controlled_markers_provider()
+    assert snapshot == [3, 7]
+    assert snapshot is not services._app._controlled_ids
+
+
 # --------------------------------------------------------------------------- #
 # _init_overlay_state
 # --------------------------------------------------------------------------- #

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -39,6 +39,7 @@ from openfollow.web.validation import (
     _validate_int_list,
     _validate_ip_list,
     _validate_keybinding,
+    _validate_markers,
     _validate_model,
     _validate_multicast_ip,
     _validate_service_name,
@@ -600,6 +601,19 @@ def test_validate_int_list_all_valid() -> None:
     assert _validate_int_list("0, 1, 2", None) is None
 
 
+def test_validate_markers_empty() -> None:
+    assert _validate_markers("", None) is None
+
+
+def test_validate_markers_all_valid_token_kinds() -> None:
+    assert _validate_markers("1, c2, all", None) is None
+
+
+def test_validate_markers_flags_offending_entry() -> None:
+    err = _validate_markers("1, c0", None)
+    assert err is not None and "c0" in err
+
+
 def test_validate_model_empty() -> None:
     assert _validate_model("", None) is None
 
@@ -843,13 +857,18 @@ def test_validate_osc_message_rejects_unclosed_quote(raw: str) -> None:
         # Connection is chosen via a destination; empty is allowed (no send).
         ("destination_id", "", False),
         ("destination_id", "dest-1", False),
-        ("marker_id", "0", False),
-        ("marker_id", "-1", True),
-        # marker_id can be empty (no default marker).
-        ("marker_id", "", False),
-        ("marker_id", "   ", False),
-        ("marker_id", "5", False),
-        ("marker_id", "bogus", True),
+        ("markers", "0", False),
+        ("markers", "1, 3, c1", False),
+        ("markers", "all", False),
+        # A valid-but-non-controlled id is ignored at runtime, not flagged.
+        ("markers", "5", False),
+        # markers can be empty (no default marker).
+        ("markers", "", False),
+        ("markers", "   ", False),
+        # Malformed tokens (negative, junk, bad alias) block.
+        ("markers", "-1", True),
+        ("markers", "bogus", True),
+        ("markers", "1, c0", True),
         # Combined ``osc_message`` field – address as first token.
         ("osc_message", "/foo/[markerId] [x] [y]", False),
         ("osc_message", "", False),

--- a/tests/test_web_osc_bindings.py
+++ b/tests/test_web_osc_bindings.py
@@ -11,6 +11,7 @@ branch is reachable without a live HTTP round-trip.
 from __future__ import annotations
 
 import json
+import re
 import socket
 import time
 import urllib.error
@@ -21,6 +22,7 @@ import pytest
 
 import openfollow.web.discovery as discovery_module
 from openfollow.configuration import (
+    AppConfig,
     ControllerButtonTrigger,
     FaderOnChangeTrigger,
     HotkeyTrigger,
@@ -37,7 +39,9 @@ from openfollow.configuration import (
 )
 from openfollow.web.routes import (
     _apply_osc_binding_fields,
+    _effective_default_marker_id,
     _midi_patches_for_form,
+    _osc_binding_marker_display,
     _parse_osc_message,
     _parse_trigger_subtable,
     _row_unresolved_placeholders,
@@ -167,7 +171,8 @@ def test_section_renders_existing_rows(live_server) -> None:
     status, body = _get(base, "/section/osc_bindings")
     assert status == 200
     assert "Stage 1" in body
-    assert "10.0.0.1" in body
+    # The destination's address rides inside the <option> label, not below it.
+    assert "<option" in body and "Console – udp://10.0.0.1:8001</option>" in body
 
 
 def test_section_focus_query_reopens_row(live_server) -> None:
@@ -255,7 +260,7 @@ def test_save_updates_basics(live_server) -> None:
             "enabled": "on",
             "name": "Edited",
             "destination_id": "dest-7",
-            "marker_id": "2",
+            "markers": "2",
             "trigger.type": "stream",
             "trigger.rate_hz": "60",
         },
@@ -266,7 +271,7 @@ def test_save_updates_basics(live_server) -> None:
     assert row.enabled is True
     assert row.name == "Edited"
     assert row.destination_id == "dest-7"
-    assert row.marker_id == 2
+    assert row.markers == ["2"]
     assert isinstance(row.trigger, StreamTrigger)
     assert row.trigger.rate_hz == 60
 
@@ -296,7 +301,7 @@ def test_save_round_trips_non_ascii_form_bytes(live_server) -> None:
             "host": "1.2.3.4",
             "port": "8000",
             "protocol": "udp",
-            "marker_id": "1",
+            "markers": "1",
             "trigger.type": "stream",
             "trigger.rate_hz": "30",
             "osc_message": msg,
@@ -332,7 +337,7 @@ def test_save_partial_form_keeps_unsent_fields(live_server) -> None:
             "enabled": "on",
             "name": "Stage",
             "destination_id": "dest-3",
-            "marker_id": "1",
+            "markers": "1",
             "trigger.type": "stream",
             "trigger.rate_hz": "30",
         },
@@ -412,7 +417,7 @@ def test_save_with_marker_fader_on_change_trigger(live_server) -> None:
             "host": "10.0.0.1",
             "port": "9000",
             "protocol": "udp",
-            "marker_id": "1",
+            "markers": "1",
             "osc_message": "/spot/[markerfader]",
             "trigger.type": "fader_on_change",
             "trigger.fader_source": "marker:1",
@@ -440,7 +445,7 @@ def test_save_with_indexed_fader_on_change_trigger(live_server) -> None:
             "host": "10.0.0.1",
             "port": "9000",
             "protocol": "udp",
-            "marker_id": "1",
+            "markers": "1",
             "osc_message": "/lvl/[fader:3]",
             "trigger.type": "fader_on_change",
             "trigger.fader_source": "index:3",
@@ -478,7 +483,7 @@ def test_trigger_form_lists_and_selects_marker_fader(
                 "host": "10.0.0.1",
                 "port": "9000",
                 "protocol": "udp",
-                "marker_id": "1",
+                "markers": "1",
                 "osc_message": "/spot/[markerfader]",
                 "trigger.type": "fader_on_change",
                 "trigger.fader_source": "marker:1",
@@ -792,7 +797,7 @@ def test_row_unresolved_placeholders_collapses_across_address_and_args() -> None
     address + every arg, with duplicates collapsed across the whole
     row. The pill JS treats them as one dependency per token."""
     row = OscTransmitterConfig(
-        marker_id=None,
+        markers=[],
         address="/eos/[markerid]/go",
         args=["[x]", "[x]", "[y:7]"],
     )
@@ -803,7 +808,7 @@ def test_row_unresolved_placeholders_collapses_across_address_and_args() -> None
 @pytest.mark.unit
 def test_row_unresolved_placeholders_empty_when_all_resolve() -> None:
     row = OscTransmitterConfig(
-        marker_id=1,
+        markers=["1"],
         address="/eos/[markerid]/go",
         args=["[x:1]"],
     )
@@ -817,12 +822,154 @@ def test_row_unresolved_placeholders_empty_for_literal_only_row() -> None:
     no marker is registered, and the UX must not flag them as
     unresolved either."""
     row = OscTransmitterConfig(
-        marker_id=None,
+        markers=[],
         address="/cue/go",
         args=["My Cue"],
     )
     out = _row_unresolved_placeholders(row, frozenset())
     assert out == ()
+
+
+class _FakeCatalog:
+    """Minimal marker-name lookup for the display-helper unit tests."""
+
+    def __init__(self, names: dict[int, str]) -> None:
+        self._names = names
+
+    def get(self, marker_id: int):  # noqa: ANN201 – duck-typed entry
+        name = self._names.get(marker_id)
+        if name is None:
+            return None
+        return type("_Entry", (), {"name": name})()
+
+
+@pytest.mark.unit
+def test_effective_default_marker_id_resolution() -> None:
+    """The unresolved-pill heuristic: a usable default marker exists when a
+    numeric id is controlled, or when a dynamic token (``all`` / ``cN``)
+    is named and the station controls at least one marker."""
+    # Numeric token in the registry → that id.
+    assert _effective_default_marker_id(["7"], frozenset({7})) == 7
+    # Numeric token not in the registry → no usable default.
+    assert _effective_default_marker_id(["7"], frozenset({1})) is None
+    # ``all`` / ``cN`` are dynamic → lowest registered id stands in.
+    assert _effective_default_marker_id(["all"], frozenset({5, 2})) == 2
+    assert _effective_default_marker_id(["c1"], frozenset({3})) == 3
+    # Dynamic token but nothing controlled → no usable default.
+    assert _effective_default_marker_id(["all"], frozenset()) is None
+    # No markers named → no usable default.
+    assert _effective_default_marker_id([], frozenset({1})) is None
+
+
+@pytest.mark.unit
+def test_marker_display_multi_marker_all_nested() -> None:
+    """A row with >1 markers nests every marker (primary included) as a chip
+    – no header badge – so they read uniformly."""
+    from openfollow.configuration import OscTransmittersConfig
+
+    cfg = AppConfig(
+        controlled_marker_ids=[1, 3, 7],
+        osc_transmitters=OscTransmittersConfig(
+            transmitters=[OscTransmitterConfig(id="r1", markers=["1", "3", "7"])],
+        ),
+    )
+    catalog = _FakeCatalog({1: "Marker 1", 3: "Sänger", 7: "Gitarre"})
+    display = _osc_binding_marker_display(cfg, catalog)
+    assert display["r1"]["header"] is None
+    assert display["r1"]["nested"] == [
+        {"label": "Marker 1 (1)", "controlled": True},
+        {"label": "Sänger (3)", "controlled": True},
+        {"label": "Gitarre (7)", "controlled": True},
+    ]
+    assert display["r1"]["markers_unusable"] is False
+
+
+@pytest.mark.unit
+def test_marker_display_single_marker_uses_header() -> None:
+    """A single marker shows in the header badge with no nested list; an
+    uncontrolled single marker sets ``markers_unusable`` True (red dot)."""
+    from openfollow.configuration import OscTransmittersConfig
+
+    cfg = AppConfig(
+        controlled_marker_ids=[1],
+        osc_transmitters=OscTransmittersConfig(
+            transmitters=[
+                OscTransmitterConfig(id="ok", markers=["1"]),
+                OscTransmitterConfig(id="bad", markers=["5"]),
+            ],
+        ),
+    )
+    display = _osc_binding_marker_display(cfg, _FakeCatalog({1: "Lead"}))
+    assert display["ok"] == {"header": "Lead (1)", "nested": [], "markers_unusable": False}
+    assert display["bad"] == {"header": "Marker 5 (5)", "nested": [], "markers_unusable": True}
+
+
+@pytest.mark.unit
+def test_marker_display_multi_marker_flags_uncontrolled_chip() -> None:
+    """In a multi-marker row each chip carries its own controlled flag; at least one is
+    controlled so ``markers_unusable`` is False (yellow dot)."""
+    from openfollow.configuration import OscTransmittersConfig
+
+    cfg = AppConfig(
+        controlled_marker_ids=[1],
+        osc_transmitters=OscTransmittersConfig(
+            transmitters=[OscTransmitterConfig(id="r1", markers=["1", "5"])],
+        ),
+    )
+    display = _osc_binding_marker_display(cfg, _FakeCatalog({}))
+    assert display["r1"]["header"] is None
+    assert display["r1"]["nested"] == [
+        {"label": "Marker 1 (1)", "controlled": True},
+        {"label": "Marker 5 (5)", "controlled": False},
+    ]
+    assert display["r1"]["markers_unusable"] is False
+
+
+@pytest.mark.unit
+def test_marker_display_all_token_nests_controlled() -> None:
+    from openfollow.configuration import OscTransmittersConfig
+
+    cfg = AppConfig(
+        controlled_marker_ids=[5, 2],
+        osc_transmitters=OscTransmittersConfig(
+            transmitters=[OscTransmitterConfig(id="r1", markers=["all"])],
+        ),
+    )
+    catalog = _FakeCatalog({2: "Diva"})
+    display = _osc_binding_marker_display(cfg, catalog)
+    assert display["r1"]["header"] is None
+    # Controlled markers, id-sorted; missing catalog name falls back to "Marker N".
+    assert display["r1"]["nested"] == [
+        {"label": "Diva (2)", "controlled": True},
+        {"label": "Marker 5 (5)", "controlled": True},
+    ]
+    assert display["r1"]["markers_unusable"] is False
+
+
+@pytest.mark.unit
+def test_marker_display_controller_alias_and_empty() -> None:
+    from openfollow.configuration import OscTransmittersConfig
+
+    cfg = AppConfig(
+        controlled_marker_ids=[1],
+        osc_transmitters=OscTransmittersConfig(
+            transmitters=[
+                OscTransmitterConfig(id="alias", markers=["1", "c2"]),
+                OscTransmitterConfig(id="empty", markers=[]),
+            ],
+        ),
+    )
+    catalog = _FakeCatalog({1: "Lead"})
+    display = _osc_binding_marker_display(cfg, catalog)
+    # >1 markers → both nested (alias always resolves to a controlled marker).
+    assert display["alias"]["header"] is None
+    assert display["alias"]["nested"] == [
+        {"label": "Lead (1)", "controlled": True},
+        {"label": "Controller c2", "controlled": True},
+    ]
+    assert display["alias"]["markers_unusable"] is False
+    # No markers → nothing, dot not reddened by markers.
+    assert display["empty"] == {"header": None, "nested": [], "markers_unusable": False}
 
 
 def test_save_with_empty_marker_id_persists_as_none(live_server) -> None:
@@ -837,11 +984,11 @@ def test_save_with_empty_marker_id_persists_as_none(live_server) -> None:
         base,
         f"/section/osc_binding/{row_id}",
         {
-            "marker_id": "",
+            "markers": "",
         },
     )
     cfg = load_config(cfg_path)
-    assert cfg.osc_transmitters.transmitters[0].marker_id is None
+    assert cfg.osc_transmitters.transmitters[0].markers == []
 
 
 def test_save_with_explicit_marker_id_persists_as_int(
@@ -858,11 +1005,11 @@ def test_save_with_explicit_marker_id_persists_as_int(
         base,
         f"/section/osc_binding/{row_id}",
         {
-            "marker_id": "1",
+            "markers": "1",
         },
     )
     cfg = load_config(cfg_path)
-    assert cfg.osc_transmitters.transmitters[0].marker_id == 1
+    assert cfg.osc_transmitters.transmitters[0].markers == ["1"]
 
 
 def test_save_coerces_enabled_false_when_default_marker_unresolved(
@@ -882,13 +1029,13 @@ def test_save_coerces_enabled_false_when_default_marker_unresolved(
         f"/section/osc_binding/{row_id}",
         {
             "enabled": "on",
-            "marker_id": "",
+            "markers": "",
             "osc_message": "/eos/1/go [x]",
         },
     )
     cfg = load_config(cfg_path)
     row = cfg.osc_transmitters.transmitters[0]
-    assert row.marker_id is None
+    assert row.markers == []
     assert row.enabled is False
     assert row.address == "/eos/1/go"
     assert row.args == ["[x]"]
@@ -910,13 +1057,13 @@ def test_save_coerces_enabled_false_for_unregistered_explicit_marker(
         f"/section/osc_binding/{row_id}",
         {
             "enabled": "on",
-            "marker_id": "1",  # default is registered, so [x] alone would be fine
+            "markers": "1",  # default is registered, so [x] alone would be fine
             "osc_message": "/multi [x:9]",  # marker 9 not registered
         },
     )
     cfg = load_config(cfg_path)
     row = cfg.osc_transmitters.transmitters[0]
-    assert row.marker_id == 1
+    assert row.markers == ["1"]
     assert row.enabled is False
 
 
@@ -935,7 +1082,7 @@ def test_save_keeps_enabled_true_when_all_placeholders_resolve(
         {
             "enabled": "on",
             # The live_server fixture seeds marker 1 in ``controlled_marker_ids``.
-            "marker_id": "1",
+            "markers": "1",
             "osc_message": "/eos/[markerid]/pos [x] [y]",
         },
     )
@@ -959,13 +1106,13 @@ def test_save_keeps_enabled_true_for_literal_only_row_without_marker(
         f"/section/osc_binding/{row_id}",
         {
             "enabled": "on",
-            "marker_id": "",
+            "markers": "",
             "osc_message": "/cue/go MyCue",
         },
     )
     cfg = load_config(cfg_path)
     row = cfg.osc_transmitters.transmitters[0]
-    assert row.marker_id is None
+    assert row.markers == []
     assert row.enabled is True
 
 
@@ -981,7 +1128,7 @@ def test_section_render_marks_unresolved_pill_in_dataset(live_server) -> None:
         OscTransmitterConfig(
             id="r-uns",
             name="Unset",
-            marker_id=None,
+            markers=[],
             address="/eos/1/go",
             args=["[x]"],
         ),
@@ -1093,7 +1240,7 @@ def test_section_render_no_unresolved_for_clean_row(live_server) -> None:
         OscTransmitterConfig(
             id="r-ok",
             name="Clean",
-            marker_id=1,
+            markers=["1"],
             address="/eos/[markerid]/pos",
             args=["[x]"],
         ),
@@ -1126,6 +1273,106 @@ def test_section_render_passes_registered_marker_ids_to_editor(
     assert "data-osc-registered-marker-ids" in body
     # Don't pin the exact JSON shape – Bottle's HTML escape can vary.
     assert "[1, 2, 5]" in body or "[1,2,5]" in body
+
+
+def _summary_dot_state(body: str, row_id: str) -> str:
+    """Return the summary (header) status-dot state for a row: the dot class
+    inside the row's ``<summary>``, scoped so nested-chip dots don't leak in."""
+    row = re.search(
+        r'data-row-id="' + re.escape(row_id) + r'".*?<summary[^>]*>(.*?)</summary>',
+        body,
+        re.S,
+    )
+    assert row is not None, f"row {row_id} not found"
+    dot = re.search(r"osc-binding-enabled-dot (on|off|invalid)", row.group(1))
+    assert dot is not None, "no status dot in summary"
+    return dot.group(1)
+
+
+def test_section_render_uncontrolled_secondary_is_red_chip_not_dot(live_server) -> None:
+    """A multi-marker row with a valid primary keeps a yellow (``on``) summary
+    dot; the uncontrolled secondary reddens only its own nested chip."""
+    _, base, cfg_path = live_server
+    cfg = load_config(cfg_path)
+    cfg.controlled_marker_ids = [1]
+    cfg.osc_destinations.destinations.append(OscDestinationConfig(id="d1", name="C", host="10.0.0.1", port=8001))
+    cfg.osc_transmitters.transmitters.append(
+        # Primary 1 controlled, secondary 5 not.
+        OscTransmitterConfig(id="r1", name="X", enabled=True, markers=["1", "5"], destination_id="d1"),
+    )
+    save_config(cfg, cfg_path)
+    status, body = _get(base, "/section/osc_bindings")
+    assert status == 200
+    # Summary dot stays yellow – at least one marker is controlled.
+    assert _summary_dot_state(body, "r1") == "on"
+    # The uncontrolled secondary shows a red chip.
+    assert "osc-binding-nested-row is-invalid" in body
+
+
+def test_section_render_no_controlled_marker_reddens_dot(live_server) -> None:
+    """A row that names markers but controls none of them can't send any, so
+    its summary dot is red."""
+    _, base, cfg_path = live_server
+    cfg = load_config(cfg_path)
+    cfg.controlled_marker_ids = [1]
+    cfg.osc_destinations.destinations.append(OscDestinationConfig(id="d1", name="C", host="10.0.0.1", port=8001))
+    cfg.osc_transmitters.transmitters.append(
+        OscTransmitterConfig(id="r1", name="X", markers=["5"], destination_id="d1"),
+    )
+    save_config(cfg, cfg_path)
+    status, body = _get(base, "/section/osc_bindings")
+    assert status == 200
+    assert _summary_dot_state(body, "r1") == "invalid"
+
+
+def test_section_render_invalid_message_reddens_dot(live_server) -> None:
+    """An unresolvable placeholder in the address/args (``[x:9]`` for an
+    unregistered marker) reddens the summary dot even when destination and
+    markers are fine."""
+    _, base, cfg_path = live_server
+    cfg = load_config(cfg_path)
+    cfg.controlled_marker_ids = [1]
+    cfg.osc_destinations.destinations.append(OscDestinationConfig(id="d1", name="C", host="10.0.0.1", port=8001))
+    cfg.osc_transmitters.transmitters.append(
+        OscTransmitterConfig(id="r1", name="X", markers=["1"], destination_id="d1", address="/eos", args=["[x:9]"]),
+    )
+    save_config(cfg, cfg_path)
+    status, body = _get(base, "/section/osc_bindings")
+    assert status == 200
+    assert _summary_dot_state(body, "r1") == "invalid"
+
+
+def test_section_render_marks_missing_destination_red(live_server) -> None:
+    """A transmitter with no destination can never fire, so its summary dot
+    is red even when its (single) marker is controlled."""
+    _, base, cfg_path = live_server
+    cfg = load_config(cfg_path)
+    cfg.controlled_marker_ids = [1]
+    cfg.osc_transmitters.transmitters.append(
+        OscTransmitterConfig(id="r1", name="X", markers=["1"]),  # no destination_id
+    )
+    save_config(cfg, cfg_path)
+    status, body = _get(base, "/section/osc_bindings")
+    assert status == 200
+    assert _summary_dot_state(body, "r1") == "invalid"
+
+
+def test_section_render_no_invalid_dot_when_valid(live_server) -> None:
+    """A row with a valid destination whose every named id is controlled
+    renders no ``invalid`` marker dot anywhere – the summary dot reflects
+    only enabled/disabled."""
+    _, base, cfg_path = live_server
+    cfg = load_config(cfg_path)
+    cfg.controlled_marker_ids = [1, 5]
+    cfg.osc_destinations.destinations.append(OscDestinationConfig(id="d1", name="C", host="10.0.0.1", port=8001))
+    cfg.osc_transmitters.transmitters.append(
+        OscTransmitterConfig(id="r1", name="X", markers=["1", "5"], destination_id="d1"),
+    )
+    save_config(cfg, cfg_path)
+    status, body = _get(base, "/section/osc_bindings")
+    assert status == 200
+    assert "osc-binding-enabled-dot invalid" not in body
+    assert "osc-binding-nested-row is-invalid" not in body
 
 
 def test_save_persists_explicit_markerN_placeholder(live_server) -> None:
@@ -1326,6 +1573,24 @@ def test_initial_page_render_with_osc_row_includes_framing_dropdown(live_server)
     # ``<option value="slip">`` confirms the loop over valid_framings ran.
     assert 'value="slip"' in body
     assert 'value="length_prefix"' in body
+
+
+def test_initial_page_render_shows_nested_markers(live_server) -> None:
+    """A multi-marker row's nested chips must render on the first index page
+    load, not only after a save – ``index()`` builds the same marker context
+    the section render does."""
+    _, base, cfg_path = live_server
+    cfg = load_config(cfg_path)
+    cfg.controlled_marker_ids = [1, 3]
+    cfg.osc_transmitters.transmitters.append(
+        OscTransmitterConfig(id="r1", name="X", markers=["1", "3"]),
+    )
+    save_config(cfg, cfg_path)
+    status, body = _get(base, "/")
+    assert status == 200
+    assert 'class="osc-binding-nested"' in body
+    assert "Marker 1 (1)" in body
+    assert "Marker 3 (3)" in body
 
 
 def test_add_with_unknown_template_id_falls_back_to_blank_row(live_server) -> None:
@@ -2060,7 +2325,7 @@ def test_apply_osc_binding_fields_top_level_and_trigger() -> None:
             "enabled": "on",
             "name": "X",
             "destination_id": "dest-9",
-            "marker_id": "3",
+            "markers": "3",
             "osc_message": "/foo [x] [y]",
             "trigger.type": "stream",
             "trigger.rate_hz": "60",
@@ -2069,7 +2334,7 @@ def test_apply_osc_binding_fields_top_level_and_trigger() -> None:
     assert row.name == "X"
     assert row.enabled is True
     assert row.destination_id == "dest-9"
-    assert row.marker_id == 3
+    assert row.markers == ["3"]
     assert row.address == "/foo"
     assert row.args == ["[x]", "[y]"]
     assert isinstance(row.trigger, StreamTrigger)
@@ -2087,10 +2352,10 @@ def test_apply_osc_binding_fields_without_osc_message_keeps_address_and_args() -
 
 def test_apply_osc_binding_fields_skips_missing_fields() -> None:
     row = OscTransmitterConfig(name="seed", destination_id="seed-dest")
-    _apply_osc_binding_fields(row, {"marker_id": "3"})
+    _apply_osc_binding_fields(row, {"markers": "3"})
     assert row.name == "seed"
     assert row.destination_id == "seed-dest"
-    assert row.marker_id == 3
+    assert row.markers == ["3"]
 
 
 def test_apply_osc_binding_fields_no_trigger_keys_keeps_trigger() -> None:
@@ -2330,7 +2595,7 @@ def test_validate_osc_message_blurs_clean_when_default_marker_set(
     _, base, _ = live_server
     status, body = _get(
         base,
-        "/api/validate/osc_binding/osc_message?osc_message=%2Feos+%5Bx%5D&marker_id=1",
+        "/api/validate/osc_binding/osc_message?osc_message=%2Feos+%5Bx%5D&markers=1",
     )
     assert status == 200
     assert body == ""
@@ -2344,7 +2609,7 @@ def test_validate_osc_message_surfaces_missing_default_marker(
     _, base, _ = live_server
     status, body = _get(
         base,
-        "/api/validate/osc_binding/osc_message?osc_message=%2Feos+%5Bx%5D&marker_id=",
+        "/api/validate/osc_binding/osc_message?osc_message=%2Feos+%5Bx%5D&markers=",
     )
     assert status == 200
     assert "[x]" in body
@@ -2365,14 +2630,14 @@ def test_validate_osc_message_surfaces_unregistered_explicit_marker(
     _, base, _ = live_server
     status, body = _get(
         base,
-        "/api/validate/osc_binding/osc_message?osc_message=%2Feos+%5Bx%3A9%5D&marker_id=1",
+        "/api/validate/osc_binding/osc_message?osc_message=%2Feos+%5Bx%3A9%5D&markers=1",
     )
     assert status == 200
     assert "[x:9]" in body
     assert "isn" in body  # "isn't registered"
 
 
-def test_validate_marker_id_surfaces_message_dependency_error(
+def test_validate_markers_surfaces_message_dependency_error(
     live_server,
 ) -> None:
     """Symmetric: the ``marker_id`` blur endpoint also surfaces the
@@ -2381,7 +2646,7 @@ def test_validate_marker_id_surfaces_message_dependency_error(
     _, base, _ = live_server
     status, body = _get(
         base,
-        "/api/validate/osc_binding/marker_id?marker_id=&osc_message=%2Feos+%5Bx%5D",
+        "/api/validate/osc_binding/markers?markers=&osc_message=%2Feos+%5Bx%5D",
     )
     assert status == 200
     assert "[x]" in body
@@ -2397,7 +2662,7 @@ def test_validate_osc_message_with_explicit_markerid_no_error(
     _, base, _ = live_server
     status, body = _get(
         base,
-        "/api/validate/osc_binding/osc_message?osc_message=%2Feos%2F%5Bmarkerid%3A9%5D%2Fgo&marker_id=1",
+        "/api/validate/osc_binding/osc_message?osc_message=%2Feos%2F%5Bmarkerid%3A9%5D%2Fgo&markers=1",
     )
     assert status == 200
     assert body == ""
@@ -2411,13 +2676,13 @@ def test_validate_osc_message_blurs_clean_for_literal_only_message(
     _, base, _ = live_server
     status, body = _get(
         base,
-        "/api/validate/osc_binding/osc_message?osc_message=%2Fcue%2Fgo+MyCue&marker_id=",
+        "/api/validate/osc_binding/osc_message?osc_message=%2Fcue%2Fgo+MyCue&markers=",
     )
     assert status == 200
     assert body == ""
 
 
-def test_validate_marker_id_blurs_clean_when_no_message_present(
+def test_validate_markers_blurs_clean_when_no_message_present(
     live_server,
 ) -> None:
     """The ``marker_id`` endpoint also runs the cross-field check,
@@ -2427,13 +2692,13 @@ def test_validate_marker_id_blurs_clean_when_no_message_present(
     _, base, _ = live_server
     status, body = _get(
         base,
-        "/api/validate/osc_binding/marker_id?marker_id=&osc_message=",
+        "/api/validate/osc_binding/markers?markers=&osc_message=",
     )
     assert status == 200
     assert body == ""
 
 
-def test_validate_marker_id_blurs_clean_when_message_key_omitted(
+def test_validate_markers_blurs_clean_when_message_key_omitted(
     live_server,
 ) -> None:
     """If a blur sends only ``marker_id`` (no ``osc_message`` key), the
@@ -2443,42 +2708,50 @@ def test_validate_marker_id_blurs_clean_when_message_key_omitted(
     _, base, _ = live_server
     status, body = _get(
         base,
-        "/api/validate/osc_binding/marker_id?marker_id=5",
+        "/api/validate/osc_binding/markers?markers=5",
     )
     assert status == 200
     assert body == ""
 
 
-def test_validate_osc_message_suppresses_default_warn_for_invalid_marker_id(
-    live_server,
-) -> None:
-    """When the sibling ``marker_id`` field is filled with a value
-    that doesn't parse as a non-negative integer (``"abc"``, ``"-1"``,
-    ``"1.5"``), the cross-field validator must not surface the
-    "needs a default marker" warning. The field-level numeric-shape
-    blur on ``marker_id`` surfaces the actual error; doubling up here
-    would mislead the operator into thinking the field is empty."""
+def test_validate_markers_flags_malformed_token(live_server) -> None:
+    """A malformed ``markers`` entry (junk / negative / bad alias) blurs
+    with a hard field-error naming the offending entry. The runtime drops
+    such tokens, but the operator gets feedback on the typo."""
     _, base, _ = live_server
-    for bad in ("abc", "-1", "1.5"):
+    for bad in ("bogus", "-1", "c0"):
         status, body = _get(
             base,
-            "/api/validate/osc_binding/osc_message?osc_message=%2Feos+%5Bx%5D&marker_id=" + bad,
+            "/api/validate/osc_binding/markers?markers=1," + bad,
         )
         assert status == 200, f"bad input: {bad!r}"
-        assert body == "", f"expected suppression for marker_id={bad!r}, got {body!r}"
+        assert 'class="field-error-msg"' in body, f"expected error for {bad!r}, got {body!r}"
+        assert bad in body
 
 
-def test_validate_osc_message_keeps_explicit_warn_when_marker_id_invalid(
-    live_server,
-) -> None:
-    """The invalid-``marker_id`` suppression only applies to the
-    default-marker arm. ``[x:9]`` is unrelated to the operator's
-    ``marker_id`` field, so its "references a marker that isn't
-    registered" warning still surfaces."""
+def test_validate_markers_allows_non_controlled_id(live_server) -> None:
+    """A syntactically-valid id this station doesn't control is ignored at
+    send time, not flagged – the markers field blurs clean. The fixture
+    controls only marker 1."""
     _, base, _ = live_server
     status, body = _get(
         base,
-        "/api/validate/osc_binding/osc_message?osc_message=%2Feos+%5Bx%3A9%5D&marker_id=abc",
+        "/api/validate/osc_binding/markers?markers=5",
+    )
+    assert status == 200
+    assert 'class="field-error-msg"' not in body
+
+
+def test_validate_osc_message_keeps_explicit_warn_regardless_of_markers(
+    live_server,
+) -> None:
+    """An explicit ``[x:9]`` is independent of the ``markers`` field, so its
+    "references a marker that isn't registered" warning surfaces even when
+    ``markers`` carries malformed tokens."""
+    _, base, _ = live_server
+    status, body = _get(
+        base,
+        "/api/validate/osc_binding/osc_message?osc_message=%2Feos+%5Bx%3A9%5D&markers=bogus",
     )
     assert status == 200
     assert "[x:9]" in body
@@ -2496,7 +2769,7 @@ def test_validate_osc_message_collapses_duplicate_unresolved_tokens(
     _, base, _ = live_server
     status, body = _get(
         base,
-        "/api/validate/osc_binding/osc_message?osc_message=%2Feos+%5Bx%5D+%5Bx%5D+%5Bx%5D&marker_id=",
+        "/api/validate/osc_binding/osc_message?osc_message=%2Feos+%5Bx%5D+%5Bx%5D+%5Bx%5D&markers=",
     )
     assert status == 200
     assert body.count("[x]") == 1
@@ -2630,7 +2903,7 @@ class TestPhaseBTriggerSaveRoundTrip:
                 "host": "127.0.0.1",
                 "port": "9000",
                 "protocol": "udp",
-                "marker_id": "",
+                "markers": "",
                 "default_fader": "",
                 "osc_message": "/cue/[value]",
                 "trigger.type": "midi_message",
@@ -2665,7 +2938,7 @@ class TestPhaseBTriggerSaveRoundTrip:
                 "host": "127.0.0.1",
                 "port": "9000",
                 "protocol": "udp",
-                "marker_id": "",
+                "markers": "",
                 "default_fader": "1",
                 "osc_message": "/level/[fader]",
                 "trigger.type": "fader_on_change",

--- a/tests/test_web_routes_unit.py
+++ b/tests/test_web_routes_unit.py
@@ -271,7 +271,7 @@ class TestAsOptionalInt:
 
     def test_bool_collapses_to_none(self) -> None:
         """``bool`` is an ``int`` subclass, so a crafted POST with
-        ``marker_id=true`` would otherwise silently save marker 1.
+        ``default_fader=true`` would otherwise silently save fader 1.
         ``OscTransmitterConfig.__post_init__`` already collapses bool
         inputs to ``None``; the web parser agrees so save-time and
         POST-time coercion stay in lockstep."""

--- a/tests/test_web_templates.py
+++ b/tests/test_web_templates.py
@@ -476,7 +476,7 @@ class TestApplyOscOutput:
 
     def test_apply_restores_extended_fields(self, live_server) -> None:
         # Apply restores name / host / port / protocol / address / args /
-        # rate_hz / trigger; ``enabled`` and ``marker_id`` are forced to
+        # rate_hz / trigger; ``enabled`` and ``markers`` are forced to
         # apply-time defaults regardless of payload.
         _, base, cfg_path = live_server
         write_user_template(
@@ -515,10 +515,10 @@ class TestApplyOscOutput:
         self,
         live_server,
     ) -> None:
-        # The strict schema refuses ``enabled`` / ``marker_id`` keys at
+        # The strict schema refuses ``enabled`` / ``markers`` keys at
         # load time, so apply never sees them. This exercises the apply
         # contract for a legitimate template: force ``enabled=False`` and
-        # ``marker_id=None``.
+        # empty ``markers``.
         _, base, cfg_path = live_server
         write_user_template(
             _templates_root(cfg_path),
@@ -534,10 +534,10 @@ class TestApplyOscOutput:
         cfg = load_config(cfg_path)
         row = cfg.osc_transmitters.transmitters[0]
         assert row.enabled is False
-        assert row.marker_id is None
+        assert row.markers == []
 
     def test_strict_schema_refuses_enabled_key(self) -> None:
-        # ``enabled`` / ``marker_id`` are excluded from the schema (apply
+        # ``enabled`` / ``markers`` are excluded from the schema (apply
         # forces both; they belong to the binding, not the template).
         # The writer's strict-schema gate refuses them before any write.
         from openfollow.templates.schema import TemplateValidationError
@@ -548,7 +548,7 @@ class TestApplyOscOutput:
                 Path("/tmp"),  # noqa: S108 – never reached
                 "osc_output",
                 "Hot",
-                {"address": "/x", "enabled": True, "marker_id": 7},
+                {"address": "/x", "enabled": True, "markers": ["7"]},
             )
 
 
@@ -571,7 +571,7 @@ class TestSaveOscBindingAsTemplate:
                 "template_name": "Stage Cue",
                 "name": "Stage Cue (live)",
                 "destination_id": "dest-99",
-                "marker_id": "0",
+                "markers": "0",
                 "trigger.type": "stream",
                 "trigger.rate_hz": "60",
                 "osc_message": "/cue/[markerid]/go [x]",
@@ -594,10 +594,10 @@ class TestSaveOscBindingAsTemplate:
         assert p["rate_hz"] == 60
         assert p["trigger"]["kind"] == "stream"
         assert p["trigger"]["rate_hz"] == 60
-        # ``enabled`` / ``marker_id`` are dropped even though the form
-        # supplied a marker_id.
+        # ``enabled`` / ``markers`` are dropped even though the form
+        # supplied markers.
         assert "enabled" not in p
-        assert "marker_id" not in p
+        assert "markers" not in p
 
     def test_rejects_missing_template_name(self, live_server) -> None:
         _, base, cfg_path = live_server
@@ -733,7 +733,7 @@ class TestSaveOscBindingAsTemplate:
         assert applied.args == ["[x]"]
         assert applied.rate_hz == 20
         assert applied.enabled is False  # forced
-        assert applied.marker_id is None  # forced
+        assert applied.markers == []  # forced
 
 
 class TestApplyCameraGrid:


### PR DESCRIPTION
  ## Summary
  An OSC transmitter can now drive **more than one marker** from a single row. The "Default marker" field becomes a comma-separated **"Default markers"** list, where each entry is a marker id, a
  controller alias (`c1`, `c2`, …), or `all`. A row with multiple markers behaves like that many independent transmitters: the same message / trigger / destination is sent once per resolved
  marker, each rendered against its own position.
  
  The lowest id is the **primary** (shown in the row header); the rest render as read-only chips **nested** beneath it. Markers this station doesn't control are marked with a red status dot so
  the operator can see they won't send.

  > Replaces the single `OscTransmitterConfig.marker_id` with a `markers` list. Existing configs upgrade automatically.

  ## Behavior

  **Field grammar** — comma-separated; each entry is `<marker id>` | `cN` | `all`.
  - `all` expands to every marker in `controlled_marker_ids`, re-evaluated live (no restart) as the controlled set changes.
  - `cN` resolves to the marker that controller currently drives; if it drives nothing (disconnected / unselected), that one send is skipped while the row's other markers still send.
  - Tokens are de-duplicated and ordered: numeric ids ascending, then aliases. `all` collapses the list.

  **Validity** 
  - **Malformed** tokens (`bogus`, `c0`, `-1`) are dropped and blocked on the form with a blur error so you fix the typo.
  - A **valid id this station doesn't control** is ignored at send time (per the "only controlled ids" rule) and shown with a **red status dot** — on the row header and on its nested chip, with 
  a "Not controlled by this station (ignored)" tooltip. Controller aliases and `all` always resolve to controlled markers, so they're never flagged.

  **Sending**
  - One independent send per resolved marker.
  - A row whose message doesn't reference the default marker (constant text, or only explicit `[x:2]`-style refs) still sends **once**, not N duplicate packets.
  - The on-change gate is tracked per `(row, marker)`, so one marker moving doesn't suppress another marker's send.
  - Diagnostics preview / test-send show the primary (lowest) marker; the live path fires every marker.
  
  ## Implementation
  - **`configuration.py`** — `marker_id: int | None` → `markers: list[str]`; new `_coerce_marker_tokens` + the `cN` / `all` grammar. A legacy single `marker_id` in TOML lifts into the new list
  on load.
  - **`osc/transmitter.py`** — add a `controlled_markers_provider`; split `_plan_for_row` into `_resolve_marker_ids` + `_plans_for_row` (returns a list) + `_build_plan` so every dispatch path
  fans out one plan per resolved marker. On-change cache rekeyed `(row_id, marker_id)`.
  - **`services.py`** — wire the controlled-markers provider from `app._controlled_ids`.
  - **`web/routes.py`, `web/validation.py`** — `markers` form parser + `FieldRule` / `_validate_markers`; an effective-default-marker heuristic for the unresolved-pill / blur check;
  `_osc_binding_marker_display` builds per-row badge + nested-chip data carrying a `controlled` flag and a row-level `has_invalid` that turns the status dot red.
  - **`templates/partials/osc_bindings.tpl`, `base.tpl`** — CSV input, summary marker badge, nested chips; red `invalid` state reusing the existing `.osc-binding-enabled-dot`; JS 
  unresolved-recompute reads the multi-token field.
  - **`help/osc_bindings.md`** — documents the list grammar, `all` / `cN`, and the red indicator.

  ## Backward compatibility
  - TOML rows carrying the old `marker_id` key load unchanged (lifted into `markers`).
  - Single-marker rows keep their exact prior behavior.
  - OSC routing is never peer-broadcast, so the field change doesn't cross machines.

  ## Testing
  - **Config:** token parse / dedupe / order, `all` collapse, invalid-drop, legacy `marker_id` lift, TOML round-trip.
  - **Transmitter:** `TestMultiMarkerFanOut` — fan-out, per-marker on-change, live `all` re-expansion, controlled filtering, alias resolve / skip, single-send for marker-independent rows.
  - **Web:** marker-display helper incl. uncontrolled marking, validation cases, and HTML-level render regressions asserting the red `invalid` dot / `is-invalid` chip appear (and don't, when all
  controlled).
