### PR TITLE
test: cap per-worker OpenCV thread pool to stop the suite freezing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,14 @@ See `docs/PROJECT_STRUCTURE.md` for layout.
   or rewrite the sentence. This applies everywhere: code comments, docstrings,
   UI strings, templates, help text, and Markdown.
 
+## Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org):
+`<type>(<optional scope>): <imperative summary>`. Types: `feat`, `fix`, `test`,
+`docs`, `refactor`, `perf`, `build`, `ci`, `chore`. Keep the summary under ~72
+chars and put the rationale in the body. Do not put issue/PR numbers in the
+summary (see Code comments).
+
 ## Task Management
 
 1. Write plan with checkable items

--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,21 @@
 # value never drifts between local `make test` and CI.
 COVERAGE_MIN ?= 100
 
-# Parallelize the suite with pytest-xdist.
+# Parallelize the suite with pytest-xdist, and cap each worker's native thread
+# pools so the two don't multiply.
 #
 # Worker count is headroom-aware (not ``-n logical``/``-n auto``): small
 # CI/Pi runners (≤4 logical CPUs) use every core, but a fat interactive dev
 # workstation reserves ~1/3 of its cores so the OS/UI stays responsive – a
-# 10-core Mac runs 6 workers and keeps 4 cores free. Saturating every core
-# starves macOS's WindowServer and freezes the machine mid-run. ``getconf`` is
-# portable across macOS/Linux; the ``|| echo 2`` keeps the 2-vCPU CI default if
-# it's absent.
+# 10-core Mac runs 6 workers and keeps 4 cores free. ``getconf`` is portable
+# across macOS/Linux; the ``|| echo 2`` keeps the 2-vCPU CI default if it's
+# absent.
+#
+# Worker count alone is not enough: OpenCV and numpy-BLAS each grow a pool sized
+# to the full core count inside every worker, so N workers fan out to N x cores
+# threads and freeze an interactive workstation regardless of ``-n``.
+# ``PYTEST_THREAD_CAPS`` pins the BLAS/OpenMP pools per worker (Linux/Pi target);
+# the OpenCV pool ignores those env vars on macOS and is capped in conftest.py.
 #
 # ``--dist load`` distributes individual tests across workers; ``loadscope``
 # would pin each large module to one worker and bottleneck on the slowest. Safe
@@ -30,6 +36,11 @@ COVERAGE_MIN ?= 100
 PYTEST_WORKERS ?= $(shell n=$$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2); \
                           if [ "$$n" -gt 4 ]; then echo $$((2 * n / 3)); else echo "$$n"; fi)
 PYTEST_PARALLEL ?= -n $(PYTEST_WORKERS) --dist load
+
+# One thread per worker for the BLAS/OpenMP pools (see the note above). Prefixed
+# onto every pytest invocation so the xdist workers inherit it from the shell.
+PYTEST_THREAD_CAPS ?= OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+                      NUMEXPR_NUM_THREADS=1 VECLIB_MAXIMUM_THREADS=1
 
 ci: lint typecheck security test build
 
@@ -79,26 +90,26 @@ typecheck:
 test: test-unit test-integration
 
 test-unit:
-	poetry run pytest -m unit -q $(PYTEST_PARALLEL) --cov=openfollow --cov-report=term-missing
+	$(PYTEST_THREAD_CAPS) poetry run pytest -m unit -q $(PYTEST_PARALLEL) --cov=openfollow --cov-report=term-missing
 
 test-integration:
-	poetry run pytest -m "integration or smoke" -q $(PYTEST_PARALLEL) --cov=openfollow --cov-append --cov-report=term-missing --cov-fail-under=$(COVERAGE_MIN)
+	$(PYTEST_THREAD_CAPS) poetry run pytest -m "integration or smoke" -q $(PYTEST_PARALLEL) --cov=openfollow --cov-append --cov-report=term-missing --cov-fail-under=$(COVERAGE_MIN)
 
 # End-to-end smoke test. Spins a real GStreamer pipeline and PSN packet
 # through OTP/RTTrPM output sockets. Opt-in, OUT of `make ci` (needs
 # GStreamer runtime). Per-main-push signal, not a PR gate. Skips if
 # GStreamer isn't installed.
 test-smoke-e2e:
