### PR TITLE
Fix flaky distortion round-trip test (out-of-domain inputs)

### DIFF
--- a/tests/test_solver_distortion.py
+++ b/tests/test_solver_distortion.py
@@ -105,12 +105,38 @@ def test_nan_rows_pass_through() -> None:
 # Mirror the CameraConfig clamps.
 _K1 = st.floats(min_value=-0.4, max_value=0.4)
 _K2 = st.floats(min_value=-0.2, max_value=0.2)
-# A central disk where the forward map is a clean bijection for every coeff in
-# range (a strong barrel shrinks the reachable radius, so the extreme corner has
-# no preimage – exercised separately by the bounded-output test below). Even at
-# k1=-0.4, k2=-0.2 the map stays monotonic well past r=0.6, so the disk is safe.
-_R = 0.6 * _HALF_DIAG
+# Undistorted-input disk: where the forward map is a clean bijection for every
+# coeff in range, so apply -> invert recovers the original. Even at k1=-0.4,
+# k2=-0.2 the map stays monotonic well past r=0.6, so a pinhole point this far
+# out has a valid distorted image to invert back.
+_R_EDGE = 0.6  # normalised working-disk radius (1.0 == frame corner)
+_R = _R_EDGE * _HALF_DIAG
 _OFFSET = st.floats(min_value=-_R / math.sqrt(2), max_value=_R / math.sqrt(2))
+
+
+@st.composite
+def _reachable_distorted(draw: st.DrawFn) -> tuple[float, float, float, float]:
+    """An ``(ox, oy, k1, k2)`` whose distorted point is reachable for that pair.
+
+    The invert -> apply round-trip is identity only for *reachable* distorted
+    points: a strong barrel folds the forward map at r_u~0.75, and beyond the
+    fold there is no preimage (invert floors the point – bounded, not identity;
+    covered by the out-of-domain test below). The forward image of the working
+    disk, ``apply(_R_EDGE)``, is the reachable cap for each coefficient pair –
+    it shrinks under barrel (~0.50) and grows under pincushion (~0.70), and stays
+    below the fold (its preimage r_u <= _R_EDGE), so the inverse is well
+    conditioned. Drawing the distorted radius *freely* within that per-coeff cap
+    (not as the forward image of a fixed pinhole point) exercises
+    ``apply o invert == id`` over the whole reachable range for every coefficient,
+    independently of the inverse-then-forward direction.
+    """
+    k1 = draw(_K1)
+    k2 = draw(_K2)
+    r_d_max = _R_EDGE * (1.0 + k1 * _R_EDGE**2 + k2 * _R_EDGE**4)
+    frac = draw(st.floats(min_value=0.0, max_value=1.0))
+    theta = draw(st.floats(min_value=0.0, max_value=2.0 * math.pi))
+    r = frac * r_d_max * _HALF_DIAG
+    return r * math.cos(theta), r * math.sin(theta), k1, k2
 
 
 @given(ox=_OFFSET, oy=_OFFSET, k1=_K1, k2=_K2)
@@ -121,8 +147,9 @@ def test_inverse_round_trips_forward(ox: float, oy: float, k1: float, k2: float)
     np.testing.assert_allclose(back, pt, atol=0.5)
 
 
-@given(ox=_OFFSET, oy=_OFFSET, k1=_K1, k2=_K2)
-def test_forward_round_trips_inverse(ox: float, oy: float, k1: float, k2: float) -> None:
+@given(params=_reachable_distorted())
+def test_forward_round_trips_inverse(params: tuple[float, float, float, float]) -> None:
+    ox, oy, k1, k2 = params
     pt = np.array([[_CX + ox, _CY + oy]])
     fwd = apply_overlay_distortion(invert_overlay_distortion(pt, _W, _H, k1, k2), _W, _H, k1, k2)
     np.testing.assert_allclose(fwd, pt, atol=0.5)


### PR DESCRIPTION
## Problem

`tests/test_solver_distortion.py::test_forward_round_trips_inverse` intermittently fails (`make ci` flake): it asserted `apply_overlay_distortion(invert_overlay_distortion(pt)) == pt` within 0.5 px for "distorted" input points anywhere in a disk of radius `0.6 × half-diagonal`.

But under a strong barrel (`k1=-0.4, k2=-0.2`) the forward map `r_d = r_u·(1 + k1 r_u² + k2 r_u⁴)` folds at `r_u ≈ 0.75`, so the **reachable** distorted radius is capped at `r_d ≈ 0.534`. A "distorted" input beyond that has **no preimage**: `invert` correctly floors it (kept bounded — covered by `test_inverse_stays_bounded_for_out_of_domain_corner`), but then the round-trip can't be the identity. The property failed by a hair (0.5004 px) right at the fold and diverged past it (62782 px at r=0.6).

## Fix

The solver is correct — the test asserted a property that doesn't hold for out-of-domain inputs. Drive the invert→forward test from a **coefficient-aware** domain: cap the distorted radius at the **forward image of the working-disk edge**, `apply(0.6)`. That cap shrinks under barrel (≈0.50) and grows under pincushion (≈0.70), and always stays below the fold (its preimage `r_u ≤ 0.6`), so the inverse is well-conditioned. The radius is drawn **freely** within that per-coefficient cap (not as a forward image of a fixed pinhole point), so `apply ∘ invert == id` is tested **independently** of the inverse→forward direction, over the full reachable range for every coefficient.

This is strictly more coverage than a fixed disk (exercises distorted radii up to ≈0.70 under pincushion), with no out-of-domain points and no flake. No production code changes.

## Verification
- Worst `apply(invert(pt)) − pt` over **8000** Hypothesis examples across the full coeff box: **~0.002 px** (atol 0.5); max distorted radius reached ≈0.69.
- Previously-cached failing example now passes; passes across multiple `--hypothesis-seed`s.
- Distortion/solver/wizard suite green; lint / format / mypy clean.

## Does it still catch real bugs?
Yes — and with no reduction. The unchanged `test_inverse_round_trips_forward` exercises the inverse across its full reachable domain (left-inverse), and this test now asserts the right-inverse directly over the full reachable range per coefficient. Distortion error grows smoothly with radius, so a genuine implementation bug (wrong formula, sign flip, dropped iterations) shows up well within the tested range; only out-of-domain/near-fold points — where the property is meaningless — are excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)