### PR TITLE
fix(config): preserve per-marker move speeds across Web UI saves

### DIFF
--- a/openfollow/app.py
+++ b/openfollow/app.py
@@ -174,6 +174,9 @@ from openfollow.runtime.app_orchestration import (
     check_config_reload as runtime_check_config_reload,
 )
 from openfollow.runtime.app_orchestration import (
+    check_marker_speeds_persist as runtime_check_marker_speeds_persist,
+)
+from openfollow.runtime.app_orchestration import (
     get_config_mtime as runtime_get_config_mtime,
 )
 from openfollow.runtime.app_orchestration import (
@@ -340,6 +343,10 @@ class OpenFollowApp:
         self._speed_key_last_t: dict[int, float] = {}
         self._speed_key_last_dir: dict[int, int] = {}
 
+        # Debounced persistence of the runtime-authoritative per-marker move speeds.
+        self._marker_speeds_dirty: bool = False
+        self._marker_speeds_dirty_since: float = 0.0
+
         self._button_detection: ButtonDetectionWizard | None = None
 
         self._update_worker: threading.Thread | None = None
@@ -464,6 +471,9 @@ class OpenFollowApp:
 
     def _check_restart_request(self) -> None:
         runtime_check_restart_request(self)
+
+    def _check_marker_speeds_persist(self) -> None:
+        runtime_check_marker_speeds_persist(self)
 
     def _check_pi_network_worker(self) -> None:
         from openfollow.runtime.app_modes_network import drain_pi_network_worker

--- a/openfollow/configuration.py
+++ b/openfollow/configuration.py
@@ -2837,10 +2837,11 @@ def apply_runtime_config_changes(app: OpenFollowApp, new_config: AppConfig) -> b
     if new_config.marker != app._config.marker:
         app._config.marker = new_config.marker
 
-    if new_config.marker_move_speeds != app._config.marker_move_speeds:
-        # Readers go through ``get_marker_move_speed``, so a direct swap
-        # suffices – no service restart.
-        app._config.marker_move_speeds = new_config.marker_move_speeds
+    # ``marker_move_speeds`` is deliberately NOT reloaded here. It is device-local
+    # and runtime-authoritative – written live by the R/T keys + gamepad bumpers, so
+    # the in-memory dict is the source of truth. A hot-reload from any config write (a
+    # web section save, the debounced self-persist, an import) must never overwrite it.
+    # Startup ``load_config`` seeds the initial value from disk; it is not reloaded after.
 
     # ``unit_system`` is read live every frame by ``sync_ui_config`` and
     # ``show_experimental_features`` gates the web UI off ``app._config``; a

--- a/openfollow/runtime/app_modes.py
+++ b/openfollow/runtime/app_modes.py
@@ -599,6 +599,10 @@ def adjust_move_speed(
     else:
         new_speed = min(app._config.marker.max_speed, round(current + step, 1))
     app._config.marker_move_speeds[marker_id] = new_speed
+    # Mark dirty; the housekeeping loop flushes to disk after a quiet window so a
+    # tap-streak / held bumper coalesces into one write (see check_marker_speeds_persist).
+    app._marker_speeds_dirty = True
+    app._marker_speeds_dirty_since = now
 
 
 def handle_key_press(app: OpenFollowApp, key: str) -> None:

--- a/openfollow/runtime/app_orchestration.py
+++ b/openfollow/runtime/app_orchestration.py
@@ -10,7 +10,12 @@ import os
 import time
 from typing import TYPE_CHECKING
 
-from openfollow.configuration import apply_runtime_config_changes, load_config
+from openfollow.configuration import (
+    apply_runtime_config_changes,
+    config_write_lock,
+    load_config,
+    save_config,
+)
 
 if TYPE_CHECKING:
     from openfollow.app import OpenFollowApp
@@ -30,6 +35,10 @@ _HOUSEKEEPING_INTERVAL_MS = 100
 # marker at the wrong speed on non-60Hz displays (≈2× on a 120 Hz panel).
 _DEFAULT_FRAME_DT = 1.0 / 60.0  # first-tick fallback before a real delta exists
 _MAX_FRAME_DT = 0.1  # clamp the step after a stall so a marker can't teleport
+
+# Quiet window after the last per-marker speed edit before it's flushed to disk,
+# so a tap-streak / held bumper coalesces into a single write.
+_SPEED_PERSIST_SETTLE_S = 2.5
 
 
 def run_native_loop(app: OpenFollowApp) -> None:
@@ -77,6 +86,7 @@ def housekeeping(app: OpenFollowApp) -> bool:
         app._check_restart_request,
         app._check_pi_network_worker,
         app._check_button_detection_request,
+        app._check_marker_speeds_persist,
     ):
         try:
             check()
@@ -173,3 +183,30 @@ def check_config_reload(app: OpenFollowApp) -> None:
 
     app._config_mtime = mtime
     logger.info("Config reloaded.")
+
+
+def check_marker_speeds_persist(app: OpenFollowApp) -> None:
+    """Flush the runtime-authoritative per-marker move speeds ~2.5s after the
+    last R/T / gamepad-bumper edit, coalescing a tap-streak into one write.
+
+    The flush reads the config fresh from disk under ``config_write_lock`` and
+    injects the live ``marker_move_speeds`` before saving, so a concurrent web
+    section save (which holds the same lock) can never be clobbered by writing
+    the whole in-memory config wholesale. The mtime is deliberately left alone:
+    the benign reload that follows is a no-op for speeds (they're not reloaded)
+    and correctly picks up whatever else the disk holds.
+    """
+    if not app._marker_speeds_dirty:
+        return
+    if time.monotonic() - app._marker_speeds_dirty_since < _SPEED_PERSIST_SETTLE_S:
+        return
+
+    try:
+        with config_write_lock:
+            cfg = load_config(app._config_path)
+            cfg.marker_move_speeds = dict(app._config.marker_move_speeds)
+            save_config(cfg, app._config_path)
+    except Exception:
+        logger.exception("Failed to persist per-marker move speeds.")
+        return
+    app._marker_speeds_dirty = False

--- a/openfollow/runtime/app_orchestration.py
+++ b/openfollow/runtime/app_orchestration.py
@@ -192,9 +192,13 @@ def check_marker_speeds_persist(app: OpenFollowApp) -> None:
     The flush reads the config fresh from disk under ``config_write_lock`` and
     injects the live ``marker_move_speeds`` before saving, so a concurrent web
     section save (which holds the same lock) can never be clobbered by writing
-    the whole in-memory config wholesale. The mtime is deliberately left alone:
-    the benign reload that follows is a no-op for speeds (they're not reloaded)
-    and correctly picks up whatever else the disk holds.
+    the whole in-memory config wholesale. The load is ``strict=True`` (mirrors
+    ``check_config_reload``): this flush fires automatically with no operator
+    intent, so on a malformed/unparseable ``config.toml`` it must raise and retry
+    rather than silently heal the file to its ``.bak`` snapshot or to defaults.
+    The mtime is deliberately left alone: the benign reload that follows is a
+    no-op for speeds (they're not reloaded) and correctly picks up whatever else
+    the disk holds.
     """
     if not app._marker_speeds_dirty:
         return
@@ -203,10 +207,14 @@ def check_marker_speeds_persist(app: OpenFollowApp) -> None:
 
     try:
         with config_write_lock:
-            cfg = load_config(app._config_path)
+            cfg = load_config(app._config_path, strict=True)
             cfg.marker_move_speeds = dict(app._config.marker_move_speeds)
             save_config(cfg, app._config_path)
     except Exception:
         logger.exception("Failed to persist per-marker move speeds.")
+        # Back off to the settle cadence so a persistent failure (e.g. a full
+        # disk, or a transiently-malformed file) doesn't retry + log on every
+        # housekeeping tick. Stays dirty, so it still retries after the window.
+        app._marker_speeds_dirty_since = time.monotonic()
         return
     app._marker_speeds_dirty = False

--- a/openfollow/services.py
+++ b/openfollow/services.py
@@ -1832,6 +1832,9 @@ class AppRuntimeServices:
             zone_diagnostics_provider=self._get_zone_diagnostics_snapshot,
             zone_test_send=self._zone_test_send,
             marker_positions_provider=self._get_marker_positions_snapshot,
+            # Live per-marker move speeds; the ``dict(...)`` copy is the
+            # mutation-isolation boundary so the web thread never holds the live dict.
+            marker_move_speeds_provider=lambda: dict(self._app._config.marker_move_speeds),
             full_snapshot_provider=self._snapshot_provider.get_snapshot,
             # Diagnostics + conflict-probe hooks. ``init_web_server`` runs
             # before ``init_osc_transmitters``, so the manager is ``None``

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -2150,11 +2150,15 @@ def _config_dict_redacted(cfg: AppConfig) -> dict[str, Any]:
     ``web_pin`` is the login credential – stripped so it never travels in
     cleartext. ``detection.storage_path`` is an absolute path that only makes
     sense on this host (a path from another machine would be unwritable here),
-    so it is stripped too. On import an absent value keeps the current one
-    (``_apply_import_data`` restores both), so the round-trip can't clear them.
+    so it is stripped too. ``marker_move_speeds`` is device-local and
+    runtime-authoritative, so it is dropped as well. On import an absent value
+    keeps the current one (``_apply_import_data`` restores them), so the
+    round-trip can't clear them.
     """
     d = asdict(cfg)
     d.pop("web_pin", None)
+    # Device-local, runtime-authoritative per-marker speeds never leave this box.
+    d.pop("marker_move_speeds", None)
     # ``detection`` is always present (asdict of a dataclass field); drop the
     # host-local storage path so it never travels to another machine.
     d["detection"].pop("storage_path", None)
@@ -3663,6 +3667,20 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         data.update(_build_input_template_data(cfg))
         return template("partials/video_source", **data)
 
+    def _load_config_for_edit() -> AppConfig:
+        """Fresh disk load with the live per-marker move speeds overlaid.
+
+        The disk copy doesn't know the runtime R/T + gamepad-bumper speeds, so an
+        operator-local section save would otherwise write stale speeds. Overlaying
+        the live values makes the write faithful and the subsequent hot-reload a
+        no-op for that (device-local, runtime-authoritative) field.
+        """
+        cfg = load_config(server.config_path)
+        speeds = server.get_marker_move_speeds()
+        if speeds:
+            cfg.marker_move_speeds = dict(speeds)
+        return cfg
+
     def _save_section_from_form(
         section: str,
         *,
@@ -3675,7 +3693,7 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         if extra_fields:
             form_data.update(extra_fields)
         with _config_write_lock:
-            cfg = load_config(server.config_path)
+            cfg = _load_config_for_edit()
             # In imperial mode, length/speed fields arrive as imperial
             # strings ("5 ft 6 in"). Rewrite to canonical metric before the
             # metric-only section parsers run, so storage stays metric.
@@ -4363,7 +4381,7 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         """Update video source settings."""
         form_data = dict(request.forms)
         with _config_write_lock:
-            cfg = load_config(server.config_path)
+            cfg = _load_config_for_edit()
             apply_section_data(cfg, "video_source", form_data)
             save_config(cfg, server.config_path)
 
@@ -4382,7 +4400,7 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         """Update general settings."""
         form_data = dict(request.forms)
         with _config_write_lock:
-            cfg = load_config(server.config_path)
+            cfg = _load_config_for_edit()
             apply_section_data(cfg, "general", form_data)
             save_config(cfg, server.config_path)
 
@@ -4543,7 +4561,7 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         """Update PSN output settings."""
         form_data = dict(request.forms)
         with _config_write_lock:
-            cfg = load_config(server.config_path)
+            cfg = _load_config_for_edit()
             apply_section_data(cfg, "psn", form_data)
             save_config(cfg, server.config_path)
 
@@ -6731,6 +6749,15 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
 
         with _config_write_lock:
             current = load_config(server.config_path)
+            # Per-marker move speeds are device-local + runtime-authoritative:
+            # preserve THIS station's live speeds and ignore any that rode along in
+            # the imported payload. Overlay them onto ``current`` so the deepcopy
+            # inside ``_apply_import_data`` carries them through (nothing in the
+            # section applies touches ``marker_move_speeds``, so the imported value
+            # is dropped either way – this keeps the live value, not the stale disk one).
+            speeds = server.get_marker_move_speeds()
+            if speeds:
+                current.marker_move_speeds = dict(speeds)
             full_cfg = _apply_import_data(current, data)
             save_config(full_cfg, server.config_path)
             return json.dumps({"success": True, "needs_restart": False})
@@ -6795,6 +6822,10 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
             return json.dumps({"error": "Invalid JSON"})
 
         with _config_write_lock:
+            # A peer-broadcast / external-API receive: no live-speed overlay. Section
+            # applies never touch top-level ``marker_move_speeds`` (device-local,
+            # runtime-authoritative), and Part 0 keeps the ensuing reload from
+            # clobbering the live dict, so a plain disk load is correct here.
             cfg = load_config(server.config_path)
             scrubbed = strip_device_local_fields(section, data)
             if not apply_section_data(cfg, section, scrubbed):
@@ -6827,7 +6858,9 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
             return json.dumps({"error": "Invalid JSON"})
 
         with _config_write_lock:
-            cfg = load_config(server.config_path)
+            # Local apply is an operator saving their own form, so overlay the
+            # live per-marker speeds like the other section-save flows.
+            cfg = _load_config_for_edit()
             if not apply_section_data(cfg, section, data):
                 response.status = 404
                 return json.dumps({"error": "Unknown section"})

--- a/openfollow/web/server.py
+++ b/openfollow/web/server.py
@@ -131,6 +131,10 @@ class ConfigWebServer:
         zone_diagnostics_provider: (Callable[[int], dict[str, Any] | None] | None) = None,
         zone_test_send: (Callable[[int, str], dict[str, Any]] | None) = None,
         marker_positions_provider: Callable[[], list[tuple[int, float, float]]] | None = None,
+        # Live per-marker move speeds (R/T + gamepad bumpers). Device-local and
+        # runtime-authoritative; the section-save path overlays them onto the fresh
+        # disk load so a save can't clobber a speed the operator just ramped.
+        marker_move_speeds_provider: Callable[[], dict[int, float]] | None = None,
         full_snapshot_provider: Callable[[], bytes | None] | None = None,
         osc_binding_status_provider: Callable[[str], dict[str, Any] | None] | None = None,
         osc_binding_preview_provider: Callable[[str], dict[str, Any] | None] | None = None,
@@ -205,6 +209,7 @@ class ConfigWebServer:
         self._zone_diagnostics_provider = zone_diagnostics_provider
         self._zone_test_send = zone_test_send
         self._marker_positions_provider = marker_positions_provider
+        self._marker_move_speeds_provider = marker_move_speeds_provider
         self._full_snapshot_provider = full_snapshot_provider
         self._osc_binding_status_provider = osc_binding_status_provider
         self._osc_binding_preview_provider = osc_binding_preview_provider
@@ -567,6 +572,16 @@ class ConfigWebServer:
         if self._marker_positions_provider is None:
             return []
         return self._marker_positions_provider()
+
+    def get_marker_move_speeds(self) -> dict[int, float]:
+        """Return live per-marker move speeds; empty dict when unwired.
+
+        The provider (wired in ``services``) hands back a copy, so a section save
+        can overlay these onto its fresh disk load without touching the live dict.
+        """
+        if self._marker_move_speeds_provider is None:
+            return {}
+        return self._marker_move_speeds_provider()
 
     def get_full_snapshot(self) -> bytes | None:
         """Return a full-resolution JPEG snapshot, or None."""

--- a/tests/test_app_lifecycle.py
+++ b/tests/test_app_lifecycle.py
@@ -615,6 +615,7 @@ class TestDelegators:
             ("_check_video_disconnect_banner", "runtime_check_video_disconnect_banner", ()),
             ("_restart_app", "runtime_restart_app", ()),
             ("_check_config_reload", "runtime_check_config_reload", ()),
+            ("_check_marker_speeds_persist", "runtime_check_marker_speeds_persist", ()),
         ],
     )
     def test_no_arg_delegators(

--- a/tests/test_app_modes.py
+++ b/tests/test_app_modes.py
@@ -71,6 +71,8 @@ class TestAdjustMoveSpeed:
                 self._speed_key_last_t: dict[int, float] = {}
                 self._speed_key_streak: dict[int, int] = {}
                 self._speed_key_last_dir: dict[int, int] = {}
+                self._marker_speeds_dirty = False
+                self._marker_speeds_dirty_since = 0.0
                 # Seed the per-marker entry to the test's starting speed so
                 # the first ``adjust_move_speed`` call has a defined base.
                 if selected_id is not None:
@@ -168,6 +170,22 @@ class TestAdjustMoveSpeed:
         adjust_move_speed(app, +1)
         assert app._config.marker_move_speeds == {}
         assert app._speed_key_streak == {}
+
+    def test_marks_dirty_with_edit_timestamp(self, monkeypatch) -> None:
+        """A speed edit marks the config dirty and stamps the edit time so the
+        housekeeping loop can flush it after the settle window."""
+        app = self._make_app(move_speed=1.0)
+        monkeypatch.setattr(time, "monotonic", lambda: 123.0)
+        adjust_move_speed(app, +1)
+        assert app._marker_speeds_dirty is True
+        assert app._marker_speeds_dirty_since == 123.0
+
+    def test_no_selection_does_not_mark_dirty(self) -> None:
+        """A no-op call (no marker resolved) must not mark the config dirty –
+        there is nothing to persist."""
+        app = self._make_app(move_speed=1.0, selected_id=None)
+        adjust_move_speed(app, +1)
+        assert app._marker_speeds_dirty is False
 
     def test_explicit_marker_id_overrides_selection(self) -> None:
         """``marker_id`` passed by the gamepad bumper resolver overrides

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -127,6 +127,7 @@ def _make_fake_app(
         _check_restart_request=_recorder("check_restart_request"),
         _check_pi_network_worker=_recorder("check_pi_network_worker"),
         _check_button_detection_request=_recorder("check_button_detection_request"),
+        _check_marker_speeds_persist=_recorder("check_marker_speeds_persist"),
         _check_video_disconnect_banner=_recorder("check_video_disconnect_banner"),
         _process_input=_recorder("process_input"),
         _refresh_iface_list=_recorder("refresh_iface_list"),
@@ -261,6 +262,7 @@ class TestHousekeeping:
             "check_restart_request",
             "check_pi_network_worker",
             "check_button_detection_request",
+            "check_marker_speeds_persist",
         ]
 
     def test_swallows_check_exception_and_keeps_timer(self) -> None:
@@ -280,6 +282,7 @@ class TestHousekeeping:
             "check_update_request",
             "check_pi_network_worker",
             "check_button_detection_request",
+            "check_marker_speeds_persist",
         ]
 
 
@@ -519,3 +522,162 @@ class TestRunNativeLoop:
         with pytest.raises(KeyboardInterrupt):
             orch.run_native_loop(app)
         assert app._runtime_services.shutdown_calls == 1
+
+
+# --------------------------------------------------------------------------- #
+# check_marker_speeds_persist
+# --------------------------------------------------------------------------- #
+
+
+class TestCheckMarkerSpeedsPersist:
+    """The debounced disk flush for the runtime-authoritative per-marker speeds.
+
+    Exercised through the public ``check_marker_speeds_persist`` boundary against
+    a real config file, so the assertions are about observable disk state, not
+    the helper's internals.
+    """
+
+    def _app(self, tmp_path, live_speeds: dict[int, float], dirty: bool, dirty_since: float):
+        from openfollow.configuration import AppConfig, save_config
+
+        config_path = tmp_path / "config.toml"
+        # Seed a real on-disk config the flush will re-load fresh.
+        save_config(AppConfig(controlled_marker_ids=list(live_speeds)), str(config_path))
+        cfg = AppConfig(
+            controlled_marker_ids=list(live_speeds),
+            marker_move_speeds=dict(live_speeds),
+        )
+        return SimpleNamespace(
+            _config_path=str(config_path),
+            _config=cfg,
+            _marker_speeds_dirty=dirty,
+            _marker_speeds_dirty_since=dirty_since,
+        )
+
+    def test_clean_app_never_flushes(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from openfollow.configuration import load_config
+
+        monkeypatch.setattr(orch.time, "monotonic", lambda: 1000.0)
+        app = self._app(tmp_path, {5: 2.7}, dirty=False, dirty_since=0.0)
+        orch.check_marker_speeds_persist(app)
+        # Disk still has no speeds; nothing was written.
+        assert load_config(app._config_path).marker_move_speeds == {}
+        assert app._marker_speeds_dirty is False
+
+    def test_dirty_before_settle_window_does_not_flush(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from openfollow.configuration import load_config
+
+        monkeypatch.setattr(orch.time, "monotonic", lambda: 100.0)
+        # Edited 1.0s ago; the settle window is 2.5s, so no flush yet.
+        app = self._app(tmp_path, {5: 2.7}, dirty=True, dirty_since=99.0)
+        orch.check_marker_speeds_persist(app)
+        assert load_config(app._config_path).marker_move_speeds == {}
+        assert app._marker_speeds_dirty is True  # still pending
+
+    def test_flushes_and_clears_after_settle_window(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from openfollow.configuration import load_config
+
+        monkeypatch.setattr(orch.time, "monotonic", lambda: 100.0)
+        # Edited 3.0s ago (>= 2.5s settle) → flush.
+        app = self._app(tmp_path, {5: 2.7}, dirty=True, dirty_since=97.0)
+        orch.check_marker_speeds_persist(app)
+        assert load_config(app._config_path).marker_move_speeds == {5: 2.7}
+        assert app._marker_speeds_dirty is False
+
+    def test_flush_holds_config_write_lock(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The flush must serialise on ``config_write_lock`` so it can't race a
+        concurrent web section save."""
+        monkeypatch.setattr(orch.time, "monotonic", lambda: 100.0)
+        app = self._app(tmp_path, {5: 2.7}, dirty=True, dirty_since=90.0)
+
+        observed: list[bool] = []
+        real_save = orch.save_config
+
+        def _spy_save(cfg, path):  # noqa: ANN001
+            observed.append(orch.config_write_lock.locked())
+            return real_save(cfg, path)
+
+        monkeypatch.setattr(orch, "save_config", _spy_save)
+        orch.check_marker_speeds_persist(app)
+        assert observed == [True]  # lock held across the save
+
+    def test_save_failure_is_swallowed_and_stays_dirty(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A failed disk write must not crash the housekeeping loop and must leave
+        the config marked dirty so the next tick retries the flush."""
+        monkeypatch.setattr(orch.time, "monotonic", lambda: 100.0)
+        app = self._app(tmp_path, {5: 2.7}, dirty=True, dirty_since=90.0)
+
+        def _boom(*_a, **_kw):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(orch, "save_config", _boom)
+        # Must not raise.
+        orch.check_marker_speeds_persist(app)
+        # Still dirty → retried next tick; the lock was released.
+        assert app._marker_speeds_dirty is True
+        assert orch.config_write_lock.locked() is False
+
+    def test_flush_preserves_a_concurrently_saved_section(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The flush loads the config fresh from disk and only injects the live
+        speeds, so an unrelated field another writer just persisted survives –
+        it does NOT save the whole in-memory config wholesale."""
+        from openfollow.configuration import AppConfig, load_config, save_config
+
+        monkeypatch.setattr(orch.time, "monotonic", lambda: 100.0)
+        config_path = tmp_path / "config.toml"
+        # A web save landed on disk with a changed grid width; the live app's
+        # in-memory config still has the OLD width (it hasn't reloaded yet).
+        on_disk = AppConfig(controlled_marker_ids=[5])
+        on_disk.grid.width = 42.0
+        save_config(on_disk, str(config_path))
+
+        live = AppConfig(controlled_marker_ids=[5], marker_move_speeds={5: 2.7})
+        live.grid.width = 10.0  # stale in-memory value
+        app = SimpleNamespace(
+            _config_path=str(config_path),
+            _config=live,
+            _marker_speeds_dirty=True,
+            _marker_speeds_dirty_since=90.0,
+        )
+
+        orch.check_marker_speeds_persist(app)
+
+        result = load_config(str(config_path))
+        assert result.marker_move_speeds == {5: 2.7}  # live speeds injected
+        assert result.grid.width == 42.0  # concurrent save NOT clobbered
+
+    def test_restart_survival_round_trip(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """adjust -> settle -> flush -> a fresh ``load_config`` (as a restart would
+        do) shows the persisted speed."""
+        from openfollow.configuration import AppConfig, load_config, save_config
+        from openfollow.runtime.app_modes import adjust_move_speed
+
+        config_path = tmp_path / "config.toml"
+        save_config(AppConfig(controlled_marker_ids=[1]), str(config_path))
+
+        cfg = AppConfig(controlled_marker_ids=[1], marker_move_speeds={1: 1.0})
+        app = SimpleNamespace(
+            _config_path=str(config_path),
+            _config=cfg,
+            _selected_id=1,
+            _speed_key_streak={},
+            _speed_key_last_t={},
+            _speed_key_last_dir={},
+            _marker_speeds_dirty=False,
+            _marker_speeds_dirty_since=0.0,
+            get_marker_move_speed=lambda mid: cfg.marker_move_speeds.get(mid, cfg.marker.move_speed),
+        )
+
+        monkeypatch.setattr(orch.time, "monotonic", lambda: 100.0)
+        # app_modes uses its own ``time`` module; patch that too for a stable stamp.
+        import openfollow.runtime.app_modes as modes
+
+        monkeypatch.setattr(modes.time, "monotonic", lambda: 100.0)
+        adjust_move_speed(app, +1)  # 1.0 -> 1.1, marks dirty at t=100.0
+
+        # Settle window elapsed.
+        monkeypatch.setattr(orch.time, "monotonic", lambda: 103.0)
+        orch.check_marker_speeds_persist(app)
+
+        reloaded = load_config(str(config_path))
+        assert reloaded.marker_move_speeds == {1: 1.1}

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -601,11 +601,16 @@ class TestCheckMarkerSpeedsPersist:
         orch.check_marker_speeds_persist(app)
         assert observed == [True]  # lock held across the save
 
-    def test_save_failure_is_swallowed_and_stays_dirty(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_save_failure_is_swallowed_stays_dirty_and_backs_off(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """A failed disk write must not crash the housekeeping loop and must leave
-        the config marked dirty so the next tick retries the flush."""
+        the config marked dirty so a later tick retries. On failure the edit
+        timestamp is advanced to now, so a persistent failure backs off to the
+        settle cadence instead of retrying + logging on every tick."""
         monkeypatch.setattr(orch.time, "monotonic", lambda: 100.0)
         app = self._app(tmp_path, {5: 2.7}, dirty=True, dirty_since=90.0)
+        before = app._marker_speeds_dirty_since
 
         def _boom(*_a, **_kw):
             raise OSError("disk full")
@@ -613,9 +618,34 @@ class TestCheckMarkerSpeedsPersist:
         monkeypatch.setattr(orch, "save_config", _boom)
         # Must not raise.
         orch.check_marker_speeds_persist(app)
-        # Still dirty → retried next tick; the lock was released.
+        # Still dirty → retried later; the lock was released.
         assert app._marker_speeds_dirty is True
         assert orch.config_write_lock.locked() is False
+        # Backoff: the timestamp was advanced to now, so the next flush attempt
+        # waits out the settle window again rather than firing every tick.
+        assert app._marker_speeds_dirty_since == 100.0
+        assert app._marker_speeds_dirty_since != before
+
+    def test_malformed_config_is_not_overwritten(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The flush loads ``strict=True``, so a malformed / unparseable
+        ``config.toml`` (e.g. an in-progress hand-edit) is left byte-for-byte
+        intact instead of being silently healed to its ``.bak`` snapshot or to
+        defaults. A background flush must never clobber a bad config."""
+        monkeypatch.setattr(orch.time, "monotonic", lambda: 100.0)
+        app = self._app(tmp_path, {5: 2.7}, dirty=True, dirty_since=90.0)
+
+        # Corrupt the on-disk config (unterminated table header -> invalid TOML).
+        bad_bytes = b"[grid\nthis = is not valid toml ]]]"
+        config_path = tmp_path / "config.toml"
+        config_path.write_bytes(bad_bytes)
+
+        # Must not raise.
+        orch.check_marker_speeds_persist(app)
+
+        # The bad file is untouched (strict load raised before any save) and the
+        # config stays dirty so it retries once the file is valid again.
+        assert config_path.read_bytes() == bad_bytes
+        assert app._marker_speeds_dirty is True
 
     def test_flush_preserves_a_concurrently_saved_section(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
         """The flush loads the config fresh from disk and only injects the live

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -989,15 +989,40 @@ def test_loading_default_config_does_not_emit_deprecation_warnings(
     assert not any("deprecated" in r.message for r in caplog.records)
 
 
-def test_apply_runtime_marker_move_speeds_diff() -> None:
-    """Marker speed changes apply directly; no restart needed."""
+def test_apply_runtime_does_not_reload_marker_move_speeds() -> None:
+    """Per-marker speeds are device-local + runtime-authoritative: a hot-reload
+    must NOT overwrite the live in-memory dict from disk, whatever the reloaded
+    file happens to contain. This is the fix for the reported "saving any Web UI
+    setting resets all marker speeds" bug – the web save writes the file, the
+    watcher reloads it, and that reload must leave the live speeds untouched."""
     app = _DummyApp(AppConfig(marker_move_speeds={2: 2.0}))
+    # A reloaded config carrying DIFFERENT speeds must not clobber the live ones.
     new_config = AppConfig(marker_move_speeds={2: 3.5, 1: 1.5})
 
     apply_runtime_config_changes(app, new_config)
 
-    assert app._config.marker_move_speeds == {2: 3.5, 1: 1.5}
+    assert app._config.marker_move_speeds == {2: 2.0}
     assert app._web_commands.restart_requested is False
+
+
+def test_apply_runtime_does_not_clear_marker_move_speeds_when_disk_empty() -> None:
+    """A reloaded config with EMPTY speeds (e.g. a fresh disk load that never saw
+    the runtime edits) must not wipe the live dict."""
+    app = _DummyApp(AppConfig(marker_move_speeds={2: 2.0, 3: 4.0}))
+    new_config = AppConfig()  # no speeds
+
+    apply_runtime_config_changes(app, new_config)
+
+    assert app._config.marker_move_speeds == {2: 2.0, 3: 4.0}
+
+
+def test_startup_load_seeds_marker_move_speeds_from_disk(temp_config_path) -> None:
+    """Part 0 only skips the *reload*; the initial ``load_config`` at startup
+    still seeds the speeds from disk so a restart picks up the persisted values."""
+    config = AppConfig(controlled_marker_ids=[2, 3], marker_move_speeds={2: 1.5, 3: 4.0})
+    save_config(config, str(temp_config_path))
+    reloaded = load_config(str(temp_config_path))
+    assert reloaded.marker_move_speeds == {2: 1.5, 3: 4.0}
 
 
 def test_apply_runtime_ui_unit_system_propagates_to_config() -> None:

--- a/tests/test_services_init_and_updates.py
+++ b/tests/test_services_init_and_updates.py
@@ -910,6 +910,28 @@ class TestInitWebServer:
         # isn't stable across attribute lookups, so compare by __func__.
         assert srv.kwargs["runtime_stats_provider"].__func__ is AppRuntimeServices.get_runtime_stats_snapshot
 
+    def test_wires_marker_move_speeds_provider_returning_a_copy(
+        self, services: AppRuntimeServices, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The section-save path reads the live per-marker speeds through this
+        provider. It must return the current live values as a fresh copy so the
+        web thread can never mutate the app's live dict."""
+        from openfollow import web
+
+        monkeypatch.setattr(web, "ConfigWebServer", _FakeWebServer)
+        services._preview_provider = SimpleNamespace(get_snapshot=lambda: None)
+        services._snapshot_provider = SimpleNamespace(get_snapshot=lambda: None)
+        services._app._config.marker_move_speeds = {5: 2.7}
+
+        services.init_web_server()
+        provider = services._app._web_server.kwargs["marker_move_speeds_provider"]
+
+        snapshot = provider()
+        assert snapshot == {5: 2.7}
+        # Mutation isolation: the returned dict is a copy, not the live one.
+        snapshot[9] = 4.0
+        assert services._app._config.marker_move_speeds == {5: 2.7}
+
     def test_wires_osc_binding_diagnostics_providers(
         self, services: AppRuntimeServices, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -5546,3 +5546,157 @@ def test_csrf_safe_method_ignores_foreign_origin(pin_protected_server) -> None:
         base, "/api/config", extra_headers={"Origin": "http://evil.example.com"}, method="GET", data=None
     )
     assert status != 403
+
+
+# --------------------------------------------------------------------------- #
+# Per-marker move speeds: device-local, runtime-authoritative (Web-save reset fix)
+# --------------------------------------------------------------------------- #
+
+
+def _speeds_server(tmp_path, monkeypatch, *, live_speeds, controlled_ids, disk_speeds=None):
+    """Live server with a ``marker_move_speeds_provider`` wired and an on-disk
+    config seeded with ``controlled_ids`` (and optionally ``disk_speeds``).
+
+    Models production: the disk config never carries the live runtime speeds
+    (they're written only by the debounced flush), so the provider is the only
+    source of the operator's just-ramped values during a section save.
+    """
+    monkeypatch.setattr(discovery_module.BeaconSender, "start", lambda self: None)
+    monkeypatch.setattr(discovery_module.BeaconSender, "stop", lambda self: None)
+    monkeypatch.setattr(discovery_module.BeaconReceiver, "start", lambda self: None)
+    monkeypatch.setattr(discovery_module.BeaconReceiver, "stop", lambda self: None)
+
+    port = _find_free_tcp_port()
+    config_path = tmp_path / "config.toml"
+    cfg = AppConfig(controlled_marker_ids=list(controlled_ids))
+    if disk_speeds:
+        cfg.marker_move_speeds = dict(disk_speeds)
+    save_config(cfg, str(config_path))
+
+    server = ConfigWebServer(
+        config_path=str(config_path),
+        host="127.0.0.1",
+        port=port,
+        system_name="TestSystem",
+        marker_move_speeds_provider=lambda: dict(live_speeds),
+    )
+    server.start()
+    assert _wait_for_port(port)
+    return server, f"http://127.0.0.1:{port}"
+
+
+def test_section_save_preserves_live_marker_speeds_on_disk(tmp_path, monkeypatch) -> None:
+    """Canonical repro: the operator ramps marker 5's speed at runtime (live dict
+    holds {5: 2.7}), the disk config has none, then they save an UNRELATED web
+    section (Grid). The written file must carry {5: 2.7}, not the empty disk
+    value, so the follow-up hot-reload of that file is a no-op for the speeds.
+
+    (The complementary guarantee – the reload itself never clobbers the live
+    dict – is covered directly in ``test_configuration.py``.)"""
+    server, base = _speeds_server(
+        tmp_path,
+        monkeypatch,
+        live_speeds={5: 2.7},
+        controlled_ids=[5],
+    )
+    try:
+        # Sanity: the disk config genuinely has no speeds before the save, so a
+        # naive "load disk, apply section, save" would drop {5: 2.7}.
+        assert load_config(server.config_path).marker_move_speeds == {}
+
+        status, _ = _post_form(base, "/section/grid", {"width": "25"})
+        assert status == 200
+
+        reloaded = load_config(server.config_path)
+        assert reloaded.marker_move_speeds == {5: 2.7}
+        # The unrelated edit still landed.
+        assert reloaded.grid.width == 25.0
+    finally:
+        server.stop()
+
+
+def test_section_save_prunes_deselected_live_speed(tmp_path, monkeypatch) -> None:
+    """A live speed for a marker no longer in ``controlled_marker_ids`` is pruned
+    on save (``config_to_toml_dict`` prunes), even though it was overlaid from the
+    provider. Marker 5 stays; marker 9 (not controlled) is dropped."""
+    server, base = _speeds_server(
+        tmp_path,
+        monkeypatch,
+        live_speeds={5: 2.7, 9: 4.0},
+        controlled_ids=[5],
+    )
+    try:
+        status, _ = _post_form(base, "/section/grid", {"width": "25"})
+        assert status == 200
+        reloaded = load_config(server.config_path)
+        assert reloaded.marker_move_speeds == {5: 2.7}
+    finally:
+        server.stop()
+
+
+def test_import_preserves_station_speeds_ignoring_payload(tmp_path, monkeypatch) -> None:
+    """Import is device-local for speeds: this station's live {5: 2.7} survives,
+    and speeds carried in the imported payload ({7: 3.3}) are ignored."""
+    server, base = _speeds_server(
+        tmp_path,
+        monkeypatch,
+        live_speeds={5: 2.7},
+        controlled_ids=[5],
+    )
+    try:
+        payload = {
+            "controlled_marker_ids": [5, 7],
+            "marker_move_speeds": {"7": 3.3},
+            "grid": {"width": 30.0},
+        }
+        status, body = _post_json(base, "/api/config/import", payload)
+        assert status == 200
+        assert body.get("success") is True
+
+        reloaded = load_config(server.config_path)
+        # Station's live speed kept; the imported {7: 3.3} did not land.
+        assert reloaded.marker_move_speeds == {5: 2.7}
+    finally:
+        server.stop()
+
+
+def test_export_omits_marker_move_speeds(tmp_path, monkeypatch) -> None:
+    """Per-marker speeds are device-local and must never leave the box via the
+    config export."""
+    server, base = _speeds_server(
+        tmp_path,
+        monkeypatch,
+        live_speeds={5: 2.7},
+        controlled_ids=[5],
+        disk_speeds={5: 2.7},
+    )
+    try:
+        with urllib.request.urlopen(f"{base}/api/config/export", timeout=5) as resp:
+            assert resp.status == 200
+            body = json.loads(resp.read().decode())
+        assert "marker_move_speeds" not in body
+    finally:
+        server.stop()
+
+
+def test_section_broadcast_receive_does_not_carry_or_clobber_speeds(tmp_path, monkeypatch) -> None:
+    """A ``marker`` section applied via ``POST /api/config/<section>`` (the peer
+    broadcast receive) neither injects the provider's live speeds nor writes any
+    ``marker_move_speeds`` – the section apply doesn't touch that top-level field.
+    On-disk speeds (whatever they were) are left as-is."""
+    server, base = _speeds_server(
+        tmp_path,
+        monkeypatch,
+        live_speeds={5: 2.7},
+        controlled_ids=[5],
+        disk_speeds={5: 1.0},
+    )
+    try:
+        status, body = _post_json(base, "/api/config/marker", {"ball_size": 0.3})
+        assert status == 200
+        reloaded = load_config(server.config_path)
+        # The receive path does NOT overlay the live provider value; the disk
+        # value is preserved untouched by the marker-section apply.
+        assert reloaded.marker_move_speeds == {5: 1.0}
+    finally:
+        server.stop()


### PR DESCRIPTION
## The bug

A user reported: *"when I save some setting through the Web UI all the markers speed reset."*

Confirmed by tracing the code end to end. Per-marker move speed lives in `AppConfig.marker_move_speeds` and is written **only at runtime** by the keyboard R/T keys and the gamepad LB/RB bumpers (`adjust_move_speed`). That path never wrote to disk and no web form edits the field.

The reset chain when the operator saved **any** section:
1. The web save loaded a **fresh** config from disk (no live speeds), applied the edited section, and saved it back, writing stale/empty `marker_move_speeds`.
2. The config-file watcher reloaded the file and called `apply_runtime_config_changes`.
3. That unconditionally swapped `app._config.marker_move_speeds = new_config.marker_move_speeds`, clobbering the live dict. Readers then fell back to the global `MarkerConfig.move_speed`. **Speeds appeared reset.**

## Root cause

Per-marker speeds are **device-local and runtime-authoritative** – the live in-memory dict is the source of truth – but the hot-reload treated the disk copy as authoritative and overwrote the live one.

## The fix (four parts)

- **Part 0 (root):** `apply_runtime_config_changes` no longer copies `marker_move_speeds` from a reloaded config into the live app. A hot-reload from any write path leaves the live dict untouched. Startup `load_config` still seeds the initial value from disk. This alone fixes the reported reset for every config-write path.
- **Part 1:** the web section-save path overlays the live speeds onto its fresh disk load. A new `marker_move_speeds_provider` on `ConfigWebServer` (wired in `services.py`, copying under the GIL as the mutation-isolation boundary) feeds a nested `_load_config_for_edit()` helper used by the five operator-local edit-then-save flows (generic section save, `video_source`, `general`, `psn`, broadcast local-apply). The write stays faithful and the ensuing reload is a no-op. Peer-broadcast / API receive deliberately does **not** overlay (documented inline).
- **Part 2 (device-local transfer):** export strips `marker_move_speeds` (via `_config_dict_redacted`, covering export and full-config broadcast); import preserves this station's live speeds and ignores any in the imported payload.
- **Part 3 (restart survival):** `adjust_move_speed` marks the config dirty with a timestamp; a debounced housekeeping check (`check_marker_speeds_persist`, 2.5 s settle) flushes under `config_write_lock` doing load-fresh -> inject live speeds -> save, so a concurrent web section save is never clobbered. The mtime is left alone; the benign follow-up reload is a no-op for speeds.

## Test coverage added

- `test_configuration.py`: hot-reload no longer overwrites live speeds (different **and** empty disk); startup load still seeds from disk.
- `test_web_server.py`: section save preserves the live speed on disk and prunes a de-selected one; export omits `marker_move_speeds`; import keeps the station's own speed and ignores the payload's; broadcast receive neither carries nor clobbers.
- `test_services_init_and_updates.py`: the provider is wired and returns a **copy** (mutation isolation).
- `test_app_modes.py`: `adjust_move_speed` marks dirty + timestamps; a no-op call does not.
- `test_app_orchestration.py` / `test_app_lifecycle.py`: the debounced flush respects the settle window, holds `config_write_lock`, preserves a concurrently-saved section, swallows a write failure and stays dirty (retries), survives a restart round-trip, and is wired into the housekeeping tuple + app delegate.

Coverage stays at 100%.

## CI note

The authoritative pre-push gate is `make ci-remote` (Pi-first: aarch64 / py3.13 / trixie), which can't run from a git worktree. The Mac-local `make ci` was run instead and passes green: lint + `mypy --strict` + bandit + full test suite (100% coverage, 907 integration/smoke + unit) + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)