### PR TITLE
Makefile: cap test workers to leave CPU headroom on dev machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,22 @@ COVERAGE_MIN ?= 100
 
 # Parallelize the suite with pytest-xdist.
 #
-# ``-n logical`` (not ``auto``): ``auto`` counts physical cores, so on a 2-vCPU
-# single-core-with-hyperthreads CI runner it resolves to one worker and runs
-# sequentially. ``logical`` uses both hyperthreads, which the I/O-bound
-# integration/smoke step keeps busy.
+# Worker count is headroom-aware (not ``-n logical``/``-n auto``): small
+# CI/Pi runners (≤4 logical CPUs) use every core, but a fat interactive dev
+# workstation leaves 2 cores free so the OS/UI stays responsive – ``-n logical``
+# pins all 10 cores on a 10-core Mac with zero headroom and the WindowServer
+# starves, freezing the machine mid-run. ``getconf`` is portable across
+# macOS/Linux; the ``|| echo 2`` keeps the 2-vCPU CI default if it's absent.
 #
 # ``--dist load`` distributes individual tests across workers; ``loadscope``
 # would pin each large module to one worker and bottleneck on the slowest. Safe
 # because the suite has no cross-test shared state (function-scoped fixtures,
 # ephemeral ports, ``tmp_path`` I/O). pytest-cov combines per-worker coverage, so
-# the gate is unaffected. Override with ``PYTEST_PARALLEL=`` for a sequential run.
-PYTEST_PARALLEL ?= -n logical --dist load
+# the gate is unaffected. Override with ``PYTEST_PARALLEL=`` for a sequential run,
+# or ``PYTEST_WORKERS=N`` to pin the worker count.
+PYTEST_WORKERS ?= $(shell n=$$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2); \
+                          if [ "$$n" -gt 4 ]; then echo $$((n - 2)); else echo "$$n"; fi)
+PYTEST_PARALLEL ?= -n $(PYTEST_WORKERS) --dist load
 
 ci: lint typecheck security test build
 


### PR DESCRIPTION
## Problem

Running `make ci` / `make test` locally on a multi-core dev workstation froze the whole machine. The Makefile defaulted `PYTEST_PARALLEL` to `-n logical`, which spawns one pytest-xdist worker per logical core – 10 on a 10-core Apple Silicon Mac. Every core pegged at 100% with no headroom starves macOS's WindowServer, so the UI locks up (beachball, dead cursor) for the duration of the run.

That `-n logical` default is correct for the small headless runners it was tuned for: on a 2-vCPU CI runner `-n auto` collapses to 1 worker (sequential), so `logical` was chosen to actually use both. It's pathological only on a fat interactive workstation.

## Fix

Make the worker count headroom-aware:

- **≤4 logical CPUs** (CI runner, Pi) → use every core (unchanged behaviour).
- **>4 CPUs** (dev workstations) → leave 2 cores free so the OS/UI stays responsive.

`getconf _NPROCESSORS_ONLN` is portable across macOS/Linux; `|| echo 2` preserves the 2-vCPU default if it's ever absent. Adds a `PYTEST_WORKERS=N` override to pin the count; `PYTEST_PARALLEL=` still forces a sequential run.

| Host | Before | After |
|---|---|---|
| 2-vCPU CI runner | `-n 2` | `-n 2` |
| 4-core Pi | `-n 4` | `-n 4` |
| 10-core Mac | `-n 10` (freeze) | `-n 8` |

## Verification

`make ci-remote` fell back to a local run on the 10-core Mac (no Pi reachable) and passed end-to-end **without freezing** – the real-world proof of the fix:

- lint ✅ · mypy ✅ (120 files) · bandit ✅
- **885 tests passed** with `-n 8 --dist load`
- coverage **100.00%** (floor 100%)
- build ✅ (sdist + wheel)

Build-tooling change only (no application code), so it ships without a unit test – the Makefile isn't unit-testable and the worker formula is verified by the green local run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)