### PR TITLE
Makefile: reserve ~1/3 of cores for the test suite on dev machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,11 @@ COVERAGE_MIN ?= 100
 #
 # Worker count is headroom-aware (not ``-n logical``/``-n auto``): small
 # CI/Pi runners (≤4 logical CPUs) use every core, but a fat interactive dev
-# workstation leaves 2 cores free so the OS/UI stays responsive – ``-n logical``
-# pins all 10 cores on a 10-core Mac with zero headroom and the WindowServer
-# starves, freezing the machine mid-run. ``getconf`` is portable across
-# macOS/Linux; the ``|| echo 2`` keeps the 2-vCPU CI default if it's absent.
+# workstation reserves ~1/3 of its cores so the OS/UI stays responsive – a
+# 10-core Mac runs 6 workers and keeps 4 cores free. Saturating every core
+# starves macOS's WindowServer and freezes the machine mid-run. ``getconf`` is
+# portable across macOS/Linux; the ``|| echo 2`` keeps the 2-vCPU CI default if
+# it's absent.
 #
 # ``--dist load`` distributes individual tests across workers; ``loadscope``
 # would pin each large module to one worker and bottleneck on the slowest. Safe
@@ -27,7 +28,7 @@ COVERAGE_MIN ?= 100
 # the gate is unaffected. Override with ``PYTEST_PARALLEL=`` for a sequential run,
 # or ``PYTEST_WORKERS=N`` to pin the worker count.
 PYTEST_WORKERS ?= $(shell n=$$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2); \
-                          if [ "$$n" -gt 4 ]; then echo $$((n - 2)); else echo "$$n"; fi)
+                          if [ "$$n" -gt 4 ]; then echo $$((2 * n / 3)); else echo "$$n"; fi)
 PYTEST_PARALLEL ?= -n $(PYTEST_WORKERS) --dist load
 
 ci: lint typecheck security test build


### PR DESCRIPTION
## Problem

Running the test suite locally (`make test` / `make ci` / `make coverage`) freezes the whole MacBook UI for the duration of the run.

**Root cause: CPU saturation starving macOS's WindowServer.** The pytest-xdist worker count is `cores - 2`, which resolves to `-n 8` on a 10-core Mac (`make --dry-run test-unit` → `… -n 8 --dist load …`). Eight CPU-bound workers pin 8 of 10 cores, leaving only 2 for WindowServer, the kernel, the pytest master, and coverage combining — so the UI locks up until the run finishes.

This is not caused by any single heavy test: no ML/ONNX model loads at import, no large allocations, plenty of RAM. It's purely the aggregate worker count.

## Fix

Reserve a larger share of cores. On machines with more than 4 cores, use `floor(2 * cores / 3)` instead of `cores - 2`:

| cores | before (`-n`) | after (`-n`) | free |
|------:|:-------------:|:------------:|:----:|
| 10    | 8             | **6**        | 4    |
| 8     | 6             | 5            | 3    |
| 6     | 4             | 4            | 2    |
| 12    | 10            | 8            | 4    |
| ≤4 (CI/Pi) | all      | all          | 0    |

Small ≤4-core CI/Pi runners keep using every core, so **CI wall-clock is unchanged**. The `PYTEST_WORKERS=N` and `PYTEST_PARALLEL=` (sequential) overrides are preserved.

## Verification

- `make --dry-run test-unit` / `test-integration` / `coverage` → all now emit `-n 6 --dist load` on a 10-core Mac (was `-n 8`).
- `make --dry-run test-unit PYTEST_WORKERS=3` → `-n 3`; `PYTEST_PARALLEL=` → sequential (no `-n`).
- Simulated 4-core runner → `-n 4` (unchanged).
- `make lint` passes.

Build-tooling only (a Makefile shell formula), so there's no pytest to add — verified by dry-run, same as the previous change to this variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)