### PR TITLE
Live-refresh web server local IP so the self-row tracks IP changes

### DIFF
--- a/openfollow/services.py
+++ b/openfollow/services.py
@@ -1816,9 +1816,10 @@ class AppRuntimeServices:
             port=self._app._config.web_port,
             system_name=self._app._config.psn_system_name,
             command_queue=self._app._web_commands,
-            # Resolved PSN bind IP for the web UI header so iface-pinned
-            # boxes don't display empty/stale.
+            # Resolved PSN bind IP for the web UI header; the provider
+            # re-resolves it live so an IP change updates the self-row.
             local_ip=self._resolved_source_ip(),
+            local_ip_provider=self._resolved_source_ip,
             runtime_stats_provider=self.get_runtime_stats_snapshot,
             preview_snapshot_provider=self._preview_provider.get_snapshot,
             zone_state_provider=self._get_zone_states_snapshot,

--- a/openfollow/web/discovery.py
+++ b/openfollow/web/discovery.py
@@ -128,6 +128,8 @@ class BeaconSender:
         self._packet = BeaconPacket(name=name, web_port=web_port, version=version)
         self._iface_ip = iface_ip
         self._stop_event = threading.Event()
+        # Signals the send loop to rebuild its socket on the new interface.
+        self._reopen = threading.Event()
         self._thread: threading.Thread | None = None
         # Health metrics for diagnostics bundle.
         # Reads of monotonic floats / int counters are atomic under
@@ -141,6 +143,32 @@ class BeaconSender:
     def update_name(self, name: str) -> None:
         """Update the beacon name (e.g., after config change)."""
         self._packet.name = name
+
+    def update_iface_ip(self, iface_ip: str) -> None:
+        """Repoint the multicast send interface after a host IP change.
+
+        The send loop rebuilds its socket on the next iteration so beacons
+        egress from the new source address. A no-op when the IP is unchanged.
+        """
+        if iface_ip == self._iface_ip:
+            return
+        self._iface_ip = iface_ip
+        self._reopen.set()
+
+    def _drain_reopen(self, sock: socket.socket | None) -> socket.socket | None:
+        """Drop the socket on a pending repoint so the loop rebuilds it.
+
+        Returns the socket to keep, or None to force a rebuild.
+        """
+        if not self._reopen.is_set():
+            return sock
+        self._reopen.clear()
+        if sock is not None:
+            try:
+                sock.close()
+            except OSError:
+                pass
+        return None
 
     def start(self) -> None:
         if self._thread is not None:
@@ -187,6 +215,7 @@ class BeaconSender:
         last_error_log = 0.0
         try:
             while not self._stop_event.is_set():
+                sock = self._drain_reopen(sock)
                 if sock is None:
                     try:
                         sock = self._open_socket()
@@ -298,6 +327,8 @@ class BeaconReceiver:
         self._thread: threading.Thread | None = None
         self._on_peer_discovered = on_peer_discovered
         self._iface_ip = iface_ip
+        # Signals the receive loop to rebuild its socket on the new interface.
+        self._reopen = threading.Event()
         self._local_port: int | None = None  # To filter out self
         self._local_ips: set[str] = set()
         self._local_ips_ts: float = 0.0  # timestamp of last refresh
@@ -319,6 +350,21 @@ class BeaconReceiver:
     def set_local_port(self, port: int) -> None:
         """Set local web port to filter out self-discovery."""
         self._local_port = port
+
+    def update_iface_ip(self, iface_ip: str) -> None:
+        """Rejoin the multicast group on a new interface after a host IP change.
+
+        The receive loop rebuilds its socket on the next iteration so membership
+        moves to the new interface. A no-op when the IP is unchanged.
+        """
+        if iface_ip == self._iface_ip:
+            return
+        self._iface_ip = iface_ip
+        # Force the self-filter cache to re-resolve so the new IP is recognised
+        # as local immediately; otherwise our own looped-back beacon passes the
+        # filter and we self-list as a peer until the next TTL refresh.
+        self._local_ips_ts = 0.0
+        self._reopen.set()
 
     def start(self) -> None:
         if self._thread is not None:
@@ -404,14 +450,25 @@ class BeaconReceiver:
                 continue
             consecutive = 0
             try:
