### PR TITLE
fix(video): survive GStreamer 1.26.2 StructureWrapper caps regression

### DIFF
--- a/openfollow/video/detection.py
+++ b/openfollow/video/detection.py
@@ -33,6 +33,7 @@ else:
 import numpy as np
 import numpy.typing as npt
 
+from openfollow.video.gst_compat import unwrap_gst_structure
 from openfollow.video.tracking import LOW_DETECTION_THRESHOLD, ByteTracker
 
 if TYPE_CHECKING:
@@ -1001,7 +1002,7 @@ class PersonDetector:
         """Convert a GStreamer sample to a NumPy RGB array."""
         buf = sample.get_buffer()
         caps = sample.get_caps()
-        structure = caps.get_structure(0)
+        structure = unwrap_gst_structure(caps.get_structure(0))
         w = structure.get_value("width")
         h = structure.get_value("height")
 

--- a/openfollow/video/gst_compat.py
+++ b/openfollow/video/gst_compat.py
@@ -1,0 +1,24 @@
+"""Compatibility shims for GStreamer Python binding differences."""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Name-mangled attribute on GStreamer 1.26.2's StructureWrapper that holds the
+# real Gst.Structure.
+_WRAPPED_STRUCTURE_ATTR = "_StructureWrapper__structure"
+
+
+def unwrap_gst_structure(structure: Any) -> Any:
+    """Return a ``Gst.Structure`` that exposes the typed getters.
+
+    GStreamer 1.26.2 hands structures from ``Gst.Caps.get_structure`` and
+    ``Gst.Device.get_properties`` back wrapped in a ``StructureWrapper`` that
+    doesn't forward the typed getters (``get_value`` / ``get_fraction`` /
+    ``get_string``). The real structure lives on a name-mangled attribute; reach
+    through to it when the getters are missing. Every other binding returns a
+    structure that already has them, so pass it through unchanged.
+    """
+    if structure is None or hasattr(structure, "get_value"):
+        return structure
+    return getattr(structure, _WRAPPED_STRUCTURE_ATTR, structure)

--- a/openfollow/video/inputs/avf.py
+++ b/openfollow/video/inputs/avf.py
@@ -14,6 +14,7 @@ import sys
 from collections.abc import Callable
 from typing import Any
 
