### PR TITLE
Resolve marker-catalog conflicts by logical clock, not wall time

### DIFF
--- a/openfollow/app.py
+++ b/openfollow/app.py
@@ -778,6 +778,7 @@ class OpenFollowApp:
                 tid,
                 f"Marker {tid}",
                 _PALETTE_AUTO_PICK_ORDER[tid % len(_PALETTE_AUTO_PICK_ORDER)],
+                origin=self._config.station_id,
             )
             seeded = True
         if seeded:

--- a/openfollow/marker_catalog/catalog.py
+++ b/openfollow/marker_catalog/catalog.py
@@ -6,8 +6,13 @@ The catalog is the shared source of truth for marker identity. Per-
 station selection (which catalog entries this station controls/views)
 lives in ``config.toml`` and is intentionally NOT covered here.
 
-Conflict model: per-entry last-write-wins on ``updated_at``. Deletes
-are tombstones so a late-arriving peer can't reincarnate them.
+Conflict model: per-entry last-write-wins ordered by a Lamport ``version``
+counter (with ``updated_at`` then ``origin`` as tiebreakers). The version is a
+logical clock: each local edit stamps ``max(version ever seen) + 1``, so a
+fresh edit always out-ranks anything the station has seen even when peer wall
+clocks disagree (the Pis are RTC-less and the show LAN has no NTP, so their
+clocks drift). Deletes are tombstones so a late-arriving peer can't
+reincarnate them.
 """
 
 from __future__ import annotations
@@ -35,17 +40,41 @@ logger = logging.getLogger(__name__)
 
 
 _DEFAULT_COLOR = "#ffffff"
+# Cap the logical version at the TOML 64-bit integer range so a bad/hostile
+# value can't write spec-violating markers.toml or poison the clock unbounded.
+_MAX_VERSION = 2**63 - 1
+# Cap the origin (a station id, normally a ~36-char UUID).
+_ORIGIN_MAX_LEN = 128
+
+
+def _sanitize_origin(value: object) -> str:
+    """Coerce origin to a printable, length-capped station id.
+
+    Single choke point shared by the dataclass, the loader, and the sync
+    receiver so disk and wire enforce the same contract.
+    """
+    if not isinstance(value, str):
+        return ""
+    return "".join(ch for ch in value if ch.isprintable())[:_ORIGIN_MAX_LEN]
 
 
 @dataclass
 class MarkerEntry:
-    """A single catalog entry. ``tombstone=True`` marks a deletion."""
+    """A single catalog entry. ``tombstone=True`` marks a deletion.
+
+    ``version`` is the Lamport logical clock for this entry's last write;
+    ``origin`` is the station that produced it (final, deterministic
+    tiebreaker). Both default to 0 / "" so entries from old ``markers.toml``
+    files or old-format peers parse cleanly and sort below any real edit.
+    """
 
     id: int
     name: str
     color: str
     updated_at: float
     tombstone: bool = False
+    version: int = 0
+    origin: str = ""
 
     def __post_init__(self) -> None:
         if not isinstance(self.id, int) or isinstance(self.id, bool):
@@ -65,6 +94,24 @@ class MarkerEntry:
         # Defence-in-depth: bool("false") is True; require real bool.
         if not isinstance(self.tombstone, bool):
             self.tombstone = False
+        # version is a logical clock: reject bool/non-int/negative, and cap at
+        # the TOML 64-bit range so a bad/hostile value can't poison the clock.
+        if isinstance(self.version, bool) or not isinstance(self.version, int) or self.version < 0:
+            self.version = 0
+        elif self.version > _MAX_VERSION:
+            self.version = _MAX_VERSION
+        self.origin = _sanitize_origin(self.origin)
+
+
+def _entry_rank(entry: MarkerEntry) -> tuple[int, float, str]:
+    """Total-order key for LWW: logical version, then wall time, then origin.
+
+    ``version`` (a clock-skew-proof logical counter) dominates; ``updated_at``
+    orders same-version writes (and keeps old version-0 entries ordered by their
+    original wall stamp); ``origin`` is the final deterministic tiebreak so two
+    stations converge on the same winner for a truly concurrent edit.
+    """
+    return (entry.version, entry.updated_at, entry.origin)
 
 
 class MarkerCatalog:
@@ -78,6 +125,10 @@ class MarkerCatalog:
         self._lock = threading.Lock()
         # Serialises save_catalog calls to prevent writer interleaving.
         self._save_lock = threading.Lock()
+        # Lamport logical clock: the highest version this station has ever seen
+        # (local edits + merged remotes). A local edit stamps ``_lamport + 1`` so
+        # it out-ranks anything seen, even when peer wall clocks disagree.
+        self._lamport = 0
 
     def get(self, marker_id: int) -> MarkerEntry | None:
         """Return the live (non-tombstoned) entry for ``marker_id``, or None."""
@@ -113,23 +164,28 @@ class MarkerCatalog:
         color: str,
         *,
         updated_at: float | None = None,
+        origin: str = "",
     ) -> MarkerEntry:
-        """Create or update an entry. Stamps ``updated_at`` to wall time.
+        """Create or update an entry, stamping the next logical ``version``.
 
-        Clears any tombstone (re-adding an id resurrects it locally –
-        peers will see this as a newer LWW write and resurrect too).
+        ``origin`` identifies the editing station for the merge tiebreak.
+        Clears any tombstone (re-adding an id resurrects it locally – peers
+        will see this as a higher-version write and resurrect too).
         """
         if marker_id < 1:
             raise ValueError("marker id must be >= 1")
         ts = updated_at if updated_at is not None else time.time()
