### PR TITLE
fix(detection): bundle backend in .deb, make export install opt-in

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -118,6 +118,11 @@ Installed only when the corresponding extra is requested
 
 > The prebuilt `opencv-python` wheels bundle additional libraries (e.g. FFmpeg)
 > under their own licenses, including the LGPL. These are AGPLv3-compatible.
+>
+> The `detection` backend (onnxruntime + opencv) is **bundled** in the macOS app
+> and the Raspberry Pi appliance image, so detection runs offline out of the box;
+> both are permissively licensed. Only the `export` toolchain below stays out of
+> the image.
 
 ### `export`
 
@@ -130,8 +135,8 @@ Installed only when the corresponding extra is requested
 > and the web model-export action). It is **never required at runtime**: OpenFollow
 > invokes it as a separate subprocess on a workstation, never links or imports it
 > into the running program, and it is **not bundled in the appliance image** (the
-> release-time SBOM check keeps the detection extras, ultralytics included, out of
-> the bundled venv by name). Operators install it on demand on a dev machine; the
+> release-time SBOM check keeps ultralytics out of the bundled venv by name).
+> Operators install it on demand on a dev machine; the
 > show Pi never sees it. ultralytics is AGPL-3.0-or-later – the same license as
 > OpenFollow itself – so it raises no additional licensing concern where used.
 
@@ -196,14 +201,15 @@ carries each license's own obligations:
   user can build and install modified GPL/LGPL binaries (via `apt`/`dpkg`, over
   SSH, or by re-flashing) and run them on the device.
 
-**OpenFollow's optional detection feature (the `onnxruntime` / OpenCV Python
-extras) and the NDI components are not bundled in the appliance image** – the
-NDI SDK is proprietary (§6). A release-time SBOM check fails the build if the
-proprietary NDI component appears anywhere in the image, or if a detection extra
-(ultralytics / onnxruntime / OpenCV) is bundled in the venv.
-The base GStreamer stack (`gstreamer1.0-plugins-bad`) does transitively include a
+**OpenFollow's detection backend (`onnxruntime` + OpenCV) is bundled in the
+appliance image so detection runs offline; the AGPL model-export toolchain
+(`ultralytics` / `torch`) and the NDI components are not** – the NDI SDK is
+proprietary (§6). A release-time SBOM check fails the build if the proprietary
+NDI component appears anywhere in the image, or if `ultralytics` is bundled in
+the venv.
+The base GStreamer stack (`gstreamer1.0-plugins-bad`) also transitively includes a
 permissively-licensed `libonnxruntime` system library; it carries no AGPL or
