### PR TITLE
Install scripts: surface clock-skew and stale-index causes

### DIFF
--- a/scripts/install-detection.sh
+++ b/scripts/install-detection.sh
@@ -123,7 +123,7 @@ Fix the clock, then re-run this script:
   sudo systemctl restart systemd-timesyncd
   timedatectl status         # wait for: System clock synchronized: yes
 If NTP cannot reach a server (UDP port 123 is often blocked), set it by hand:
-  sudo date -s 'YYYY-MM-DD HH:MM:SS'    # real current UTC time
+  sudo date -u -s 'YYYY-MM-DD HH:MM:SS'    # real current UTC time (-u = interpret as UTC)
 MSG
 }
 
@@ -208,7 +208,7 @@ main() {
   # failure can be classified: a wrong clock surfaces a clear fix instead of a
   # raw SSL traceback.
   local pip_log
-  pip_log="$(mktemp 2>/dev/null || echo /tmp/openfollow-install-detection-pip.log)"
+  pip_log="$(mktemp 2>/dev/null || echo "/tmp/openfollow-install-detection-pip.$$.log")"
   trap 'rm -f "$pip_log"' EXIT
 
   log "Installing CPU-only torch + torchvision (PyTorch CPU index)…"

--- a/scripts/install-detection.sh
+++ b/scripts/install-detection.sh
@@ -104,6 +104,29 @@ config_path() {
   fi
 }
 
+# True when pip output shows a certificate that is not valid yet, i.e. the
+# system clock is behind real time (no RTC + NTP not synced is the usual Pi
+# cause) so TLS verification of PyPI / the torch index fails. Reads the
+# captured output on stdin.
+clock_skew_in() {
+  grep -qiE 'not yet valid|is not valid yet|not live until' 2>/dev/null
+}
+
+clock_skew_message() {
+  cat <<'MSG'
+the system clock is wrong, so TLS certificates fail to verify
+("certificate is not yet valid") and pip cannot download the detection
+packages over HTTPS.
+
+Fix the clock, then re-run this script:
+  sudo timedatectl set-ntp true
+  sudo systemctl restart systemd-timesyncd
+  timedatectl status         # wait for: System clock synchronized: yes
+If NTP cannot reach a server (UDP port 123 is often blocked), set it by hand:
+  sudo date -s 'YYYY-MM-DD HH:MM:SS'    # real current UTC time
+MSG
+}
+
 # --- main ------------------------------------------------------------------
 
 main() {
@@ -181,12 +204,23 @@ main() {
   #     drops the ~400 MiB of unused CUDA libs the default wheel bundles; on
   #     aarch64 the default wheel is already CPU-only, so it's a no-op win there.
   #     Fall back to the default wheel when no CPU build exists for this platform.
+  # Capture each pip run's output (while still streaming it live via tee) so a
+  # failure can be classified: a wrong clock surfaces a clear fix instead of a
+  # raw SSL traceback.
+  local pip_log
+  pip_log="$(mktemp 2>/dev/null || echo /tmp/openfollow-install-detection-pip.log)"
+  trap 'rm -f "$pip_log"' EXIT
+
   log "Installing CPU-only torch + torchvision (PyTorch CPU index)…"
   # shellcheck disable=SC2086
-  if ! $sudo_pip env $pip_env "$venv_py" -m pip install --index-url https://download.pytorch.org/whl/cpu torch torchvision; then
+  if ! $sudo_pip env $pip_env "$venv_py" -m pip install --index-url https://download.pytorch.org/whl/cpu torch torchvision 2>&1 | tee "$pip_log"; then
+    if clock_skew_in <"$pip_log"; then die "$(clock_skew_message)"; fi
     warn "CPU-only torch install failed; falling back to the default wheel (on x86_64 this also pulls unused CUDA libs)."
     # shellcheck disable=SC2086
-    $sudo_pip env $pip_env "$venv_py" -m pip install torch torchvision
+    if ! $sudo_pip env $pip_env "$venv_py" -m pip install torch torchvision 2>&1 | tee "$pip_log"; then
+      if clock_skew_in <"$pip_log"; then die "$(clock_skew_message)"; fi
+      die "pip could not install torch/torchvision – see the output above. Check the network connection and re-run."
+    fi
   fi
   # onnx + onnxslim land in the venv here so the export never falls back to a
   # per-user pip install (the packaged venv is root-owned and a venv doesn't
@@ -194,7 +228,10 @@ main() {
   # 'onnx'" until now.
   log "Installing onnxruntime + opencv-python + the export tools (ultralytics + onnx + onnxslim)…"
   # shellcheck disable=SC2086
-  $sudo_pip env $pip_env "$venv_py" -m pip install "onnxruntime>=1.17" "opencv-python>=4.8" ultralytics onnx onnxslim
+  if ! $sudo_pip env $pip_env "$venv_py" -m pip install "onnxruntime>=1.17" "opencv-python>=4.8" ultralytics onnx onnxslim 2>&1 | tee "$pip_log"; then
+    if clock_skew_in <"$pip_log"; then die "$(clock_skew_message)"; fi
+    die "pip could not install the detection backend – see the output above. Check the network connection and re-run."
+  fi
 
   # --- Verify --------------------------------------------------------------
   # The detection backend is onnxruntime + opencv (the hard gate); the export

--- a/scripts/install-ndi.sh
+++ b/scripts/install-ndi.sh
@@ -51,7 +51,7 @@ Fix the clock, then re-run this script:
   sudo systemctl restart systemd-timesyncd
   timedatectl status         # wait for: System clock synchronized: yes
 If NTP cannot reach a server (UDP port 123 is often blocked), set it by hand:
-  sudo date -s 'YYYY-MM-DD HH:MM:SS'    # real current UTC time
+  sudo date -u -s 'YYYY-MM-DD HH:MM:SS'    # real current UTC time (-u = interpret as UTC)
 Then refresh the index and re-run:
   sudo apt-get update && sudo apt-get full-upgrade -y
 MSG
@@ -66,7 +66,7 @@ wrong). Refresh and reconcile, then re-run this script:
   sudo apt-get update
   sudo apt-get full-upgrade -y
 If apt-get update reports signatures "Not live until <future date>", fix the
-system clock first (timedatectl / sudo date -s).
+system clock first (timedatectl / sudo date -u -s).
 MSG
 }
 # === end diagnostics =======================================================
@@ -110,7 +110,7 @@ fi
 # The minimal Pi OS Lite image omits several of these; install-system-deps.sh
 # covers the runtime set but not the GStreamer -dev headers the plugin needs.
 log "Installing build prerequisites (apt)…"
-apt_log="$(mktemp 2>/dev/null || echo /tmp/openfollow-install-ndi-apt.log)"
+apt_log="$(mktemp 2>/dev/null || echo "/tmp/openfollow-install-ndi-apt.$$.log")"
 trap 'rm -f "$apt_log"' EXIT
 if ! sudo env DEBIAN_FRONTEND=noninteractive apt-get update 2>&1 | tee "$apt_log"; then
   # A failed update is fatal only when it's a wrong-clock signature failure –

--- a/scripts/install-ndi.sh
+++ b/scripts/install-ndi.sh
@@ -24,6 +24,53 @@ die() {
   exit 1
 }
 
+# === clock / index diagnostics (pure; sourced by tests) ====================
+# True when apt output shows a future-dated signature ("Not live until …"),
+# i.e. the system clock is behind real time – the usual Pi cause being no RTC
+# plus NTP not yet synced. Reads the captured output on stdin.
+clock_skew_in() {
+  grep -qiE 'not live until|not yet valid|is not valid yet' 2>/dev/null
+}
+
+# True when apt could not resolve dependencies. On Raspberry Pi OS this is
+# almost always a stale / inconsistent index (a failed apt-get update), not a
+# genuine conflict. Reads the captured output on stdin.
+broken_index_in() {
+  grep -qiE 'held broken packages|unmet dependencies|unable to correct problems' 2>/dev/null
+}
+
+clock_skew_message() {
+  cat <<'MSG'
+the system clock is wrong, so APT rejects the repository signatures as
+"Not live until <future date>" and cannot refresh the package index. The
+dependency errors that follow are a side effect of the stale index, not a real
+package conflict.
+
+Fix the clock, then re-run this script:
+  sudo timedatectl set-ntp true
+  sudo systemctl restart systemd-timesyncd
+  timedatectl status         # wait for: System clock synchronized: yes
+If NTP cannot reach a server (UDP port 123 is often blocked), set it by hand:
+  sudo date -s 'YYYY-MM-DD HH:MM:SS'    # real current UTC time
+Then refresh the index and re-run:
+  sudo apt-get update && sudo apt-get full-upgrade -y
+MSG
+}
+
+broken_index_message() {
+  cat <<'MSG'
+APT could not install the build prerequisites: the package index is
+inconsistent. On Raspberry Pi OS this almost always means the index is stale
+(apt-get update did not refresh it, frequently because the system clock was
+wrong). Refresh and reconcile, then re-run this script:
+  sudo apt-get update
+  sudo apt-get full-upgrade -y
+If apt-get update reports signatures "Not live until <future date>", fix the
+system clock first (timedatectl / sudo date -s).
+MSG
+}
+# === end diagnostics =======================================================
+
 FORCE=0
 RESTART_SERVICE=1
 SDK_TARBALL=""
@@ -63,13 +110,31 @@ fi
 # The minimal Pi OS Lite image omits several of these; install-system-deps.sh
 # covers the runtime set but not the GStreamer -dev headers the plugin needs.
 log "Installing build prerequisites (apt)…"
-if ! sudo env DEBIAN_FRONTEND=noninteractive apt-get update; then
+apt_log="$(mktemp 2>/dev/null || echo /tmp/openfollow-install-ndi-apt.log)"
+trap 'rm -f "$apt_log"' EXIT
+if ! sudo env DEBIAN_FRONTEND=noninteractive apt-get update 2>&1 | tee "$apt_log"; then
+  # A failed update is fatal only when it's a wrong-clock signature failure –
+  # pressing on with the stale index then produces a cryptic dependency
+  # conflict. A plain unreachable-mirror failure still falls through to the
+  # cached index (works on a fully-provisioned offline Pi).
+  if clock_skew_in <"$apt_log"; then
+    die "$(clock_skew_message)"
+  fi
   log "WARN: apt-get update failed; proceeding with cached index"
 fi
-sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+if ! sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
   curl git build-essential pkg-config \
   meson ninja-build gstreamer1.0-tools \
-  libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libglib2.0-dev libssl-dev
+  libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libglib2.0-dev libssl-dev \
+  2>&1 | tee "$apt_log"; then
+  if clock_skew_in <"$apt_log"; then
+    die "$(clock_skew_message)"
+  fi
+  if broken_index_in <"$apt_log"; then
+    die "$(broken_index_message)"
+  fi
+  die "apt-get could not install the NDI build prerequisites – see the output above."
+fi
 
 # --- 2. NDI® SDK runtime (libndi.so.*) -------------------------------------
 if ls /usr/local/lib/libndi.so.* >/dev/null 2>&1; then

--- a/tests/test_install_detection.py
+++ b/tests/test_install_detection.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import inspect
 import os
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -129,3 +130,61 @@ def test_ultralytics_is_a_soft_dependency_not_a_hard_gate() -> None:
     assert "import ultralytics, onnx" in text
     assert 'die "detection backend' in text
     assert 'die "ultralytics' not in text and "die 'ultralytics" not in text
+
+
+# --- clock-skew diagnostics -------------------------------------------------
+
+
+def _classify(sample: str) -> subprocess.CompletedProcess[str]:
+    # Pipe a captured-output sample through clock_skew_in and report the verdict.
+    return _run(f"printf '%s' {shlex.quote(sample)} | clock_skew_in && echo SKEW || echo CLEAN")
+
+
+@pytest.mark.parametrize(
+    "sample",
+    [
+        # The pip / TLS form: a wrong clock makes PyPI's cert look future-dated.
+        "ERROR: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate is not yet valid (_ssl.c:1006)",
+        # The apt-style wording, in case a clock-skew run logs it.
+        "Verifying signature: Not live until 2026-06-25T01:42:42Z",
+    ],
+)
+def test_clock_skew_in_detects_future_dated_tls(sample: str) -> None:
+    r = _classify(sample)
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip() == "SKEW"
+
+
+@pytest.mark.parametrize(
+    "sample",
+    [
+        "Successfully installed onnxruntime-1.17.0 opencv-python-4.8.0",
+        "ERROR: Could not find a version that satisfies the requirement foo",
+        "ERROR: connection timed out",
+        # A plain cert-verify failure (bad CA, MITM) is NOT a clock problem and
+        # must not be misattributed to the clock.
+        "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate",
+    ],
+)
+def test_clock_skew_in_ignores_unrelated_failures(sample: str) -> None:
+    r = _classify(sample)
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip() == "CLEAN"
+
+
+def test_clock_skew_message_is_actionable() -> None:
+    r = _run("clock_skew_message")
+    assert r.returncode == 0, r.stderr
+    out = r.stdout
+    assert "clock" in out.lower()
+    assert "timedatectl" in out
+    assert "date -s" in out
+
+
+def test_pip_failures_route_through_clock_skew_check() -> None:
+    text = _script().read_text()
+    # Every pip install path must capture output and consult clock_skew_in on
+    # failure, so a wrong clock surfaces as the fix, not a raw SSL traceback.
+    assert 'die "$(clock_skew_message)"' in text
+    # torch (incl. fallback) + the backend install = at least three checks.
+    assert text.count("clock_skew_in <") >= 3

--- a/tests/test_install_detection.py
+++ b/tests/test_install_detection.py
@@ -178,7 +178,10 @@ def test_clock_skew_message_is_actionable() -> None:
     out = r.stdout
     assert "clock" in out.lower()
     assert "timedatectl" in out
-    assert "date -s" in out
+    # ``date -u -s`` so the "enter UTC" instruction is correct regardless of the
+    # host timezone; the ambiguous bare ``date -s '...'`` form must be gone.
+    assert "date -u -s" in out
+    assert "date -s '" not in out
 
 
 def test_pip_failures_route_through_clock_skew_check() -> None:
@@ -188,3 +191,10 @@ def test_pip_failures_route_through_clock_skew_check() -> None:
     assert 'die "$(clock_skew_message)"' in text
     # torch (incl. fallback) + the backend install = at least three checks.
     assert text.count("clock_skew_in <") >= 3
+
+
+def test_pip_log_fallback_path_is_unique_per_run() -> None:
+    # When mktemp fails, the fallback log path must be PID-suffixed so concurrent
+    # runs can't collide on (or clobber a pre-existing) fixed /tmp file.
+    text = _script().read_text()
+    assert 'echo "/tmp/openfollow-install-detection-pip.$$.log"' in text

--- a/tests/test_install_ndi.py
+++ b/tests/test_install_ndi.py
@@ -174,7 +174,11 @@ def test_broken_index_in_detects_dependency_conflicts(sample: str) -> None:
 def test_diagnostic_messages_are_actionable() -> None:
     skew = _run_diag("clock_skew_message")
     assert "clock" in skew.stdout.lower()
-    assert "timedatectl" in skew.stdout and "date -s" in skew.stdout
+    # ``date -u -s`` (not bare ``date -s``): the manual instruction tells the
+    # operator to enter UTC, and ``-u`` makes ``date`` interpret it as UTC
+    # regardless of the host's timezone.
+    assert "timedatectl" in skew.stdout and "date -u -s" in skew.stdout
+    assert "date -s '" not in skew.stdout  # the timezone-ambiguous form is gone
     broken = _run_diag("broken_index_message")
     assert "full-upgrade" in broken.stdout
 
@@ -186,3 +190,10 @@ def test_apt_failures_are_wired_to_the_diagnostics() -> None:
     assert text.count('die "$(clock_skew_message)"') >= 2
     assert 'die "$(broken_index_message)"' in text
     assert "clock_skew_in <" in text and "broken_index_in <" in text
+
+
+def test_apt_log_fallback_path_is_unique_per_run() -> None:
+    # When mktemp fails, the fallback log path must be PID-suffixed so concurrent
+    # runs can't collide on (or clobber a pre-existing) fixed /tmp file.
+    text = _install_ndi_path().read_text()
+    assert 'echo "/tmp/openfollow-install-ndi-apt.$$.log"' in text

--- a/tests/test_install_ndi.py
+++ b/tests/test_install_ndi.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import inspect
 import os
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -18,6 +19,30 @@ def _install_ndi_path() -> Path:
     source = inspect.getsourcefile(_install_ndi_path)
     assert source, "Could not resolve current test source path"
     return Path(source).resolve().parents[1] / "scripts" / "install-ndi.sh"
+
+
+def _diagnostics_block() -> str:
+    """The clock / index diagnostic helper defs, between their marker comments.
+
+    install-ndi.sh runs procedurally on source (no main guard), so the pure
+    helpers are tested by sourcing just this delimited block.
+    """
+    text = _install_ndi_path().read_text()
+    start = text.index("# === clock / index diagnostics")
+    end = text.index("# === end diagnostics")
+    block = text[start:end]
+    assert "clock_skew_in()" in block and "broken_index_in()" in block
+    return block
+
+
+def _run_diag(snippet: str) -> subprocess.CompletedProcess[str]:
+    code = f"{_diagnostics_block()}\n{snippet}\n"
+    return subprocess.run(
+        ["bash", "-c", code],
+        text=True,
+        capture_output=True,
+        env={"PATH": os.environ.get("PATH", "")},
+    )
 
 
 def _libndi_selection_snippet() -> str:
@@ -99,3 +124,65 @@ def test_install_ndi_already_present_links_newest_version(tmp_path: Path) -> Non
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == str(tmp_path / "libndi.so.6.3.2")
+
+
+# --- clock-skew / stale-index diagnostics -----------------------------------
+
+
+@pytest.mark.parametrize(
+    "sample",
+    [
+        # The exact sqv wording from a Pi whose clock is behind real time.
+        "Sub-process /usr/bin/sqv returned an error code (1) … Not live until 2026-06-25T01:42:42Z",
+        "Verifying signature: not yet valid",
+    ],
+)
+def test_clock_skew_in_detects_future_signature(sample: str) -> None:
+    r = _run_diag(f"printf '%s' {shlex.quote(sample)} | clock_skew_in && echo SKEW || echo CLEAN")
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip() == "SKEW"
+
+
+@pytest.mark.parametrize(
+    "sample",
+    [
+        "Reading package lists... Done",
+        # An unreachable mirror is NOT a clock problem – it must fall through to
+        # the cached-index path, not die.
+        "Failed to fetch http://deb.debian.org/debian … Could not connect",
+    ],
+)
+def test_clock_skew_in_ignores_unrelated_update_failures(sample: str) -> None:
+    r = _run_diag(f"printf '%s' {shlex.quote(sample)} | clock_skew_in && echo SKEW || echo CLEAN")
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip() == "CLEAN"
+
+
+@pytest.mark.parametrize(
+    "sample",
+    [
+        "E: Unable to correct problems, you have held broken packages.",
+        "The following packages have unmet dependencies:",
+    ],
+)
+def test_broken_index_in_detects_dependency_conflicts(sample: str) -> None:
+    r = _run_diag(f"printf '%s' {shlex.quote(sample)} | broken_index_in && echo BROKEN || echo CLEAN")
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip() == "BROKEN"
+
+
+def test_diagnostic_messages_are_actionable() -> None:
+    skew = _run_diag("clock_skew_message")
+    assert "clock" in skew.stdout.lower()
+    assert "timedatectl" in skew.stdout and "date -s" in skew.stdout
+    broken = _run_diag("broken_index_message")
+    assert "full-upgrade" in broken.stdout
+
+
+def test_apt_failures_are_wired_to_the_diagnostics() -> None:
+    text = _install_ndi_path().read_text()
+    # Both the update and install failure paths must consult the diagnostics so a
+    # wrong clock / stale index surfaces as a clear message, not raw apt output.
+    assert text.count('die "$(clock_skew_message)"') >= 2
+    assert 'die "$(broken_index_message)"' in text
+    assert "clock_skew_in <" in text and "broken_index_in <" in text


### PR DESCRIPTION
## Why

A user's NDI install on a Raspberry Pi failed with a wall of apt output (`Sub-process /usr/bin/sqv returned an error code (1) … Not live until <future date>`, then `held broken packages` dependency conflicts). The real cause was one level down and never named: the Pi's **system clock was behind real time** (no RTC + NTP not synced), so apt rejected the repository signatures as not-yet-valid, `apt-get update` failed, the script pressed on with the stale index, and the dependency conflict was a *side effect* of that stale index — not a real package problem.

Both install scripts hid this:
- `install-ndi.sh` downgraded the failed `apt-get update` to a `WARN` and barreled into the cryptic dependency error.
- `install-detection.sh` let pip's raw `[SSL: CERTIFICATE_VERIFY_FAILED] certificate is not yet valid` traceback be the error.

## What

Capture each apt/pip run's output (still streamed live via `tee`) and **classify** failures instead of dumping them:

- **Future-dated signature / certificate** → a clear clock-fix message (`timedatectl set-ntp` / `sudo date -s`, then `apt-get update && full-upgrade`). This is fatal on the NDI update path, because proceeding is what produces the confusing dependency conflict.
- **apt dependency conflict** (`held broken packages` / `unmet dependencies`) → a stale-index message pointing at `apt-get update && full-upgrade`.
- **Anything else** → a plain "see the output above" error with a next step.

An *unreachable-mirror* update failure is deliberately **not** fatal — it still falls through to the cached index, so a fully-provisioned offline Pi keeps installing.

The detection script gets the same treatment on all three pip paths (CPU torch, torch fallback, the onnxruntime/opencv backend), framed for TLS.

## Tests

New cases in `tests/test_install_ndi.py` and `tests/test_install_detection.py`:
- Positive: the reporter's exact `sqv` / TLS wording is classified as clock-skew; apt conflict wording as stale-index.
- Negative (no false positives): an unreachable mirror and a *non-clock* cert failure (bad CA / missing local issuer) are **not** misattributed to the clock.
- Structural: the apt/pip failure paths are actually wired to the diagnostics, and the messages stay actionable (`timedatectl`, `date -s`, `full-upgrade`).

`make ci` green locally (lint + typecheck + security + 869 tests @ 100% coverage + build). No testing Pi was reachable on the LAN, so the gate took its documented Mac fallback; the change is shell + `subprocess`/`grep` only, nothing arch-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)