-        entry = MarkerEntry(
-            id=marker_id,
-            name=name,
-            color=color,
-            updated_at=ts,
-            tombstone=False,
-        )
         with self._lock:
+            self._lamport += 1
+            entry = MarkerEntry(
+                id=marker_id,
+                name=name,
+                color=color,
+                updated_at=ts,
+                tombstone=False,
+                version=self._lamport,
+                origin=origin,
+            )
             self._entries[marker_id] = entry
         return entry
 
@@ -149,7 +205,7 @@ class MarkerCatalog:
             else:
                 self._entries[marker_id] = entry
 
-    def delete(self, marker_id: int) -> MarkerEntry | None:
+    def delete(self, marker_id: int, *, origin: str = "") -> MarkerEntry | None:
         """Tombstone an entry. Returns the new tombstone, or None if unknown."""
         ts = time.time()
         with self._lock:
@@ -161,12 +217,15 @@ class MarkerCatalog:
                 # bound. A peer's later upsert of that id will still
                 # win normally.
                 return None
+            self._lamport += 1
             tomb = MarkerEntry(
                 id=marker_id,
                 name=existing.name,
                 color=existing.color,
                 updated_at=ts,
                 tombstone=True,
+                version=self._lamport,
+                origin=origin,
             )
             self._entries[marker_id] = tomb
         return tomb