-proprietary obligation and is unrelated to OpenFollow's detection feature.
+proprietary obligation and is separate from OpenFollow's own bundled backend.
 
 OpenFollow is built on Debian GNU/Linux and Raspberry Pi OS components but is
 **not affiliated with or endorsed by** the Debian Project, Raspberry Pi Ltd, or

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -44,7 +44,7 @@ is the input artifact for the `rpi-image-gen` appliance image build
 ## Install layout
 
 ```
-/opt/openfollow/venv/                      all Python deps + the openfollow package
+/opt/openfollow/venv/                      all Python deps + the openfollow package (incl. the detection backend: onnxruntime + opencv)
 /usr/lib/systemd/system/openfollow.service
 /usr/lib/systemd/system/openfollow-splash.service
 /usr/share/openfollow/{openfollow.svg,splash.png,splash.sh,config.example.toml,install-ndi.sh,install-detection.sh}
@@ -270,9 +270,10 @@ attaches **`openfollow-<target>_<version>.spdx.json`** (SPDX 2.3 JSON) to the
 GitHub Release alongside the `.img.xz`, and uploads it as the
 `openfollow-sbom-<target>` workflow artifact on every run. It is the
 machine-readable companion to the curated
-[`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md); the optional
-`detection` extra is not installed in the image, so it is documented there
-rather than in the SBOM.
+[`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md). The detection **backend**
+(`onnxruntime` + `opencv`) is bundled in the venv, so it appears in the SBOM; the
+AGPL model-**export** toolchain (`ultralytics` / `torch`) is not installed in the
+image and is documented in the notices instead.
 
 ### Compliance gate
 
@@ -282,18 +283,19 @@ scans it and **fails the build before either release-attach** if it finds:
 
 - **NDI** anywhere, by package name – the proprietary NDI SDK/plugin, whose
   license metadata is unreliable.
-- **Detection extras** (`onnxruntime` / `opencv` / `ultralytics`) bundled in the
-  **venv** – OpenFollow's own optional feature. These are permissively licensed,
-  so a transitive copy in the OS media stack (Debian's `gstreamer1.0-plugins-bad`
-  pulls `libonnxruntime`) is fine; the gate only asserts the extras stay out of
-  the bundled venv. The name gate also keeps Ultralytics (AGPL-3.0) out of the
-  venv regardless of its license.
+- **The model-export toolchain** (`ultralytics`) bundled in the **venv** – it is
+  AGPL-3.0 and only needed to *export* models on a workstation, never at show
+  time. The inference **backend** (`onnxruntime` + `opencv`) is bundled on purpose
+  – both are permissively licensed – so detection runs on an offline Pi with no
+  pip; the gate scopes to venv (pypi) packages, so a transitive copy in the OS
+  media stack (Debian's `gstreamer1.0-plugins-bad` pulls `libonnxruntime`) never
+  trips it.
 
 There is **no blanket AGPL-license gate**: OpenFollow itself is
 AGPL-3.0-or-later, so AGPL is the image's own license, not a forbidden one. The
 Debian operating system it sits beside is an independent work combined on the
-same medium (mere aggregation, predominantly GPL-2.0). This proves "OpenFollow's
-detection feature and NDI are not shipped" is enforced, not just intended, and
+same medium (mere aggregation, predominantly GPL-2.0). This proves "the AGPL
+export toolchain and NDI are not shipped" is enforced, not just intended, and
 keeps the proprietary NDI code out of the image. The accepted, redistributable
 Raspberry Pi GPU firmware blob is proprietary but is **not** flagged.
 

--- a/openfollow/web/help/detection.md
+++ b/openfollow/web/help/detection.md
@@ -8,15 +8,13 @@ Experimental YOLO-based person detection that finds people in the camera frame a
 
 ## Dependencies
 
-On the macOS app everything needed is bundled. On a Raspberry Pi the inference backend (onnxruntime + opencv) is an optional install:
+Nothing to install: the inference backend (onnxruntime + opencv) is bundled in the macOS app and the Raspberry Pi image, so detection runs offline out of the box.
 
-```
-bash /usr/share/openfollow/install-detection.sh
-```
+If the backend isn't present (a source checkout, or a base-only build), install it into the app venv: `bash scripts/install-detection.sh` from a checkout, or `bash /usr/share/openfollow/install-detection.sh` on a packaged install.
 
-It checks for free space first, uses the NVMe when one is present, installs everything into the app venv, and restarts the service. Re-run it any time; it's idempotent. See https://openfollow.app/docs/detection-install.html.
+It checks free space, uses the NVMe when present, and restarts the service. Idempotent. Add `--with-export` on a workstation for the model-export tools (torch + ultralytics) the **Download Model** action uses; those are large, AGPL, and not needed on a show Pi. See https://openfollow.app/docs/detection-install.html.
 
-If the section shows a red "Detection needs extra components" banner, the backend isn't installed yet – run that command, then reload.
+If the red "Detection needs extra components" banner shows, the backend isn't installed; run that command, then reload.
 
 ## Tracking
 

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -5192,7 +5192,7 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         if not _export_tools_available():
             return _render_detection(
                 cfg,
-                install_feedback="Install the model export tools first: run install-detection.sh.",
+                install_feedback="Install the model export tools first: run install-detection.sh --with-export.",
                 install_error=True,
             )
         models_dir = _resolved_models_dir(cfg.detection.storage_path)

--- a/openfollow/web/templates/partials/detection_model_download.tpl
+++ b/openfollow/web/templates/partials/detection_model_download.tpl
@@ -16,7 +16,7 @@
             model-export tools and an internet connection.
         </span>
 %     if not export_installed:
-        <p class="section-note">Install the model-export tools (run <code>install-detection.sh</code>) to enable downloads.</p>
+        <p class="section-note">Install the model-export tools (run <code>install-detection.sh --with-export</code>) to enable downloads.</p>
 %     end
 %     if export_installed:
         <div class="row">

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -108,10 +108,21 @@ log "stamping package version: $pep440_version"
 cp -f "$PYPROJECT" "$PYPROJECT_BAK"
 sed -i -E "0,/^version = \".*\"/s//version = \"$pep440_version\"/" "$PYPROJECT"
 
-log "installing openfollow + dependencies (base, no detection extra) ..."
 # PEP 517 build via poetry-core; pulls runtime deps from pyproject. Compiles
 # PyGObject / python-rtmidi from sdist when no wheel matches this Python.
-"$VENV/bin/pip" install "$REPO_ROOT"
+# The detection backend (onnxruntime + opencv, both permissive) is bundled so an
+# offline Pi runs detection with no pip; the heavy AGPL export toolchain
+# (torch / ultralytics) is not. Set OF_DEB_SKIP_DETECTION=1 for a base-only .deb
+# (mirrors OF_DEB_SKIP_MODELS).
+if [ "${OF_DEB_SKIP_DETECTION:-0}" = "1" ]; then
+  WITH_DETECTION=0
+  log "OF_DEB_SKIP_DETECTION=1 - installing openfollow base only (no detection backend) ..."
+  "$VENV/bin/pip" install "$REPO_ROOT"
+else
+  WITH_DETECTION=1
+  log "installing openfollow + dependencies + detection backend (onnxruntime + opencv; no torch/ultralytics) ..."
+  "$VENV/bin/pip" install "$REPO_ROOT[detection]"
+fi
 
 # PyGObject / pycairo MUST come from the OS (python3-gi, python3-gi-cairo) so
 # they match the distro's gobject-introspection typelibs + libgirepository.
@@ -146,7 +157,7 @@ done
 
 # Sanity: the package and its heavy deps must import from the bundled venv, and
 # GStreamer must load via the OS PyGObject (the exact path that broke before).
-"$VENV/bin/python" - <<'PY'
+OF_SMOKE_WITH_DETECTION="$WITH_DETECTION" "$VENV/bin/python" - <<'PY'
 import gi
 gi.require_version("Gst", "1.0")
 from gi.repository import Gst  # OS PyGObject via system site-packages
@@ -159,10 +170,29 @@ from packaging.version import Version  # noqa: F401
 # host's system site-packages (which a slim target image won't have). `packaging`
 # regressed exactly this way once: --system-site-packages let pip skip it because
 # the runner had python3-packaging. Assert it loads from inside the venv prefix.
+import importlib.util
 import os, sys
 prefix = os.path.realpath(sys.prefix)
 mod = os.path.realpath(packaging.__file__)
 assert mod.startswith(prefix + os.sep), f"packaging not bundled in venv: {mod}"
+
+# Detection backend must be bundled (import from the venv prefix); the AGPL
+# export toolchain (torch / ultralytics) must not be – the SBOM gate's boundary,
+# verified here at build time.
+if os.environ.get("OF_SMOKE_WITH_DETECTION") == "1":
+    import cv2  # noqa: F401
+    import onnxruntime
+    for probe in (onnxruntime, cv2):
+        path = os.path.realpath(probe.__file__)
+        assert path.startswith(prefix + os.sep), f"detection backend not bundled in venv: {path}"
+    # system-site-packages is on, so a global torch/ultralytics is fine; assert
+    # only that neither is bundled inside the venv (origin under the prefix).
+    for forbidden in ("torch", "ultralytics"):
+        spec = importlib.util.find_spec(forbidden)
+        origin = os.path.realpath(spec.origin) if spec and spec.origin else ""
+        assert not origin.startswith(prefix + os.sep), f"{forbidden} must not be bundled in the venv (size / AGPL): {origin}"
+    print("[build-deb] detection backend smoke OK: onnxruntime + cv2 bundled, no torch/ultralytics in venv")
+
 print("[build-deb] venv import smoke OK:", openfollow.__version__, "| Gst", Gst.version_string())
 PY
 
@@ -205,8 +235,11 @@ install -m 0755 "$DEBIAN_DIR/apply-update.sh"                     "$SHARE/apply-
 # NDI is not bundled (closed-source SDK); this helper builds + installs it
 # post-install. See https://openfollow.app/docs/ndi-install.html.
 install -m 0755 "$REPO_ROOT/scripts/install-ndi.sh"               "$SHARE/install-ndi.sh"
-# Detection deps are not bundled (torch is large + ultralytics is AGPL-3.0); this
-# helper installs them into the app venv on demand. See
+# The detection backend (onnxruntime + opencv) is bundled in the venv above, so
+# detection runs on the Pi out of the box. This helper remains for source/dev
+# installs and to add the model-export toolchain on a workstation
+# (`install-detection.sh --with-export`; torch is large + ultralytics is
+# AGPL-3.0, so neither is bundled). See
 # https://openfollow.app/docs/detection-install.html.
 install -m 0755 "$REPO_ROOT/scripts/install-detection.sh"         "$SHARE/install-detection.sh"
 # Model export script: exported ONNX models land in the detection storage

--- a/packaging/image/check_sbom_compliance.py
+++ b/packaging/image/check_sbom_compliance.py
@@ -6,11 +6,12 @@ final rootfs (dpkg + venv) and enforces:
 
 * NDI (whole image) – the proprietary NDI SDK/plugin, matched by name (its
   license metadata is unreliable).
-* Detection extras (venv only) – `onnxruntime`/`opencv`/`ultralytics` must not be
-  bundled as OpenFollow's own Python feature. They are permissively licensed, so
-  a transitive copy in the OS media stack (e.g. gstreamer pulls libonnxruntime)
-  is fine; we only assert our extras stay out of the bundled venv. The name gate
-  also keeps Ultralytics (AGPL-3.0) out of the venv regardless of license.
+* Export toolchain (venv only) – `ultralytics` must not be bundled in the venv:
+  it is AGPL-3.0 and is only needed to *export* models on a workstation, never at
+  show time. The inference backend (`onnxruntime` + `opencv`) IS bundled in the
+  venv on purpose – both are permissively licensed – so detection runs on an
+  offline Pi with no pip. The venv scope (pypi purl only) means a transitive copy
+  in the OS media stack (e.g. gstreamer pulls libonnxruntime) never trips it.
 
 OpenFollow itself is AGPL-3.0-or-later, so there is no blanket AGPL-license gate:
 AGPL is the image's own license, and the Debian OS it sits beside is an
@@ -33,11 +34,12 @@ _GLOBAL_DENYLISTED_NAMES = [
     ("ndi", re.compile(r"(?:^|-)ndi(?:$|-)|libndi")),
 ]
 
-# Names forbidden only in the bundled venv – OpenFollow's optional detection extras.
+# Names forbidden in the bundled venv – the AGPL model-export toolchain. The
+# inference backend (onnxruntime + opencv, both permissive) is bundled on purpose
+# so detection runs offline; only ultralytics (AGPL-3.0, export-only, workstation)
+# must stay out.
 _VENV_DENYLISTED_NAMES = [
     ("ultralytics", re.compile(r"ultralytics")),
-    ("onnxruntime", re.compile(r"onnxruntime")),
-    ("opencv", re.compile(r"opencv")),
 ]
 
 
@@ -116,7 +118,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  - {line}", file=sys.stderr)
         return 1
 
-    print("[check-sbom] OK: no NDI / bundled detection extras in the image.")
+    print("[check-sbom] OK: no NDI / bundled export toolchain in the image.")
     return 0
 
 

--- a/scripts/install-detection.sh
+++ b/scripts/install-detection.sh
@@ -1,20 +1,26 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (C) 2026 OpenFollow Project
-# Install OpenFollow person-detection support: the ONNX Runtime backend
-# (onnxruntime + opencv-python) plus the ultralytics export toolchain, into the
-# application venv. Documented at https://openfollow.app/docs/detection-install.html.
-# Idempotent; safe to re-run.
+# Install OpenFollow person-detection support into the application venv.
+# Documented at https://openfollow.app/docs/detection-install.html. Idempotent.
 #
-# These are not bundled in the image: torch (pulled by ultralytics) is large and
-# ultralytics is AGPL-3.0, so the operator fetches them on demand instead.
+# The inference backend (onnxruntime + opencv-python) is all a Pi needs to run
+# detection against a pre-exported .onnx model; on the packaged Pi image it is
+# already bundled in the venv, so a bare run there is a no-op. This installs it
+# for source / dev checkouts.
+#
+# The model-export toolchain (torch + ultralytics + onnx) is a separate,
+# workstation-only add-on installed with --with-export. torch is large and
+# ultralytics is AGPL-3.0, so neither is bundled in the image nor needed at show
+# time.
 #
 # Run as the normal user (e.g. ``openfollow``), NOT root – the script invokes
 # ``sudo`` itself only to write into the packaged (root-owned) venv.
 #
 # Usage (run from a checkout, or the packaged copy that the .deb / image install
 # ships at /usr/share/openfollow/install-detection.sh):
-#   install-detection.sh                 install the detection stack
+#   install-detection.sh                 install the detection backend
+#   install-detection.sh --with-export   also install the model-export toolchain
 #   install-detection.sh --force         reinstall even if already present
 #   install-detection.sh --no-restart    skip restarting the openfollow service
 set -euo pipefail
@@ -28,12 +34,16 @@ die() {
 
 usage() {
   cat <<'USAGE'
-Install OpenFollow person-detection support (onnxruntime + opencv-python +
-ultralytics) into the app venv. Idempotent. Run as your normal user (not root);
-the script uses sudo only to write into the packaged venv.
+Install OpenFollow person-detection support into the app venv. The inference
+backend (onnxruntime + opencv-python) is all the Pi needs and is already bundled
+on the packaged image; this installs it for source / dev checkouts. Idempotent.
+Run as your normal user (not root); the script uses sudo only to write into the
+packaged venv.
 
 Usage:
-  install-detection.sh                 install the detection stack
+  install-detection.sh                 install the detection backend
+  install-detection.sh --with-export   also install the model-export toolchain
+                                       (torch + ultralytics; workstation only)
   install-detection.sh --force         reinstall even if already present
   install-detection.sh --no-restart    skip restarting the openfollow service
 USAGE
@@ -42,7 +52,8 @@ USAGE
 # Tunables (overridable via env for tests / non-standard installs).
 VENV_PY_DEFAULT="${OPENFOLLOW_VENV_PY:-/opt/openfollow/venv/bin/python}"
 NVME_MOUNT="${OPENFOLLOW_NVME_MOUNT:-/mnt/nvme}"
-MAIN_MIN_MB=4096    # hard gate: require 4 GiB free where the packages land
+BACKEND_MIN_MB="${OPENFOLLOW_BACKEND_MIN_MB:-512}"   # hard gate: backend-only install (onnxruntime+opencv)
+EXPORT_MIN_MB="${OPENFOLLOW_EXPORT_MIN_MB:-4096}"    # hard gate: --with-export adds the multi-GiB torch stack
 MODEL_WARN_MB=24576 # advisory: warn under 24 GiB where models land
 
 # --- pure helpers (unit-tested by sourcing this file) ----------------------
@@ -127,14 +138,35 @@ If NTP cannot reach a server (UDP port 123 is often blocked), set it by hand:
 MSG
 }
 
+# True when pip output shows no DNS / no network route (offline show-LAN: static
+# IP, no gateway / no DNS). Narrow on purpose: a reachable-but-refused / timed-out
+# mirror falls through to the generic error. Reads output on stdin.
+network_unreachable_in() {
+  grep -qiE 'temporary failure in name resolution|could not resolve host|name or service not known|network is unreachable|no route to host' 2>/dev/null
+}
+
+offline_message() {
+  cat <<'MSG'
+this host has no working internet connection (DNS resolution or the network
+route failed), so pip cannot download the detection packages.
+
+On the packaged Raspberry Pi image the detection backend already ships in the
+app venv, so nothing needs downloading – just reload the web page.
+
+For a source install, or to add the export tools with --with-export, run this on
+a network with an uplink (or point pip at a local package mirror), then re-run.
+MSG
+}
+
 # --- main ------------------------------------------------------------------
 
 main() {
-  local FORCE=0 RESTART=1
+  local FORCE=0 RESTART=1 WITH_EXPORT=0
   for arg in "$@"; do
     case "$arg" in
       --force | --reinstall) FORCE=1 ;;
       --no-restart) RESTART=0 ;;
+      --with-export | --export) WITH_EXPORT=1 ;;
       -h | --help)
         usage
         exit 0
@@ -156,10 +188,29 @@ main() {
   fi
   log "Using interpreter: $venv_py"
 
-  # --- Step 1: storage preflight (before any install side effect) ----------
+  # --- Already installed? --------------------------------------------------
+  # Backend bundled in the packaged venv -> bare run is a no-op. Checked before
+  # the preflight so a satisfied backend never trips the space gate.
+  if [ "$FORCE" -eq 0 ] && "$venv_py" -c "import onnxruntime, cv2" >/dev/null 2>&1; then
+    if [ "$WITH_EXPORT" -eq 0 ]; then
+      log "onnxruntime + opencv already present – detection backend is installed. Re-run with --force to reinstall, or --with-export to add the model-export toolchain."
+      exit 0
+    fi
+    if "$venv_py" -c "import ultralytics, onnx" >/dev/null 2>&1; then
+      log "detection backend + export toolchain already present. Re-run with --force to reinstall."
+      exit 0
+    fi
+    log "detection backend present; installing the requested model-export toolchain…"
+  fi
+
+  # --- Storage preflight (before any install side effect) ------------------
+  # The backend (onnxruntime + opencv) is small; the export toolchain (torch +
+  # ultralytics) is multi-GiB, so require the large headroom only with --with-export.
   local venv_root
   venv_root="$(cd "$(dirname "$venv_py")/.." && pwd)"
-  require_free_mb "main storage" "$(free_mb "$venv_root")" "$MAIN_MIN_MB" "$venv_root"
+  local main_min_mb=$BACKEND_MIN_MB
+  [ "$WITH_EXPORT" -eq 1 ] && main_min_mb=$EXPORT_MIN_MB
+  require_free_mb "main storage" "$(free_mb "$venv_root")" "$main_min_mb" "$venv_root"
 
   local mounted=0
   is_mounted "$NVME_MOUNT" && mounted=1 || true
@@ -182,14 +233,6 @@ main() {
     fi
   fi
 
-  # Already installed? Nothing to do.
-  if [ "$FORCE" -eq 0 ] && "$venv_py" -c "import onnxruntime, cv2" >/dev/null 2>&1; then
-    log "onnxruntime + opencv already present – detection backend is installed. Re-run with --force to reinstall."
-    "$venv_py" -c "import ultralytics, onnx" >/dev/null 2>&1 ||
-      warn "the model export tools (ultralytics + onnx) are not fully installed; the Download Model action stays unavailable. Re-run with --force to add them."
-    exit 0
-  fi
-
   # Writing into a root-owned (packaged) venv needs sudo; a user-owned checkout
   # venv does not.
   local sudo_pip=""
@@ -200,51 +243,82 @@ main() {
     log "venv is not writable by $(id -un); using sudo for pip."
   fi
 
-  # --- Install: prefer the explicit CPU-only torch wheel first. On x86_64 this
-  #     drops the ~400 MiB of unused CUDA libs the default wheel bundles; on
-  #     aarch64 the default wheel is already CPU-only, so it's a no-op win there.
-  #     Fall back to the default wheel when no CPU build exists for this platform.
-  # Capture each pip run's output (while still streaming it live via tee) so a
-  # failure can be classified: a wrong clock surfaces a clear fix instead of a
-  # raw SSL traceback.
-  local pip_log
+  # Capture each pip run's output (streamed live via tee) so a failure can be
+  # classified. Not 'local': the EXIT trap runs after main returns, so pip_log
+  # must stay in scope (else set -u aborts cleanup on a successful run).
   pip_log="$(mktemp 2>/dev/null || echo "/tmp/openfollow-install-detection-pip.$$.log")"
   trap 'rm -f "$pip_log"' EXIT
 
-  log "Installing CPU-only torch + torchvision (PyTorch CPU index)…"
-  # shellcheck disable=SC2086
-  if ! $sudo_pip env $pip_env "$venv_py" -m pip install --index-url https://download.pytorch.org/whl/cpu torch torchvision 2>&1 | tee "$pip_log"; then
-    if clock_skew_in <"$pip_log"; then die "$(clock_skew_message)"; fi
-    warn "CPU-only torch install failed; falling back to the default wheel (on x86_64 this also pulls unused CUDA libs)."
+  # --- Step 1: the inference backend (onnxruntime + opencv) – the hard gate.
+  #     This is all a Pi needs to run detection against a pre-exported .onnx; on
+  #     the packaged image it is already bundled, so this step is skipped there.
+  if [ "$FORCE" -eq 1 ] || ! "$venv_py" -c "import onnxruntime, cv2" >/dev/null 2>&1; then
+    log "Installing the detection backend (onnxruntime + opencv-python)…"
     # shellcheck disable=SC2086
-    if ! $sudo_pip env $pip_env "$venv_py" -m pip install torch torchvision 2>&1 | tee "$pip_log"; then
+    if ! $sudo_pip env $pip_env "$venv_py" -m pip install "onnxruntime>=1.17" "opencv-python>=4.8" 2>&1 | tee "$pip_log"; then
       if clock_skew_in <"$pip_log"; then die "$(clock_skew_message)"; fi
-      die "pip could not install torch/torchvision – see the output above. Check the network connection and re-run."
+      if network_unreachable_in <"$pip_log"; then die "$(offline_message)"; fi
+      die "pip could not install the detection backend – see the output above. Check the network connection and re-run."
     fi
+  else
+    log "Detection backend (onnxruntime + opencv) already present."
   fi
-  # onnx + onnxslim land in the venv here so the export never falls back to a
-  # per-user pip install (the packaged venv is root-owned and a venv doesn't
-  # import ~/.local), which is what left export failing with "No module named
-  # 'onnx'" until now.
-  log "Installing onnxruntime + opencv-python + the export tools (ultralytics + onnx + onnxslim)…"
-  # shellcheck disable=SC2086
-  if ! $sudo_pip env $pip_env "$venv_py" -m pip install "onnxruntime>=1.17" "opencv-python>=4.8" ultralytics onnx onnxslim 2>&1 | tee "$pip_log"; then
-    if clock_skew_in <"$pip_log"; then die "$(clock_skew_message)"; fi
-    die "pip could not install the detection backend – see the output above. Check the network connection and re-run."
+
+  # --- Step 2 (opt-in): model-export toolchain, workstation only. Large + AGPL,
+  #     so never on a show Pi. Failure doesn't abort (backend is what runs), but
+  #     flips export_ok so a scripted --with-export caller sees a non-zero exit.
+  local export_ok=1
+  if [ "$WITH_EXPORT" -eq 1 ]; then
+    # Prefer the explicit CPU-only torch wheel: on x86_64 this drops ~400 MiB of
+    # unused CUDA libs the default wheel bundles; on aarch64 the default wheel is
+    # already CPU-only. Fall back to the default wheel when no CPU build exists.
+    # CPU-only wheel first: drops ~400 MiB of CUDA libs on x86_64; a no-op on
+    # aarch64. Fall back to the default wheel when no CPU build exists.
+    log "Installing the model-export toolchain: CPU-only torch + torchvision (PyTorch CPU index)…"
+    # shellcheck disable=SC2086
+    if ! $sudo_pip env $pip_env "$venv_py" -m pip install --index-url https://download.pytorch.org/whl/cpu torch torchvision 2>&1 | tee "$pip_log"; then
+      if clock_skew_in <"$pip_log"; then warn "$(clock_skew_message)"; fi
+      warn "CPU-only torch install failed; falling back to the default wheel."
+      # shellcheck disable=SC2086
+      if ! $sudo_pip env $pip_env "$venv_py" -m pip install torch torchvision 2>&1 | tee "$pip_log"; then
+        if clock_skew_in <"$pip_log"; then warn "$(clock_skew_message)"; fi
+        if network_unreachable_in <"$pip_log"; then warn "$(offline_message)"; fi
+        warn "could not install torch/torchvision; model export (Download Model) stays unavailable."
+        export_ok=0
+      fi
+    fi
+    # onnx + onnxslim go in the same venv so export doesn't fall back to a
+    # per-user pip install (a venv doesn't import ~/.local).
+    log "Installing the export tools (ultralytics + onnx + onnxslim)…"
+    # shellcheck disable=SC2086
+    if ! $sudo_pip env $pip_env "$venv_py" -m pip install ultralytics onnx onnxslim 2>&1 | tee "$pip_log"; then
+      if clock_skew_in <"$pip_log"; then warn "$(clock_skew_message)"; fi
+      if network_unreachable_in <"$pip_log"; then warn "$(offline_message)"; fi
+      warn "could not install the export tools (ultralytics/onnx); model export (Download Model) stays unavailable."
+      export_ok=0
+    fi
   fi
 
   # --- Verify --------------------------------------------------------------
-  # The detection backend is onnxruntime + opencv (the hard gate); the export
-  # tools are optional, so a missing import warns, never fails.
+  # Backend is the hard gate; export tools are optional (warn, don't die).
   "$venv_py" -c "import onnxruntime, cv2" >/dev/null 2>&1 || die "detection backend still not importable after install."
   log "Verified: onnxruntime + opencv import cleanly."
-  "$venv_py" -c "import ultralytics, onnx" >/dev/null 2>&1 ||
-    warn "the export tools (ultralytics + onnx) did not import after install; model export (Download Model) will be unavailable."
+  if [ "$WITH_EXPORT" -eq 1 ]; then
+    "$venv_py" -c "import ultralytics, onnx" >/dev/null 2>&1 || {
+      warn "the export tools (ultralytics + onnx) did not import after install; model export (Download Model) will be unavailable."
+      export_ok=0
+    }
+  fi
 
   # --- Restart the service -------------------------------------------------
   if [ "$RESTART" -eq 1 ] && systemctl list-unit-files openfollow.service >/dev/null 2>&1; then
     log "Restarting the openfollow service…"
     sudo systemctl restart openfollow || warn "could not restart openfollow – restart it manually."
+  fi
+
+  # Backend is installed + restarted; a requested-but-failed export exits non-zero.
+  if [ "$WITH_EXPORT" -eq 1 ] && [ "$export_ok" -eq 0 ]; then
+    die "backend installed, but the model-export toolchain did not fully install (see warnings above). Fix the issue and re-run with --with-export."
   fi
 
   log "Done. Detection works in the web UI once a model (.onnx) is present in the storage models folder."

--- a/tests/test_install_detection.py
+++ b/tests/test_install_detection.py
@@ -132,6 +132,194 @@ def test_ultralytics_is_a_soft_dependency_not_a_hard_gate() -> None:
     assert 'die "ultralytics' not in text and "die 'ultralytics" not in text
 
 
+# --- behavioral: run main() against a stub venv python + pip ----------------
+#
+# The stub python answers the import probes (backend / export present?), reports
+# a writable purelib (so no sudo), and logs each `pip install` invocation instead
+# of running it, so tests can assert what the script WOULD install, in order.
+
+_STUB_PY = r"""#!/usr/bin/env bash
+sd="${STUB_STATE_DIR:-/tmp}"
+has_backend() { [ "${STUB_BACKEND:-1}" = "1" ] || [ -f "$sd/backend" ]; }
+has_export() { [ "${STUB_EXPORT:-1}" = "1" ] || [ -f "$sd/export" ]; }
+if [ "$1" = "-c" ]; then
+  case "$2" in
+    *"import onnxruntime, cv2"*) has_backend && exit 0 || exit 1 ;;
+    *"import ultralytics, onnx"*) has_export && exit 0 || exit 1 ;;
+    *purelib*) printf '%s\n' "${STUB_PURELIB:-/tmp}"; exit 0 ;;
+    *) exit 0 ;;
+  esac
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  shift 3
+  args="$*"
+  printf 'PIPINSTALL %s\n' "$args" >> "$STUB_PIP_LOG"
+  if [ -n "${STUB_PIP_FAIL:-}" ] && printf '%s' "$args" | grep -qE "$STUB_PIP_FAIL"; then
+    printf '%s\n' "${STUB_FAIL_MSG:-simulated failure}" >&2
+    exit 1
+  fi
+  # A successful install makes the module importable on subsequent probes.
+  case "$args" in *onnxruntime*) : >"$sd/backend" ;; esac
+  case "$args" in *ultralytics*) : >"$sd/export" ;; esac
+  exit 0
+fi
+exit 0
+"""
+
+_skip_if_root = pytest.mark.skipif(os.geteuid() == 0, reason="install-detection.sh refuses to run as root")
+
+
+def _run_main(
+    tmp_path: Path,
+    args: list[str],
+    *,
+    backend: int = 0,
+    export: int = 0,
+    pip_fail: str = "",
+    fail_msg: str = "simulated failure",
+    extra_env: dict[str, str] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    py = venv_bin / "python"
+    py.write_text(_STUB_PY)
+    py.chmod(0o755)
+    piplog = tmp_path / "pip.log"
+    piplog.write_text("")
+    state = tmp_path / "state"
+    state.mkdir()
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "OPENFOLLOW_VENV_PY": str(py),
+        "OPENFOLLOW_NVME_MOUNT": str(tmp_path / "no-nvme"),
+        "OPENFOLLOW_CONFIG": str(tmp_path / "config.toml"),
+        "STUB_BACKEND": str(backend),
+        "STUB_EXPORT": str(export),
+        "STUB_STATE_DIR": str(state),
+        "STUB_PURELIB": str(venv_bin.parent),  # writable -> no sudo
+        "STUB_PIP_LOG": str(piplog),
+        "STUB_PIP_FAIL": pip_fail,
+        "STUB_FAIL_MSG": fail_msg,
+    }
+    if extra_env:
+        env.update(extra_env)
+    proc = subprocess.run(["bash", str(_script()), *args], text=True, capture_output=True, env=env)
+    installs = [ln[len("PIPINSTALL ") :] for ln in piplog.read_text().splitlines() if ln.startswith("PIPINSTALL ")]
+    return proc, installs
+
+
+@_skip_if_root
+def test_bare_run_installs_backend_only(tmp_path: Path) -> None:
+    proc, installs = _run_main(tmp_path, ["--no-restart"], backend=0)
+    assert proc.returncode == 0, proc.stderr
+    # Exactly the backend, and never the torch/export stack the Pi doesn't need.
+    assert len(installs) == 1
+    assert "onnxruntime>=1.17" in installs[0] and "opencv-python>=4.8" in installs[0]
+    assert "torch" not in installs[0] and "ultralytics" not in installs[0]
+
+
+@_skip_if_root
+def test_bare_run_noops_when_backend_present(tmp_path: Path) -> None:
+    proc, installs = _run_main(tmp_path, ["--no-restart"], backend=1)
+    assert proc.returncode == 0, proc.stderr
+    assert installs == []  # early-exit, no pip
+
+
+@_skip_if_root
+def test_with_export_installs_backend_then_torch_then_ultralytics(tmp_path: Path) -> None:
+    proc, installs = _run_main(tmp_path, ["--with-export", "--no-restart"], backend=0, export=0)
+    assert proc.returncode == 0, proc.stderr
+    assert len(installs) == 3
+    assert "onnxruntime>=1.17" in installs[0] and "torch" not in installs[0]
+    assert "download.pytorch.org/whl/cpu" in installs[1] and "torch" in installs[1]
+    assert "ultralytics" in installs[2] and "onnxslim" in installs[2]
+
+
+@_skip_if_root
+def test_with_export_fallthrough_installs_export_when_backend_present(tmp_path: Path) -> None:
+    proc, installs = _run_main(tmp_path, ["--with-export", "--no-restart"], backend=1, export=0)
+    assert proc.returncode == 0, proc.stderr
+    # Backend present -> skipped; export toolchain still installed.
+    assert not any("onnxruntime>=1.17" in ln for ln in installs)
+    assert any("torch" in ln for ln in installs) and any("ultralytics" in ln for ln in installs)
+
+
+@_skip_if_root
+def test_with_export_noops_when_both_present(tmp_path: Path) -> None:
+    proc, installs = _run_main(tmp_path, ["--with-export", "--no-restart"], backend=1, export=1)
+    assert proc.returncode == 0, proc.stderr
+    assert installs == []
+
+
+@_skip_if_root
+def test_backend_failure_offline_dies_with_offline_message(tmp_path: Path) -> None:
+    proc, _ = _run_main(
+        tmp_path,
+        ["--no-restart"],
+        backend=0,
+        pip_fail="onnxruntime",
+        fail_msg="ERROR: ... Temporary failure in name resolution",
+    )
+    assert proc.returncode != 0
+    out = (proc.stdout + proc.stderr).lower()
+    assert "no working internet" in out and "uplink" in out
+
+
+@_skip_if_root
+def test_with_export_failure_exits_nonzero_but_installs_backend(tmp_path: Path) -> None:
+    proc, installs = _run_main(tmp_path, ["--with-export", "--no-restart"], backend=0, export=0, pip_fail="torch")
+    # Backend installed first (present in the log) but the requested export failed.
+    assert any("onnxruntime>=1.17" in ln for ln in installs)
+    assert proc.returncode != 0
+
+
+@_skip_if_root
+def test_with_export_offline_export_failure_surfaces_offline_message(tmp_path: Path) -> None:
+    proc, _ = _run_main(
+        tmp_path,
+        ["--with-export", "--no-restart"],
+        backend=1,  # skip backend so only the export path can fail
+        export=0,
+        pip_fail="torch",
+        fail_msg="[Errno 101] Network is unreachable",
+    )
+    out = (proc.stdout + proc.stderr).lower()
+    assert "no working internet" in out  # export path classifies offline too
+
+
+@_skip_if_root
+def test_bare_run_uses_backend_min_not_export_min(tmp_path: Path) -> None:
+    # A huge EXPORT min must NOT gate a bare (backend-only) run.
+    proc, installs = _run_main(
+        tmp_path, ["--no-restart"], backend=0, extra_env={"OPENFOLLOW_EXPORT_MIN_MB": "999999999"}
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert any("onnxruntime>=1.17" in ln for ln in installs)
+
+
+@_skip_if_root
+def test_backend_min_gate_blocks_when_short(tmp_path: Path) -> None:
+    proc, installs = _run_main(
+        tmp_path, ["--no-restart"], backend=0, extra_env={"OPENFOLLOW_BACKEND_MIN_MB": "999999999"}
+    )
+    assert proc.returncode != 0
+    assert "not enough space" in proc.stderr
+    assert installs == []  # died at preflight, before any install
+
+
+@_skip_if_root
+def test_export_min_gate_blocks_with_export_when_short(tmp_path: Path) -> None:
+    proc, installs = _run_main(
+        tmp_path,
+        ["--with-export", "--no-restart"],
+        backend=0,
+        extra_env={"OPENFOLLOW_EXPORT_MIN_MB": "999999999"},
+    )
+    assert proc.returncode != 0
+    assert "not enough space" in proc.stderr
+    assert installs == []
+
+
 # --- clock-skew diagnostics -------------------------------------------------
 
 
@@ -184,13 +372,65 @@ def test_clock_skew_message_is_actionable() -> None:
     assert "date -s '" not in out
 
 
-def test_pip_failures_route_through_clock_skew_check() -> None:
+def _classify_offline(sample: str) -> subprocess.CompletedProcess[str]:
+    # Pipe a captured-output sample through network_unreachable_in and report it.
+    return _run(f"printf '%s' {shlex.quote(sample)} | network_unreachable_in && echo OFFLINE || echo ONLINE")
+
+
+@pytest.mark.parametrize(
+    "sample",
+    [
+        # The exact DNS failures an offline show Pi (no gateway / no DNS) hits.
+        "after connection broken by 'NameResolutionError(...Temporary failure in name resolution...)'",
+        "ERROR: Could not resolve host 'pypi.org'",
+        "curl: (6) Could not resolve host: download.pytorch.org",
+        "[Errno 101] Network is unreachable",
+        "OSError: [Errno 113] No route to host",
+    ],
+)
+def test_network_unreachable_in_detects_offline(sample: str) -> None:
+    r = _classify_offline(sample)
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip() == "OFFLINE"
+
+
+@pytest.mark.parametrize(
+    "sample",
+    [
+        "Successfully installed onnxruntime-1.17.0 opencv-python-4.8.0",
+        "ERROR: Could not find a version that satisfies the requirement torch",
+        # A wrong clock is a separate cause, not an offline host.
+        "certificate is not yet valid (_ssl.c:1006)",
+        # A reached-but-slow mirror is not a name/route failure.
+        "ERROR: connection timed out",
+    ],
+)
+def test_network_unreachable_in_ignores_unrelated(sample: str) -> None:
+    r = _classify_offline(sample)
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip() == "ONLINE"
+
+
+def test_offline_message_is_actionable() -> None:
+    r = _run("offline_message")
+    assert r.returncode == 0, r.stderr
+    out = r.stdout.lower()
+    assert "internet" in out or "network" in out
+    assert "uplink" in out or "mirror" in out
+    # Points an offline Pi operator at the bundled backend / reload path.
+    assert "reload" in out
+
+
+def test_pip_failures_route_through_diagnostics() -> None:
     text = _script().read_text()
-    # Every pip install path must capture output and consult clock_skew_in on
+    # Every pip install path captures output and consults clock_skew_in on
     # failure, so a wrong clock surfaces as the fix, not a raw SSL traceback.
     assert 'die "$(clock_skew_message)"' in text
-    # torch (incl. fallback) + the backend install = at least three checks.
+    # backend + torch (primary + fallback) + export tools = at least three checks.
     assert text.count("clock_skew_in <") >= 3
+    # The backend (hard gate) also classifies an offline host, not just the clock.
+    assert 'die "$(offline_message)"' in text
+    assert text.count("network_unreachable_in <") >= 2
 
 
 def test_pip_log_fallback_path_is_unique_per_run() -> None:

--- a/tests/test_sbom_compliance.py
+++ b/tests/test_sbom_compliance.py
@@ -43,8 +43,10 @@ def _write_sbom(tmp_path: pathlib.Path, packages: list[dict], *, spdx_version: s
 
 
 # A realistic-ish clean image: AGPLv3-compatible OS libs, a clean venv, plus the
-# two real-world packages that must NOT trip the gate – a transitive
-# permissively-licensed libonnxruntime (deb) and the accepted Pi firmware blob.
+# real-world packages that must NOT trip the gate – a transitive
+# permissively-licensed libonnxruntime (deb), the accepted Pi firmware blob, and
+# the bundled detection backend (onnxruntime + opencv as venv/pypi packages),
+# which ships on purpose so detection runs on an offline Pi.
 _CLEAN_PACKAGES = [
     _pkg("python3-gi", declared="LGPL-2.1-or-later"),
     _pkg("gstreamer1.0-plugins-bad", declared="LGPL-2.1-or-later"),
@@ -54,6 +56,8 @@ _CLEAN_PACKAGES = [
     _pkg("libindicator7", declared="GPL-3.0-or-later"),
     _pkg("numpy", kind="pypi", declared="BSD-3-Clause"),
     _pkg("bottle", kind="pypi", declared="MIT"),
+    _pkg("onnxruntime", kind="pypi", declared="MIT"),
+    _pkg("opencv-python", kind="pypi", declared="Apache-2.0 AND BSD-3-Clause"),
     _pkg("openfollow", kind="pypi", declared="AGPL-3.0-or-later"),
 ]
 
@@ -89,13 +93,22 @@ def test_ndi_name_fails_anywhere(tmp_path: pathlib.Path, kind: str, name: str) -
     assert mod.main([path]) == 1
 
 
-@pytest.mark.parametrize("name", ["ultralytics", "onnxruntime", "opencv-python", "opencv-python-headless"])
-def test_detection_extra_in_venv_fails(tmp_path: pathlib.Path, name: str) -> None:
-    # Permissive license – proves the *name* policy fires on venv packages alone.
-    path = _write_sbom(tmp_path, [*_CLEAN_PACKAGES, _pkg(name, kind="pypi", declared="MIT")])
+def test_export_toolchain_in_venv_fails(tmp_path: pathlib.Path) -> None:
+    # ultralytics (AGPL, export-only) is the one detection extra kept out of the
+    # venv – proves the *name* policy fires on the venv package alone.
+    path = _write_sbom(tmp_path, [*_CLEAN_PACKAGES, _pkg("ultralytics", kind="pypi", declared="AGPL-3.0-or-later")])
     violations = mod.find_violations(mod.load_sbom(path))
-    assert any(line.startswith("venv:") and name in line for line in violations), violations
+    assert any(line.startswith("venv:") and "ultralytics" in line for line in violations), violations
     assert mod.main([path]) == 1
+
+
+@pytest.mark.parametrize("name", ["onnxruntime", "opencv-python", "opencv-python-headless"])
+def test_backend_extra_in_venv_passes(tmp_path: pathlib.Path, name: str) -> None:
+    # The inference backend ships in the venv on purpose (permissive license) so
+    # detection runs on an offline Pi with no pip; it must NOT trip the gate.
+    path = _write_sbom(tmp_path, [*_CLEAN_PACKAGES, _pkg(name, kind="pypi", declared="Apache-2.0")])
+    assert mod.find_violations(mod.load_sbom(path)) == []
+    assert mod.main([path]) == 0
 
 
 @pytest.mark.parametrize("name", ["onnxruntime", "libopencv-core4.5", "python3-opencv", "onnxruntime-gpu"])


### PR DESCRIPTION
## Installation path

The detection inference backend is `onnxruntime` + `opencv`. The model-export toolchain (`torch` + `ultralytics`) is a separate, workstation-only concern (AGPL, large) used to produce `.onnx` models, which already ship prebuilt.

- **macOS app and the Pi `.deb`/image:** the backend ships in the bundled venv, so person detection runs **offline out of the box** — no pip at show time.
- **Source / dev checkouts:** `install-detection.sh` installs the backend into the app venv as the hard gate. The export toolchain is **opt-in** via `install-detection.sh --with-export`; it is never installed on a show Pi and never bundled in the image.
- When the backend genuinely can't be fetched, the script classifies offline / DNS failures and prints an actionable message instead of a raw traceback.

## Changes

- **`build-deb.sh`** installs the `detection` extra into the venv (opt out with `OF_DEB_SKIP_DETECTION`, mirroring `OF_DEB_SKIP_MODELS`). The build-time smoke test asserts the backend imports from the venv prefix and that `torch`/`ultralytics` are **not** bundled.
- **Image SBOM compliance gate** permits the permissively-licensed backend in the venv while still blocking **AGPL `ultralytics`** by name (NDI + AGPL protections untouched).
- **`install-detection.sh`:** backend-first hard gate; `--with-export` opt-in for the export toolchain (soft, but a *requested* export that fails exits non-zero); offline/DNS classifier with an actionable message; the space preflight is sized to what's being installed; the `pip_log` EXIT-trap cleanup is robust on a successful run under `set -u`.
- Docs (`help/detection.md`, `PACKAGING.md`, `THIRD_PARTY_NOTICES.md`) and the two export-tools UI hints updated. The YOLO-model AGPL status is unchanged — the models already ship and are already declared AGPL-3.0-or-later.

## Testing

- **`make test` + `make lint`** green.
- **Behavioral test harness** runs `install-detection.sh`'s `main()` against a stubbed venv-python/pip: backend-only install pulls no torch; `--with-export` installs backend → torch → ultralytics in order; the `--with-export` fall-through; offline classification dies with the offline message; the space-gate min selection; and the requested-export-failure non-zero exit.
- **Verified on a Raspberry Pi (aarch64, Python 3.13):** the script-logic checks pass (offline/DNS output classified correctly); the early-exit no-ops cleanly against the packaged venv; and a `pip --dry-run` of the backend targets resolves to `{flatbuffers, numpy, onnxruntime, opencv-python, packaging, protobuf}` — no torch/ultralytics.

> Note: the aarch64 `.deb` build + image-SBOM gate run in release CI on the ARM64 runner; those weren't rebuilt here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