-                while not self._stop_event.is_set():
-                    try:
-                        data, addr = sock.recvfrom(1024)
-                        self._handle_packet(data, addr[0])
-                    except TimeoutError:
-                        continue
+                self._recv_loop(sock)
             finally:
                 sock.close()
+
+    def _recv_loop(self, sock: socket.socket) -> None:
+        """Receive + dispatch packets until stop, or a repoint is requested.
+
+        Returns on a pending repoint so the caller rebuilds the socket and
+        rejoins multicast on the new interface.
+        """
+        while not self._stop_event.is_set():
+            if self._reopen.is_set():
+                self._reopen.clear()
+                return
+            try:
+                data, addr = sock.recvfrom(1024)
+                self._handle_packet(data, addr[0])
+            except TimeoutError:
+                continue
 
     def _handle_packet(self, data: bytes, sender_ip: str) -> None:
         packet = BeaconPacket.from_bytes(data)

--- a/openfollow/web/server.py
+++ b/openfollow/web/server.py
@@ -50,6 +50,11 @@ _request_semaphore_rejections = 0
 # twice.
 _FALLBACK_PORTS: tuple[int, ...] = (8080, 2010)
 
+# Min seconds between live local-IP re-resolutions; the refresh runs on request
+# paths and the resolver enumerates interfaces, so an IP change is picked up
+# within this window rather than re-resolving on every request.
+_LOCAL_IP_REFRESH_TTL = 5.0
+
 _REQUEST_BUSY_BODY = b"Server busy; retry"
 _REQUEST_BUSY_RESPONSE = (
     b"HTTP/1.1 503 Service Unavailable\r\n"
@@ -119,6 +124,7 @@ class ConfigWebServer:
         system_name: str = "OpenFollow",
         command_queue: WebCommandQueue | None = None,
         local_ip: str = "",
+        local_ip_provider: Callable[[], str] | None = None,
         runtime_stats_provider: Callable[[], dict[str, Any]] | None = None,
         preview_snapshot_provider: Callable[[], bytes | None] | None = None,
         zone_state_provider: Callable[[], list[tuple[int, bool, int]]] | None = None,
@@ -187,6 +193,11 @@ class ConfigWebServer:
             if local_ip:
                 logger.warning("Configured source IP %s is not a local interface, using auto-detected IP.", local_ip)
             self._local_ip = get_primary_local_ipv4(default="127.0.0.1")
+        # Re-resolves the local IP live so an IP change is picked up without a
+        # restart; the lock guards the cached IP + beacon repoint.
+        self._local_ip_provider = local_ip_provider
+        self._local_ip_lock = threading.Lock()
+        self._local_ip_refresh_ts = 0.0  # monotonic; throttles _refresh_local_ip
         self._command_queue = command_queue or WebCommandQueue()
         self._runtime_stats_provider = runtime_stats_provider
         self._preview_snapshot_provider = preview_snapshot_provider
@@ -376,8 +387,47 @@ class ConfigWebServer:
             logger.exception("PSN source advisory provider raised")
             return empty
 
+    def _refresh_local_ip(self) -> None:
+        """Re-resolve this host's primary IP and adopt it if it changed.
+
+        The IP captured at startup goes stale when the operator switches the
+        interface from static to DHCP (or a lease hands back a new address)
+        without restarting. Peers already track us by the beacon's UDP source
+        address, so this keeps our own self-row and the beacon's send/receive
+        interface in step with them. An unresolved (offline / loopback) result
+        is ignored so the last known good IP is never downgraded to blank.
+
+        Throttled to ``_LOCAL_IP_REFRESH_TTL``: this runs on request paths
+        (overview poll, /api/info, /api/peers) and the provider does interface
+        enumeration, so it must not re-resolve on every hit.
+        """
+        if self._local_ip_provider is None:
+            return
+        now = time.monotonic()
+        with self._local_ip_lock:
+            if now - self._local_ip_refresh_ts < _LOCAL_IP_REFRESH_TTL:
+                return
+            self._local_ip_refresh_ts = now
+        try:
+            candidate = self._local_ip_provider()
+        except Exception:  # noqa: BLE001
+            logger.exception("local_ip provider raised")
+            return
+        if not candidate or candidate.startswith("127."):
+            return
+        with self._local_ip_lock:
+            if candidate == self._local_ip:
+                return
+            self._local_ip = candidate
+            # Repoint beacons under the lock so IP + interface stay consistent
+            # under concurrent refreshes (update_iface_ip never blocks).
+            self._beacon_sender.update_iface_ip(candidate)
+            self._beacon_receiver.update_iface_ip(candidate)
+        logger.info("Local IP changed to %s; beacon interface repointed.", candidate)
+
     def get_local_peer_info(self) -> PeerInfo:
         """Get info about this server as a PeerInfo object."""
+        self._refresh_local_ip()
         return PeerInfo(
             name=self._system_name,
             ip=self._local_ip,

--- a/tests/test_web_discovery.py
+++ b/tests/test_web_discovery.py
@@ -1130,3 +1130,130 @@ def test_beacon_receiver_counts_remote_packets() -> None:
     peers = receiver.get_peers()
     assert len(peers) == 1
     assert peers[0].name == "remote"
+
+
+# ---------------------------------------------------------------------------
+# update_iface_ip – repoint the beacon interface after a host IP change
+# ---------------------------------------------------------------------------
+
+
+def test_beacon_sender_update_iface_ip_flags_reopen_on_change() -> None:
+    from openfollow.web.discovery import BeaconSender
+
+    sender = BeaconSender(name="N", web_port=80, iface_ip="10.0.0.1")
+    sender.update_iface_ip("10.0.0.2")
+
+    assert sender._iface_ip == "10.0.0.2"
+    assert sender._reopen.is_set()
+
+
+def test_beacon_sender_update_iface_ip_noop_when_unchanged() -> None:
+    from openfollow.web.discovery import BeaconSender
+
+    sender = BeaconSender(name="N", web_port=80, iface_ip="10.0.0.1")
+    sender.update_iface_ip("10.0.0.1")
+
+    assert sender._iface_ip == "10.0.0.1"
+    assert not sender._reopen.is_set()
+
+
+def test_beacon_sender_drain_reopen_keeps_socket_when_no_request() -> None:
+    from openfollow.web.discovery import BeaconSender
+
+    sender = BeaconSender(name="N", web_port=80)
+    sock = _FakeSocket()
+    assert sender._drain_reopen(sock) is sock
+    assert not sock.closed
+
+
+def test_beacon_sender_drain_reopen_closes_socket_and_forces_rebuild() -> None:
+    from openfollow.web.discovery import BeaconSender
+
+    sender = BeaconSender(name="N", web_port=80)
+    sock = _FakeSocket()
+    sender._reopen.set()
+    assert sender._drain_reopen(sock) is None
+    assert sock.closed
+    assert not sender._reopen.is_set()
+
+
+def test_beacon_sender_drain_reopen_with_no_open_socket() -> None:
+    from openfollow.web.discovery import BeaconSender
+
+    sender = BeaconSender(name="N", web_port=80)
+    sender._reopen.set()
+    assert sender._drain_reopen(None) is None
+    assert not sender._reopen.is_set()
+
+
+def test_beacon_sender_drain_reopen_swallows_close_error() -> None:
+    from openfollow.web.discovery import BeaconSender
+
+    class _BadCloseSocket(_FakeSocket):
+        def close(self) -> None:
+            raise OSError("interface already gone")
+
+    sender = BeaconSender(name="N", web_port=80)
+    sender._reopen.set()
+    assert sender._drain_reopen(_BadCloseSocket()) is None
+
+
+def test_beacon_receiver_update_iface_ip_flags_reopen_on_change() -> None:
+    receiver = BeaconReceiver(iface_ip="10.0.0.1")
+    receiver.update_iface_ip("10.0.0.2")
+
+    assert receiver._iface_ip == "10.0.0.2"
+    assert receiver._reopen.is_set()
+
+
+def test_beacon_receiver_update_iface_ip_noop_when_unchanged() -> None:
+    receiver = BeaconReceiver(iface_ip="10.0.0.1")
+    receiver.update_iface_ip("10.0.0.1")
+
+    assert receiver._iface_ip == "10.0.0.1"
+    assert not receiver._reopen.is_set()
+
+
+def test_beacon_receiver_update_iface_ip_resets_self_filter_cache() -> None:
+    """The new IP must be re-resolved into the self-filter immediately, else the
+    host's own looped-back beacon passes the filter and it self-lists as a peer."""
+    receiver = BeaconReceiver(iface_ip="10.0.0.1")
+    receiver._local_ips_ts = 99999.0  # pretend a recent self-filter refresh
+    receiver.update_iface_ip("10.0.0.2")
+    assert receiver._local_ips_ts == 0.0  # forced re-resolve on the next packet
+
+
+def test_beacon_receiver_recv_loop_returns_on_reopen() -> None:
+    """A pending repoint makes the loop return at once without reading."""
+    receiver = BeaconReceiver()
+    receiver._reopen.set()
+
+    class _NeverRead:
+        def recvfrom(self, _n: int) -> tuple[bytes, tuple[str, int]]:
+            raise AssertionError("recvfrom must not run while a repoint is pending")
+
+    receiver._recv_loop(_NeverRead())
+    assert not receiver._reopen.is_set()
+
+
+def test_beacon_receiver_recv_loop_dispatches_then_exits_on_stop() -> None:
+    """Normal path: one datagram is dispatched, the timeout branch then lets
+    the stop flag terminate the loop."""
+    receiver = BeaconReceiver()
+    receiver._local_port = 99  # not our port -> packet isn't self-filtered
+
+    beacon = _beacon_bytes(name="remote", web_port=80)
+
+    class _OneThenStop:
+        def __init__(self) -> None:
+            self._calls = 0
+
+        def recvfrom(self, _n: int) -> tuple[bytes, tuple[str, int]]:
+            self._calls += 1
+            if self._calls == 1:
+                return beacon, ("10.0.0.5", 50505)
+            receiver._stop_event.set()
+            raise TimeoutError
+
+    receiver._recv_loop(_OneThenStop())
+    assert receiver.packets_received == 1

--- a/tests/test_web_server_unit.py
+++ b/tests/test_web_server_unit.py
@@ -1064,3 +1064,116 @@ def test_quiet_handler_log_request_is_noop() -> None:
     assert handler.log_request() is None
     assert handler.log_request(200, "100") is None
     assert handler.log_request(code=500, size="0") is None
+
+
+# ---------------------------------------------------------------------------
+# get_local_peer_info – live local-IP refresh after a runtime IP change
+# ---------------------------------------------------------------------------
+
+
+def test_get_local_peer_info_adopts_live_ip_change(tmp_path, monkeypatch) -> None:
+    """A static→DHCP switch (new address, same interface) is picked up without
+    a restart: the self-row IP and both beacon interfaces follow the provider."""
+    monkeypatch.setattr(
+        "openfollow.web.server.get_local_ipv4_addresses",
+        lambda: {"10.0.0.1", "10.0.0.2"},
+    )
+    current = {"ip": "10.0.0.1"}
+    srv = _make_quiet_server(
+        tmp_path,
+        monkeypatch,
+        local_ip="10.0.0.1",
+        local_ip_provider=lambda: current["ip"],
+    )
+
+    assert srv.get_local_peer_info().ip == "10.0.0.1"
+
+    current["ip"] = "10.0.0.2"
+    srv._local_ip_refresh_ts -= 1000.0  # elapse the refresh throttle window
+    assert srv.get_local_peer_info().ip == "10.0.0.2"
+    assert srv.local_ip == "10.0.0.2"
+    assert srv._beacon_sender._iface_ip == "10.0.0.2"
+    assert srv._beacon_receiver._iface_ip == "10.0.0.2"
+
+
+@pytest.mark.parametrize("unresolved", ["", "127.0.0.1"])
+def test_get_local_peer_info_keeps_ip_when_provider_unresolved(
+    tmp_path,
+    monkeypatch,
+    unresolved: str,
+) -> None:
+    """An offline / loopback resolution must not downgrade the last known IP."""
+    monkeypatch.setattr(
+        "openfollow.web.server.get_local_ipv4_addresses",
+        lambda: {"10.0.0.1"},
+    )
+    srv = _make_quiet_server(
+        tmp_path,
+        monkeypatch,
+        local_ip="10.0.0.1",
+        local_ip_provider=lambda: unresolved,
+    )
+
+    assert srv.get_local_peer_info().ip == "10.0.0.1"
+    assert srv._beacon_sender._iface_ip == "10.0.0.1"
+
+
+def test_get_local_peer_info_without_provider_uses_startup_ip(tmp_path, monkeypatch) -> None:
+    """No provider wired (e.g. test harness) keeps the boot-time resolution."""
+    monkeypatch.setattr(
+        "openfollow.web.server.get_local_ipv4_addresses",
+        lambda: {"10.0.0.1"},
+    )
+    srv = _make_quiet_server(tmp_path, monkeypatch, local_ip="10.0.0.1")
+
+    assert srv.get_local_peer_info().ip == "10.0.0.1"
+
+
+def test_get_local_peer_info_survives_provider_exception(tmp_path, monkeypatch, caplog) -> None:
+    """A raising provider is logged and ignored – the self-row stays usable."""
+    monkeypatch.setattr(
+        "openfollow.web.server.get_local_ipv4_addresses",
+        lambda: {"10.0.0.1"},
+    )
+
+    def _boom() -> str:
+        raise RuntimeError("nic enumeration failed")
+
+    srv = _make_quiet_server(
+        tmp_path,
+        monkeypatch,
+        local_ip="10.0.0.1",
+        local_ip_provider=_boom,
+    )
+
+    with caplog.at_level("ERROR", logger="openfollow.web.server"):
+        peer = srv.get_local_peer_info()
+
+    assert peer.ip == "10.0.0.1"
+    assert any("local_ip provider raised" in r.message for r in caplog.records)
+
+
+def test_get_local_peer_info_throttles_ip_refresh(tmp_path, monkeypatch) -> None:
+    """The live IP refresh runs on request paths; it must re-resolve at most
+    once per TTL, not on every call (the provider enumerates interfaces)."""
+    monkeypatch.setattr(
+        "openfollow.web.server.get_local_ipv4_addresses",
+        lambda: {"10.0.0.1", "10.0.0.2"},
+    )
+    calls = {"n": 0}
+
+    def _provider() -> str:
+        calls["n"] += 1
+        return "10.0.0.1"
+
+    srv = _make_quiet_server(tmp_path, monkeypatch, local_ip="10.0.0.1", local_ip_provider=_provider)
+
+    srv.get_local_peer_info()
+    assert calls["n"] == 1  # first call resolves
+    srv.get_local_peer_info()
+    assert calls["n"] == 1  # within TTL -> throttled, provider not called again
+
+    # Simulate the TTL elapsing -> the next call re-resolves.
+    srv._local_ip_refresh_ts -= 1000.0
+    srv.get_local_peer_info()
+    assert calls["n"] == 2


### PR DESCRIPTION
## Problem

The "Server Network" overview's own **"this server"** row (plus `/api/info` and `/api/peers`) reads `ConfigWebServer._local_ip`, which is resolved **once at startup** and never refreshed. When an operator switches an interface from static to DHCP (new address, same interface) without restarting, the self-row keeps showing the stale boot-time IP.

Peers are unaffected because they derive a peer's IP from the beacon's **UDP source address**, not its payload, so they follow the new address automatically while the device misreports its own.

## Fix

- `get_local_peer_info()` now consults an injected `local_ip_provider` (wired to `AppRuntimeServices._resolved_source_ip`) and adopts a changed address. An unresolved/loopback result is ignored so a momentary lookup failure never downgrades the last known good IP.
- On change it also repoints the beacon send/receive interface via new `BeaconSender.update_iface_ip()` / `BeaconReceiver.update_iface_ip()`, which flag their run loops to rebuild the socket so multicast egress and membership move to the new interface.
- The refresh runs only from `get_local_peer_info()` (request-driven), never from a worker thread, so it can't rebind a socket from inside its own serving thread.

## Scope / non-goals

This fixes the **self-row display** and the **beacon interface**. It does **not** rebind the HTTP listen socket, which is bound to the iface IP resolved at startup and goes stale on an IP change too. That is a separate, larger change tracked as a follow-up.

## Tests

- `tests/test_web_discovery.py`: `update_iface_ip` change/no-op + live socket-rebuild for both sender and receiver.
- `tests/test_web_server_unit.py`: live-adopt, keep-on-unresolved (parametrized `""` / `127.0.0.1`), no-provider, and provider-exception paths.
- Full `make ci` green locally (lint + mypy + bandit + 7822/885 tests + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)