@@ -178,6 +237,11 @@ class MarkerCatalog:
         replaced, or tombstoned).
         """
         with self._lock:
+            # Track the highest version seen from any peer so the next local
+            # edit (``_lamport + 1``) out-ranks it – this is what stops a
+            # clock-ahead peer's stale entry from reverting a fresh edit.
+            if remote.version > self._lamport:
+                self._lamport = remote.version
             existing = self._entries.get(remote.id)
             if existing is None:
                 if remote.tombstone:
@@ -192,7 +256,7 @@ class MarkerCatalog:
                     return False
                 self._entries[remote.id] = remote
                 return True
-            if remote.updated_at <= existing.updated_at:
+            if _entry_rank(remote) <= _entry_rank(existing):
                 return False
             self._entries[remote.id] = remote
             return True
@@ -246,7 +310,8 @@ def load_catalog(path: str) -> MarkerCatalog:
         # Require real bool; bool("false") is True in Python.
         tombstone_raw = raw.get("tombstone", False)
         tombstone = tombstone_raw if isinstance(tombstone_raw, bool) else False
-        # Leave name as-is; MarkerEntry.__post_init__ normalises it.
+        # Pass version/origin (and name) raw; MarkerEntry.__post_init__ is the
+        # single normaliser (caps version, sanitises origin) for disk + wire.
         try:
             entry = MarkerEntry(
                 id=mid,
@@ -254,11 +319,16 @@ def load_catalog(path: str) -> MarkerCatalog:
                 color=str(raw.get("color", _DEFAULT_COLOR)),
                 updated_at=float(raw.get("updated_at", 0.0)),
                 tombstone=tombstone,
+                version=raw.get("version", 0),
+                origin=raw.get("origin", ""),
             )
         except ValueError:
             logger.warning("markers.toml: dropping invalid entry %r", raw)
             continue
         catalog._entries[entry.id] = entry
+    # Resume the logical clock above every persisted version so edits after a
+    # restart keep out-ranking what's on disk (and what peers still hold).
+    catalog._lamport = max((e.version for e in catalog._entries.values()), default=0)
     return catalog
 
 

--- a/openfollow/marker_catalog/sync.py
+++ b/openfollow/marker_catalog/sync.py
@@ -80,6 +80,8 @@ def _entry_to_dict(entry: MarkerEntry) -> dict[str, object]:
         "color": entry.color,
         "updated_at": entry.updated_at,
         "tombstone": entry.tombstone,
+        "version": entry.version,
+        "origin": entry.origin,
     }
 
 
@@ -96,7 +98,9 @@ def _entry_from_dict(raw: object) -> MarkerEntry | None:
     raw_id = raw.get("id", 0)
     if not isinstance(raw_id, int) or isinstance(raw_id, bool):
         return None
-    # Leave name as-is; MarkerEntry.__post_init__ normalises it.
+    # Pass version/origin raw; MarkerEntry.__post_init__ normalises both (caps
+    # version, sanitises + length-bounds origin) for disk and wire alike.
+    # Absent from old-format peers -> 0 / "" (sort below any real edit).
     try:
         return MarkerEntry(
             id=raw_id,
@@ -104,6 +108,8 @@ def _entry_from_dict(raw: object) -> MarkerEntry | None:
             color=str(raw.get("color", "#ffffff")),
             updated_at=float(raw.get("updated_at", 0.0)),
             tombstone=tombstone,
+            version=raw.get("version", 0),
+            origin=raw.get("origin", ""),
         )
     except (TypeError, ValueError):
         return None

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -3101,7 +3101,7 @@ def _register_marker_catalog_routes(
             # told the write failed, and the value never gets
             # ``request_delta``'d to peers.
             prev = catalog.get_any(marker_id)
-            entry = catalog.upsert(marker_id, name, color)
+            entry = catalog.upsert(marker_id, name, color, origin=cfg.station_id)
             try:
                 save_catalog(
                     catalog,
@@ -3161,7 +3161,7 @@ def _register_marker_catalog_routes(
             # operator was told the delete failed, and the tombstone
             # never reaches peers via ``request_delta``.
             prev = catalog.get_any(marker_id)
-            tomb = catalog.delete(marker_id)
+            tomb = catalog.delete(marker_id, origin=cfg.station_id)
             if tomb is None:
                 response.status = 404
                 return json.dumps({"error": "unknown marker id"})

--- a/tests/test_marker_catalog.py
+++ b/tests/test_marker_catalog.py
@@ -172,9 +172,9 @@ class TestMarkerCatalog:
 
     def test_merge_newer_wins(self) -> None:
         cat = MarkerCatalog()
-        cat.upsert(1, "Old", "#ff0000", updated_at=1.0)
+        cat.upsert(1, "Old", "#ff0000")  # version 1
         applied = cat.merge_entry(
-            MarkerEntry(id=1, name="New", color="#00ff00", updated_at=2.0),
+            MarkerEntry(id=1, name="New", color="#00ff00", updated_at=2.0, version=2),
         )
         assert applied is True
         assert cat.get(1).name == "New"
@@ -207,13 +207,14 @@ class TestMarkerCatalog:
 
     def test_merge_tombstone_overrides_live(self) -> None:
         cat = MarkerCatalog()
-        cat.upsert(1, "Live", "#ff0000", updated_at=1.0)
+        cat.upsert(1, "Live", "#ff0000")  # version 1
         tomb = MarkerEntry(
             id=1,
             name="Live",
             color="#ff0000",
             updated_at=2.0,
             tombstone=True,
+            version=2,
         )
         cat.merge_entry(tomb)
         assert cat.get(1) is None
@@ -501,3 +502,166 @@ class TestMergeEntryTombstoneGuard:
         assert cat.merge_entry(tomb) is True
         got = cat.get_any(5)
         assert got is not None and got.tombstone is True
+
+
+class TestMarkerEntryVersion:
+    @pytest.mark.parametrize("bad", [True, False, -1, "5", 1.5, None, [1]])
+    def test_bad_version_coerced_to_zero(self, bad: object) -> None:
+        entry = MarkerEntry(id=1, name="X", color="#ff0000", updated_at=0.0, version=bad)
+        assert entry.version == 0
+
+    def test_valid_version_kept(self) -> None:
+        entry = MarkerEntry(id=1, name="X", color="#ff0000", updated_at=0.0, version=7)
+        assert entry.version == 7
+
+    @pytest.mark.parametrize("bad", [123, None, [], 1.5])
+    def test_non_string_origin_coerced_to_empty(self, bad: object) -> None:
+        entry = MarkerEntry(id=1, name="X", color="#ff0000", updated_at=0.0, origin=bad)
+        assert entry.origin == ""
+
+    def test_version_capped_at_max(self) -> None:
+        # A hostile/buggy peer can't push version past the TOML 64-bit range
+        # (which would write spec-violating markers.toml or poison the clock).
+        entry = MarkerEntry(id=1, name="X", color="#ff0000", updated_at=0.0, version=2**63)
+        assert entry.version == 2**63 - 1
+
+    def test_origin_sanitised_and_length_capped(self) -> None:
+        raw = "st\x00\n\x1bX" + "y" * 300
+        entry = MarkerEntry(id=1, name="X", color="#ff0000", updated_at=0.0, origin=raw)
+        assert "\x00" not in entry.origin and "\n" not in entry.origin
+        assert entry.origin.startswith("stXy")
+        assert len(entry.origin) <= 128
+
+
+class TestLogicalClockConflictResolution:
+    """The clock-skew bug: a fresh local edit must win over a stale remote even
+    when the remote carries a larger (clock-ahead) wall-clock ``updated_at``."""
+
+    def test_local_edit_beats_stale_remote_with_higher_wallclock(self) -> None:
+        cat = MarkerCatalog()
+        # A clock-ahead peer's heartbeat arrives first: stale name, far-future
+        # wall stamp, some logical version.
+        cat.merge_entry(
+            MarkerEntry(id=1, name="OldName", color="#ffffff", updated_at=1_000_000.0, version=5),
+        )
+        # Operator renames locally now; our clock is well behind the peer's.
+        cat.upsert(1, "NewName", "#ffffff", updated_at=10.0)
+        assert cat.get(1).name == "NewName"
+        # The peer keeps re-broadcasting its stale entry; it must NOT revert us.
+        reverted = cat.merge_entry(
+            MarkerEntry(id=1, name="OldName", color="#ffffff", updated_at=1_000_000.0, version=5),
+        )
+        assert reverted is False
+        assert cat.get(1).name == "NewName"
+
+    def test_upsert_assigns_monotonic_versions(self) -> None:
+        cat = MarkerCatalog()
+        assert cat.upsert(1, "A", "#ffffff").version == 1
+        assert cat.upsert(2, "B", "#ffffff").version == 2
+        assert cat.upsert(1, "A2", "#ffffff").version == 3
+
+    def test_upsert_records_origin(self) -> None:
+        cat = MarkerCatalog()
+        assert cat.upsert(1, "A", "#ffffff", origin="station-x").origin == "station-x"
+
+    def test_delete_records_origin_and_bumps_version(self) -> None:
+        cat = MarkerCatalog()
+        cat.upsert(1, "A", "#ffffff")  # version 1
+        tomb = cat.delete(1, origin="station-y")
+        assert tomb is not None
+        assert tomb.origin == "station-y"
+        assert tomb.version == 2
+
+    def test_local_edit_outranks_seen_peer_version(self) -> None:
+        cat = MarkerCatalog()
+        cat.merge_entry(MarkerEntry(id=2, name="Peer", color="#ffffff", updated_at=0.0, version=42))
+        # Next local edit must out-rank the highest version seen from any peer.
+        assert cat.upsert(1, "Local", "#ffffff").version == 43
+
+    def test_ignored_unknown_tombstone_still_advances_clock(self) -> None:
+        """An unknown-id tombstone is ignored for memory, but its version MUST
+        still advance the logical clock. Otherwise a later local create of that
+        id gets a lower version and the peer's re-broadcast tombstone out-ranks
+        and silently deletes it. Guards the clock bump that precedes the
+        unknown-tombstone early-return in merge_entry."""
+        cat = MarkerCatalog()
+        # Peer deleted id 5 long ago at a high version; we never held it.
+        ignored = MarkerEntry(id=5, name="Gone", color="#ffffff", updated_at=0.0, version=10, tombstone=True)
+        assert cat.merge_entry(ignored) is False
+        assert cat.get_any(5) is None  # ignored, not materialised
+        # A local create must out-rank what we've already seen.
+        created = cat.upsert(5, "MyMarker", "#ffffff")
+        assert created.version > 10
+        # The peer keeps re-broadcasting its stale tombstone; it must not win.
+        restale = MarkerEntry(id=5, name="Gone", color="#ffffff", updated_at=9e9, version=10, tombstone=True)
+        assert cat.merge_entry(restale) is False
+        assert cat.get(5) is not None
+        assert cat.get(5).name == "MyMarker"
+
+    def test_higher_version_wins_regardless_of_wallclock(self) -> None:
+        cat = MarkerCatalog()
+        cat.merge_entry(MarkerEntry(id=1, name="V2", color="#ffffff", updated_at=1.0, version=2))
+        # Lower version loses even with a much larger updated_at.
+        assert cat.merge_entry(MarkerEntry(id=1, name="V1", color="#ffffff", updated_at=9e9, version=1)) is False
+        assert cat.get(1).name == "V2"
+
+    def test_same_version_falls_back_to_wallclock_then_origin(self) -> None:
+        cat = MarkerCatalog()
+        cat.merge_entry(MarkerEntry(id=1, name="early", color="#ffffff", updated_at=1.0, version=3, origin="a"))
+        # Same version, later wall stamp -> wins.
+        later = MarkerEntry(id=1, name="late", color="#ffffff", updated_at=2.0, version=3, origin="a")
+        assert cat.merge_entry(later) is True
+        # Same version and wall stamp, higher origin -> wins (deterministic tiebreak).
+        higher_origin = MarkerEntry(id=1, name="z-origin", color="#ffffff", updated_at=2.0, version=3, origin="z")
+        assert cat.merge_entry(higher_origin) is True
+        assert cat.get(1).name == "z-origin"
+
+
+class TestLogicalClockPersistence:
+    def test_save_load_round_trips_version_and_origin(self, tmp_path) -> None:
+        cat = MarkerCatalog()
+        cat.upsert(1, "A", "#ffffff", origin="st-1")  # version 1
+        cat.upsert(1, "A2", "#ffffff", origin="st-1")  # version 2
+        path = str(tmp_path / "markers.toml")
+        save_catalog(cat, path)
+        loaded = load_catalog(path)
+        entry = loaded.get(1)
+        assert entry.version == 2
+        assert entry.origin == "st-1"
+
+    def test_load_resumes_lamport_above_persisted_max(self, tmp_path) -> None:
+        cat = MarkerCatalog()
+        cat.upsert(1, "A", "#ffffff")  # version 1
+        cat.upsert(1, "A2", "#ffffff")  # version 2
+        path = str(tmp_path / "markers.toml")
+        save_catalog(cat, path)
+        loaded = load_catalog(path)
+        # A post-restart edit must keep climbing, not restart at 1.
+        assert loaded.upsert(1, "A3", "#ffffff").version == 3
+
+    def test_load_back_compat_missing_version_and_origin(self, tmp_path) -> None:
+        path = tmp_path / "markers.toml"
+        path.write_text(
+            '[[marker]]\nid = 1\nname = "Old"\ncolor = "#ffffff"\nupdated_at = 5.0\ntombstone = false\n',
+            encoding="utf-8",
+        )
+        cat = load_catalog(str(path))
+        entry = cat.get(1)
+        assert entry is not None
+        assert entry.version == 0
+        assert entry.origin == ""
+
+    def test_load_sanitises_origin_and_caps_version(self, tmp_path) -> None:
+        # A hand-edited markers.toml must go through the same origin sanitise +
+        # version cap as the wire path, not load verbatim.
+        path = tmp_path / "markers.toml"
+        path.write_text(
+            '[[marker]]\nid = 1\nname = "X"\ncolor = "#ffffff"\nupdated_at = 1.0\n'
+            'origin = "ok\\u0007bad"\nversion = 99999999999999999999\n',
+            encoding="utf-8",
+        )
+        cat = load_catalog(str(path))
+        entry = cat.get_any(1)
+        assert entry is not None
+        assert entry.origin == "okbad"  # BEL stripped
+        assert entry.version == 2**63 - 1  # clamped to the 64-bit cap

--- a/tests/test_marker_sync.py
+++ b/tests/test_marker_sync.py
@@ -1173,3 +1173,59 @@ def test_entry_from_dict_non_numeric_updated_at_returns_none() -> None:
     from openfollow.marker_catalog.sync import _entry_from_dict
 
     assert _entry_from_dict({"id": 5, "updated_at": "soon"}) is None
+
+
+# --------------------------------------------------------------------------- #
+# Logical-clock fields on the wire (version / origin)
+# --------------------------------------------------------------------------- #
+
+
+def test_entry_dict_round_trips_version_and_origin() -> None:
+    from openfollow.marker_catalog.sync import _entry_from_dict, _entry_to_dict
+
+    entry = MarkerEntry(id=1, name="A", color="#ffffff", updated_at=2.0, version=7, origin="st-9")
+    raw = _entry_to_dict(entry)
+    assert raw["version"] == 7
+    assert raw["origin"] == "st-9"
+    back = _entry_from_dict(raw)
+    assert back is not None
+    assert back.version == 7
+    assert back.origin == "st-9"
+
+
+def test_entry_from_dict_defaults_missing_version_and_origin() -> None:
+    """An old-format peer omits version/origin -> 0 / "" (sorts below any edit)."""
+    from openfollow.marker_catalog.sync import _entry_from_dict
+
+    back = _entry_from_dict({"id": 1, "name": "A", "color": "#ffffff", "updated_at": 1.0})
+    assert back is not None
+    assert back.version == 0
+    assert back.origin == ""
+
+
+@pytest.mark.parametrize("bad", [True, False, "5", 1.5, None, [1]])
+def test_entry_from_dict_bad_version_coerced_to_zero(bad: object) -> None:
+    from openfollow.marker_catalog.sync import _entry_from_dict
+
+    back = _entry_from_dict({"id": 1, "name": "A", "color": "#ffffff", "version": bad})
+    assert back is not None
+    assert back.version == 0
+
+
+def test_entry_from_dict_sanitizes_origin() -> None:
+    from openfollow.marker_catalog.sync import _entry_from_dict
+
+    back = _entry_from_dict({"id": 1, "name": "A", "color": "#ffffff", "origin": "st\x00\n\x1bX"})
+    assert back is not None
+    # Control chars (NUL, LF, ESC) dropped; printable remainder kept.
+    assert back.origin == "stX"
+
+
+def test_entry_from_dict_caps_huge_version() -> None:
+    """An unbounded version from an untrusted peer is clamped to the 64-bit cap
+    so it can't poison the clock or produce spec-violating markers.toml."""
+    from openfollow.marker_catalog.sync import _entry_from_dict
+
+    back = _entry_from_dict({"id": 1, "name": "A", "color": "#ffffff", "version": 10**30})
+    assert back is not None
+    assert back.version == 2**63 - 1