-	poetry run pytest -m smoke_e2e -q
+	$(PYTEST_THREAD_CAPS) poetry run pytest -m smoke_e2e -q
 
 coverage:
-	poetry run pytest -q $(PYTEST_PARALLEL) --cov=openfollow --cov-report=term-missing
+	$(PYTEST_THREAD_CAPS) poetry run pytest -q $(PYTEST_PARALLEL) --cov=openfollow --cov-report=term-missing
 
 coverage-html:
-	poetry run pytest -q $(PYTEST_PARALLEL) --cov=openfollow --cov-report=html:htmlcov --cov-report=term
+	$(PYTEST_THREAD_CAPS) poetry run pytest -q $(PYTEST_PARALLEL) --cov=openfollow --cov-report=html:htmlcov --cov-report=term
 
 coverage-xml:
-	poetry run pytest -q $(PYTEST_PARALLEL) --cov=openfollow --cov-report=xml:coverage.xml --cov-report=term
+	$(PYTEST_THREAD_CAPS) poetry run pytest -q $(PYTEST_PARALLEL) --cov=openfollow --cov-report=xml:coverage.xml --cov-report=term
 
 build:
 	poetry build --no-interaction

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,24 @@ settings.register_profile("dev", max_examples=200, deadline=None, print_blob=Tru
 settings.register_profile("ci", parent=settings.get_profile("dev"), derandomize=True)
 settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "dev"))
 
+# Cap native thread pools to one thread per worker. Each xdist worker's OpenCV
+# pool otherwise grows to the full core count on first use, so N workers fan out
+# to N x cores threads and freeze an interactive desktop. macOS OpenCV uses GCD
+# and ignores the OMP_/BLAS env vars, so setNumThreads is the only lever (the
+# Makefile caps BLAS for the OpenBLAS Linux/Pi target). See test_thread_headroom.
+try:
+    import cv2
+
+    cv2.setNumThreads(1)
+except Exception:  # cv2 is an optional extra, absent in minimal envs
+    pass
+try:
+    import torch
+
+    torch.set_num_threads(1)
+except Exception:  # torch is an optional extra, absent in minimal envs
+    pass
+
 # Suite markers declared in pyproject.toml [tool.pytest.ini_options]. A
 # collected test that carries none of these is defaulted to ``unit`` (with a
 # warning) by pytest_collection_modifyitems below, so it can't silently vanish.