+from openfollow.video.gst_compat import unwrap_gst_structure
 from openfollow.video.inputs._base import (
     ConfigField,
     InputCapabilities,
@@ -61,7 +62,7 @@ def _discover_avf_devices() -> list[dict[str, str]]:
         result: list[dict[str, str]] = []
         avf_index = 0
         for dev in devices:
-            props = dev.get_properties()
+            props = unwrap_gst_structure(dev.get_properties())
             if props is None:
                 continue
             api = props.get_string("device.api") or ""

--- a/openfollow/video/receiver.py
+++ b/openfollow/video/receiver.py
@@ -14,6 +14,7 @@ from openfollow.runtime.receiver_bus import ReceiverBusHandler
 from openfollow.runtime.receiver_pipeline import ReceiverPipelineAssembler
 from openfollow.runtime.receiver_state import ReceiverStateMachine
 from openfollow.video.connection_status import NdiStatusMarker
+from openfollow.video.gst_compat import unwrap_gst_structure
 from openfollow.video.inputs import get_input_class
 from openfollow.video.inputs._base import InputCapabilities, ReconnectPolicy
 
@@ -846,7 +847,7 @@ class GstNativeSinkReceiver:
         if event is not None and event.type == Gst.EventType.CAPS:
             caps = event.parse_caps()
             if caps is not None:
-                structure = caps.get_structure(0)
+                structure = unwrap_gst_structure(caps.get_structure(0))
                 if structure is not None:
                     w = structure.get_value("width")
                     h = structure.get_value("height")

--- a/tests/test_detection_edge_cases.py
+++ b/tests/test_detection_edge_cases.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -459,6 +460,25 @@ def test_sample_to_numpy_returns_copy_of_rgb_frame() -> None:
     assert int(out[0, 0, 0]) == 7
     # unmap must always run so GStreamer doesn't leak the buffer.
     assert buffer.unmapped is True
+
+
+def test_sample_to_numpy_reads_through_structure_wrapper() -> None:
+    """GStreamer 1.26.2 wraps the caps structure and drops get_value; the
+    converter must reach the wrapped structure instead of crashing the
+    detection worker thread."""
+    detection_module = _load_detection_module()
+    real = _FakeStructure(w=4, h=4)
+    # Mimic StructureWrapper: no get_value, real structure on the mangled name.
+    wrapper = SimpleNamespace(**{"_StructureWrapper__structure": real})
+    assert not hasattr(wrapper, "get_value")
+    data = np.full((4, 4, 3), 7, dtype=np.uint8).tobytes()
+    sample = _FakeSample(buffer=_FakeBuffer(data), caps=_FakeCaps(wrapper))
+
+    out = detection_module.PersonDetector._sample_to_numpy(sample, _FakeGst)
+
+    assert out is not None
+    assert out.shape == (4, 4, 3)
+    assert int(out[0, 0, 0]) == 7
 
 
 def test_sample_to_numpy_returns_none_when_map_fails() -> None:

--- a/tests/test_gst_compat.py
+++ b/tests/test_gst_compat.py
@@ -1,0 +1,42 @@
+"""Tests for the GStreamer binding compatibility shims."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from openfollow.video.gst_compat import unwrap_gst_structure
+
+pytestmark = pytest.mark.unit
+
+
+def test_unwrap_passes_through_structure_with_typed_getters() -> None:
+    """A binding that exposes get_value is returned untouched."""
+    structure = SimpleNamespace(get_value=lambda key: {"width": 1280}.get(key))
+    assert unwrap_gst_structure(structure) is structure
+
+
+def test_unwrap_none_returns_none() -> None:
+    assert unwrap_gst_structure(None) is None
+
+
+def test_unwrap_reaches_through_structure_wrapper() -> None:
+    """GStreamer 1.26.2 wraps the structure and drops the typed getters; the
+    real structure on the name-mangled attribute is returned instead."""
+    real = SimpleNamespace(get_value=lambda key: {"width": 800, "height": 600}.get(key))
+    # Mimic StructureWrapper: no get_value, real structure under the mangled name.
+    wrapper = SimpleNamespace(**{"_StructureWrapper__structure": real})
+    assert not hasattr(wrapper, "get_value")
+
+    unwrapped = unwrap_gst_structure(wrapper)
+
+    assert unwrapped is real
+    assert unwrapped.get_value("width") == 800
+
+
+def test_unwrap_returns_object_unchanged_when_no_wrapped_attr() -> None:
+    """An unknown object lacking both get_value and the wrapped attribute is
+    returned as-is rather than raising."""
+    obj = SimpleNamespace(other=1)
+    assert unwrap_gst_structure(obj) is obj

--- a/tests/test_video_input_avf.py
+++ b/tests/test_video_input_avf.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import sys
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -253,6 +254,25 @@ class TestDiscoverAvfDevices:
                 ),
             ]
         )
+        with patch("gi.repository.Gst", fake):
+            result = _discover_avf_devices()
+        assert result == [
+            {"unique_id": "FX30", "name": "Sony", "index": "0"},
+        ]
+
+    def test_reads_through_structure_wrapper(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GStreamer 1.26.2 wraps device-property structures in a
+        StructureWrapper without get_string; discovery must reach the wrapped
+        structure rather than raising AttributeError."""
+        monkeypatch.setattr(sys, "platform", "darwin")
+        real_props = _FakeProps({"device.api": "avf", "avf.unique_id": "FX30"})
+        wrapper = SimpleNamespace(**{"_StructureWrapper__structure": real_props})
+        assert not hasattr(wrapper, "get_string")
+        device = SimpleNamespace(
+            get_properties=lambda: wrapper,
+            get_display_name=lambda: "Sony",
+        )
+        fake = _make_fake_gst_with_devices([device])
         with patch("gi.repository.Gst", fake):
             result = _discover_avf_devices()
         assert result == [

--- a/tests/test_video_receiver.py
+++ b/tests/test_video_receiver.py
@@ -1588,6 +1588,26 @@ class TestPadEvent:
         assert r.connected is False
         assert r.source_framerate == 30.0
 
+    def test_caps_event_reads_through_structure_wrapper(self, fake_gst, fake_glib, fake_input_cls) -> None:
+        """GStreamer 1.26.2 hands back a StructureWrapper without get_value /
+        get_fraction. The probe must reach the wrapped structure rather than
+        raising AttributeError and leaving video stuck on 'No Signal'."""
+        r = _make_receiver(input_config={"fake_source": "cam-1"})
+        real = SimpleNamespace(
+            get_value=lambda key: {"width": 1280, "height": 720}.get(key),
+            get_fraction=lambda _key: (True, 30, 1),
+        )
+        wrapper = SimpleNamespace(**{"_StructureWrapper__structure": real})
+        assert not hasattr(wrapper, "get_value")
+        caps = SimpleNamespace(get_structure=lambda _idx: wrapper)
+        event = SimpleNamespace(type=FakeEventType.CAPS, parse_caps=lambda: caps)
+        info = SimpleNamespace(get_event=lambda: event)
+
+        r._on_pad_event(object(), info)
+
+        assert r.resolution == (1280, 720)
+        assert r.source_framerate == 30.0
+
     def test_caps_event_with_invalid_dims_no_state_change(self, fake_gst, fake_glib, fake_input_cls) -> None:
         r = _make_receiver()
         info, _ = self._make_caps_event(0, 0)


### PR DESCRIPTION
## The bug

On Debian/xfce (an Acer CP511 Chromebook, reported by a user), **no video appeared for any source** and the receiver crashed in the caps probe:

```
File ".../openfollow/video/receiver.py", line 851, in _on_pad_event
    w = structure.get_value("width")
AttributeError: 'StructureWrapper' object has no attribute 'get_value'
```

## Root cause

This is a [known upstream GStreamer 1.26.2 regression](https://discourse.gstreamer.org/t/python-get-structure-api-change/4767). In 1.26.2 the Python bindings return caps (and device-property) structures wrapped in a `StructureWrapper` that **no longer forwards the typed getters** (`get_value` / `get_fraction` / `get_string`). It was an accidental breakage, fixed upstream in 1.26.3.

It is **not** installable around:

- GStreamer is a **system package**, not a Poetry/pip dependency, so the app can't pick the version.
- Debian **trixie** ships `gst-python` **1.26.2-1** with **no backport** (verified against the Debian changelog), and stable releases don't track upstream point releases - so `apt upgrade` stays on the broken version for the release's lifetime.
- Trixie is **OpenFollow's own Pi target**. Current Pi images are still bookworm-based (GStreamer 1.22, pre-regression), but a trixie-based image would hit this on every source.
- Offline show LANs can't pull a newer GStreamer anyway, which is the whole runtime contract.

| GStreamer band | Affected? |
|---|---|
| ≤ 1.26.1 (bookworm/RPiOS 1.22, Ubuntu 24.04 1.24) | No (predates the wrapper) |
| **1.26.2 (Debian trixie)** | **Yes** |
| ≥ 1.26.3 (incl. sid 1.28) | No (fixed upstream) |

## The fix

A small version-agnostic shim, `openfollow/video/gst_compat.py`:

```python
def unwrap_gst_structure(structure):
    if structure is None or hasattr(structure, "get_value"):
        return structure
    return getattr(structure, "_StructureWrapper__structure", structure)
```

When a structure lacks `get_value`, reach through to the real structure on the wrapper's name-mangled attribute; pass it through unchanged on every healthy binding (1.26.3+, the 1.28 on dev Macs, and pre-1.26 distros). Applied at all three caps/structure sites:

- `video/receiver.py` - the caps probe that produced the report (no video on any source)
- `video/detection.py` - `_sample_to_numpy`, which crashes the detection worker the same way
- `video/inputs/avf.py` - `dev.get_properties().get_string(...)` for macOS camera enumeration

## Tests

- New `tests/test_gst_compat.py` - direct unit tests for the shim (pass-through, `None`, wrapper unwrap, unknown object).
- Regression test at each of the three sites reproducing the exact `StructureWrapper` crash and proving it now reads the real values.
- `gst_compat.py` at 100% line + branch; full gate green (`make ci`: lint + mypy --strict + bandit + 885 tests @ 100% coverage + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)