--- a/tests/test_web_markers.py
+++ b/tests/test_web_markers.py
@@ -275,12 +275,15 @@ class TestCatalogEndpoints:
             # Mid-save peer race: a newer remote entry merges into the
             # catalog before save_catalog raises. ``catalog_arg`` is
             # the same MarkerCatalog instance the route handler passed.
+            # Higher version than the local edit -> the peer write wins.
+            local_version = catalog_arg.get_any(1).version
             peer = MarkerEntry(
                 id=1,
                 name="From peer",
                 color="#0000ff",
                 updated_at=time.time() + 10.0,
                 tombstone=False,
+                version=local_version + 1,
             )
             catalog_arg.merge_entry(peer)
             raise OSError("disk full")
@@ -345,13 +348,15 @@ class TestCatalogEndpoints:
         def boom_with_peer_merge(catalog_arg, _path):
             # Peer broadcasts a newer live entry while our save_catalog
             # is in flight. ``merge_entry`` replaces our local tombstone
-            # because the remote ``updated_at`` is strictly greater.
+            # because the remote ``version`` is higher.
+            local_version = catalog_arg.get_any(1).version
             peer = MarkerEntry(
                 id=1,
                 name="Revived by peer",
                 color="#0000ff",
                 updated_at=time.time() + 10.0,
                 tombstone=False,
+                version=local_version + 1,
             )
             catalog_arg.merge_entry(peer)
             raise OSError("disk full")