--- a/tests/test_thread_headroom.py
+++ b/tests/test_thread_headroom.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""Regression guard: the suite must not oversubscribe OpenCV's thread pool.
+
+Each pytest-xdist worker imports OpenCV, whose parallel pool otherwise grows to
+the full core count on first use; N workers running cv2 ops at once fan out to
+N x cores threads and freeze an interactive desktop. tests/conftest.py caps it
+with cv2.setNumThreads(1). These tests pin that so dropping the cap fails loudly.
+"""
+
+import os
+import subprocess
+import sys
+
+import numpy as np
+import psutil
+import pytest
+
+pytestmark = pytest.mark.unit
+
+cv2 = pytest.importorskip("cv2")
+
+# Absolute OS thread count of a fresh process after a burst of cv2 parallel ops.
+# ``cap`` is Python injected right after the cv2 import (empty = leave default).
+_PROBE = (
+    "import numpy as np, cv2, psutil\n"
+    "{cap}\n"
+    "img = (np.random.rand(480, 640) * 255).astype('uint8')\n"
+    "clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))\n"
+    "for _ in range(20):\n"
+    "    clahe.apply(img)\n"
+    "print(psutil.Process().num_threads())\n"
+)
+
+
+def _probe_threads(cap: str) -> int:
+    out = subprocess.run(
+        [sys.executable, "-c", _PROBE.format(cap=cap)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return int(out.stdout.strip().splitlines()[-1])
+
+
+def test_setnumthreads_caps_the_opencv_pool() -> None:
+    """setNumThreads(1) collapses the pool – the lever conftest.py relies on.
+
+    Measured in isolated subprocesses so nothing in the test worker masks it.
+    """
+    uncapped = _probe_threads(cap="")
+    capped = _probe_threads(cap="cv2.setNumThreads(1)")
+    assert uncapped >= 3, f"expected OpenCV to fan out uncapped, saw {uncapped} threads"
+    assert capped < uncapped
+    assert capped <= 2, f"setNumThreads(1) left {capped} threads"
+
+
+def test_conftest_caps_opencv_in_the_test_process() -> None:
+    """conftest.py must cap OpenCV in the worker itself, not just a subprocess.
+
+    Warm cv2 here, then compare this (capped) worker's thread count against a
+    freshly spawned uncapped process: capped stays far below the full pool. The
+    pool only registers on >=4 cores, so below that the signal is unmeasurable.
+    """
+    if (os.cpu_count() or 1) < 4:
+        pytest.skip("OpenCV pool too small to measure below 4 cores")
+    img = (np.random.rand(480, 640) * 255).astype("uint8")
+    clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
+    for _ in range(20):
+        clahe.apply(img)
+    in_process = psutil.Process().num_threads()
+    uncapped = _probe_threads(cap="")
+    assert in_process < uncapped, (
+        f"this worker holds {in_process} threads vs {uncapped} for an uncapped process - conftest.py did not cap OpenCV"
+    )


### PR DESCRIPTION
## Problem

`make test` / `make ci` / `make coverage` still froze the MacBook M1 Max (10 cores, 64 GB) completely, even after PR #36 lowered the pytest-xdist worker count from `-n 8` to `-n 6`. The machine was unusable for the whole run.

## Root cause (measured, not guessed)

The `-n` worker cap controls *Python-level* parallelism, but each worker process independently spins up a **native OpenCV thread pool sized to the full core count (10)**. `cv2` creates it the first time any parallel primitive runs (`CLAHE.apply`, `resize`) and it **persists for the worker's lifetime**.

Under `--dist load`, cv2-touching detection/overlay/tracking tests spread across all 6 workers, so every worker ends up holding a ~10-thread OpenCV pool. When several run a `cv2` op at once, dozens of CPU-bound threads become runnable on 10 cores, saturating every core (including the 4 PR #36 "reserved") and starving macOS's WindowServer. Cutting `-n 8` to `-n 6` only trimmed this from ~80 to ~60 threads, so it kept freezing.

Measured on the affected machine (`psutil.Process().num_threads()`):

| Condition | Extra OS threads from one `cv2` CLAHE workload |
|---|---|
| default | **+10** per process |
| `cv2.setNumThreads(1)` | **+0** |
| `OMP_/OPENBLAS_/MKL_/VECLIB_ = 1` (env vars only) | **+10** (no effect on macOS) |

On the macOS `opencv-python` wheel the pool uses GCD and **ignores** `OMP_NUM_THREADS` / `OPENBLAS_NUM_THREADS` / `VECLIB_MAXIMUM_THREADS`; `cv2.setNumThreads()` is the only lever. numpy (Apple Accelerate) stays single-threaded for the small solver/overlay matrices, and ONNX inference is mocked in tests, so OpenCV is the dominant amplifier. Memory is not a factor.

## Fix

- **`tests/conftest.py`** - `cv2.setNumThreads(1)` + `torch.set_num_threads(1)` at import. Runs in every xdist worker on every invocation (make, bare pytest, IDE). This is the actual fix.
- **`Makefile`** - `PYTEST_THREAD_CAPS` (`OMP/OPENBLAS/MKL/NUMEXPR/VECLIB=1`) prefixed on the pytest/coverage recipes. Belt-and-suspenders for the OpenBLAS-backed Linux/Pi CI target (where these env vars *do* work); the `2n/3` worker headroom from #36 stays.
- **`tests/test_thread_headroom.py`** - regression guard (subprocess + `psutil`) that fails if the conftest cap is ever dropped. Confirmed it passes with the cap and fails without it.

No product-code change: on-device detection runs in a single background thread, so it was never oversubscribed.

## Verification

- `make test` -> **902 passed, 100.00% coverage**, machine responsive throughout (interactive commands ran with zero lockup).
- During the run, workers held **3-6 idle threads each** instead of ~11+ CPU-bound.
- `make lint`, `make typecheck` pass. New guard test passes and discriminates (fails when the cap is removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)