### PR DESCRIPTION
## Bug report

On a multi-station LAN, renaming a marker on one station was **reverted to the old name by the other station**.

## Root cause

The shared marker catalog resolved conflicting edits with **last-write-wins on `updated_at`**, a raw `time.time()` wall-clock stamp (`catalog.py` merge: `remote.updated_at <= existing.updated_at`).

Stations are RTC-less Raspberry Pis on an **uplink-less show LAN** (no NTP), so their clocks free-run from boot and drift apart - often by a lot. When the *other* station's clock ran ahead, its **stale** entry carried a numerically larger `updated_at` than the fresh edit:

1. Rename on station A → `updated_at` = A's (slow) clock.
2. Station B still holds the old name with `updated_at` = B's (fast) clock.
3. A's edit reaches B → rejected (`A <= B`); B keeps and re-heartbeats the old name.
4. B's heartbeat reaches A → `B > A` → A adopts B's **old** name. Revert.

The "3 switches + heavy traffic" in the report isn't the cause - it only widens the window by delaying A's delta so B re-broadcasts the stale entry longer. The revert *requires* clock skew, which is guaranteed in this deployment.

## Fix: Lamport logical clock

- `MarkerEntry` gains **`version`** (logical counter) and **`origin`** (editing station). Merge orders by **`(version, updated_at, origin)`**: version dominates (skew-proof), `updated_at` orders same-version writes (and keeps legacy version-0 entries ordered as before), `origin` is a deterministic final tiebreak.
- The catalog tracks the **highest version it has ever seen** (local edits + merged remotes); each local edit stamps `seen_max + 1`, so a fresh edit always out-ranks anything the station has seen - a clock-ahead peer's stale entry can no longer revert it. `load_catalog` resumes the clock above the persisted max so edits keep climbing across restarts.
- Wire (beacon) and storage (`markers.toml`) carry `version`/`origin`; both **default to `0`/`""`** so old files and old-format peers parse cleanly and sort below any real edit (safe rolling upgrade).

### Why not just sync the clocks (NTP)?

A show LAN has no uplink, so NTP can't run on the data path - the whole reason the catalog can't trust wall time. A logical clock needs no synchronized time at all.

## Tests

- **Regression** (`TestLogicalClockConflictResolution`): a fresh local edit beats a stale remote carrying a far-larger (clock-ahead) `updated_at`, and the peer re-broadcast can't revert it.
- Monotonic version assignment, origin recording, "local edit out-ranks highest seen peer version", version-dominates-wallclock, and the same-version → wallclock → origin tiebreak chain.
- Persistence: save/load round-trips version+origin, resumes the clock above the persisted max, and back-compat with a version-less `markers.toml`.
- Wire: `_entry_to_dict`/`_entry_from_dict` round-trip + back-compat defaults + bad-version coercion + origin sanitisation.
- Full `make ci` green (lint + mypy + bandit + tests + build, 100% combined coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)