### PR TITLE
fix(overlay): dismiss stale video-disconnect banner on recovery

### DIFF
--- a/openfollow/app.py
+++ b/openfollow/app.py
@@ -288,6 +288,8 @@ class OpenFollowApp:
         self._video_disconnect_deadline: float = float("inf")
         self._video_disconnect_banner_shown: bool = False
         self._video_was_connected: bool = False
+        # Settings menu is the one the startup disconnect check auto-opened.
+        self._video_disconnect_menu_open: bool = False
 
         self._psn_source_resolved_ip: str = ""
         self._psn_source_status: str = ""

--- a/openfollow/runtime/app_modes.py
+++ b/openfollow/runtime/app_modes.py
@@ -398,6 +398,7 @@ def enter_settings_menu(app: OpenFollowApp, *, banner: str = "") -> None:
 def exit_settings_menu(app: OpenFollowApp) -> None:
     app._settings_menu_active = False
     app._settings_menu_banner = ""
+    app._video_disconnect_menu_open = False
 
 
 def enter_about(app: OpenFollowApp) -> None:
@@ -1615,6 +1616,15 @@ def check_video_disconnect_banner(app: OpenFollowApp) -> None:
         # (self-healing), not an auto-opened menu.
         app._video_was_connected = True
         app._video_disconnect_deadline = float("inf")
+        # Close the menu we auto-opened for the dead source, now video is back.
+        if app._video_disconnect_menu_open and app._settings_menu_active:
+            app._exit_settings_menu()
+        return
+
+    # Our auto-opened menu is up but the source is still down: refresh its
+    # banner from current state so a stale source name can't linger.
+    if app._video_disconnect_menu_open and app._settings_menu_active:
+        app._settings_menu_banner = _video_disconnect_banner_text(app)
         return
 
     # Disconnected. Only the startup case (never connected) auto-opens;
@@ -1638,6 +1648,7 @@ def check_video_disconnect_banner(app: OpenFollowApp) -> None:
         return
 
     app._video_disconnect_banner_shown = True
+    app._video_disconnect_menu_open = True
     logger.warning(
         "Video source %r never connected after startup – opening Settings.",
         app._config.video_source_type,

--- a/tests/test_app_modes.py
+++ b/tests/test_app_modes.py
@@ -355,6 +355,15 @@ class TestSettingsMenu:
         exit_settings_menu(app)
         assert app._settings_menu_banner == ""
 
+    def test_exit_clears_video_disconnect_menu_flag(self) -> None:
+        """Exiting resets the auto-opened bookkeeping so the disconnect
+        check doesn't keep managing a menu the operator has closed."""
+        app = self._make_app()
+        app._video_disconnect_menu_open = True
+        enter_settings_menu(app, banner="X")
+        exit_settings_menu(app)
+        assert app._video_disconnect_menu_open is False
+
     def test_key_navigation_and_confirm_network(self) -> None:
         """Default selection is the Network entry. Enter opens the
         Network screen directly."""

--- a/tests/test_webkit_browser.py
+++ b/tests/test_webkit_browser.py
@@ -754,12 +754,15 @@ class TestVideoDisconnectBanner:
         deadline_passed: bool = True,
         already_shown: bool = False,
         any_modal: bool = False,
+        menu_auto_opened: bool = False,
+        source_type: str = "rtsp",
+        banner: str = "",
         status_marker: object | None = None,
     ) -> SimpleNamespace:
         from openfollow.configuration import AppConfig
 
         cfg = AppConfig()
-        cfg.video_source_type = "rtsp"
+        cfg.video_source_type = source_type
 
         if status_marker is None:
             status_marker = SimpleNamespace(
@@ -773,13 +776,16 @@ class TestVideoDisconnectBanner:
         )
 
         opened: list[dict] = []
+        exited: list[bool] = []
         app = SimpleNamespace(
             _config=cfg,
             _video_receiver=receiver,
             _video_disconnect_deadline=(0.0 if deadline_passed else float("inf")),
             _video_disconnect_banner_shown=already_shown,
+            _video_disconnect_menu_open=menu_auto_opened,
             _video_was_connected=was_connected,
             _settings_menu_active=any_modal,
+            _settings_menu_banner=banner,
             _iface_selection_active=False,
             _source_type_selection_active=False,
             _url_editor_active=False,
@@ -788,9 +794,18 @@ class TestVideoDisconnectBanner:
             _button_detection=None,
         )
         app._opened = opened
+        app._exited = exited
         app._enter_settings_menu = lambda *, banner="": opened.append(
             {"banner": banner},
         )
+
+        def _exit() -> None:
+            exited.append(True)
+            app._settings_menu_active = False
+            app._settings_menu_banner = ""
+            app._video_disconnect_menu_open = False
+
+        app._exit_settings_menu = _exit
         return app
 
     def test_no_op_when_receiver_missing(self) -> None:
@@ -925,6 +940,7 @@ class TestVideoDisconnectBanner:
         assert "Connection refused" in banner
         assert "Reconnect attempt 3" in banner
         assert app._video_disconnect_banner_shown is True
+        assert app._video_disconnect_menu_open is True
 
     def test_banner_omits_optional_fields_when_empty(self) -> None:
         """The banner gracefully drops empty source label, error, and
@@ -999,6 +1015,65 @@ class TestVideoDisconnectBanner:
         clock[0] = 9000.0
         app_modes.check_video_disconnect_banner(app)
         assert len(app._opened) == 1  # never re-fired
+
+    def test_auto_opened_menu_closes_on_recovery(self) -> None:
+        """The auto-opened menu closes itself once video returns (e.g. the
+        operator switched to a working source in the web UI)."""
+        from openfollow.runtime import app_modes
+
+        app = self._make_app(
+            connected=True,
+            menu_auto_opened=True,
+            any_modal=True,
+            already_shown=True,
+            banner="Video source (ndi) is not available. ...",
+        )
+        app_modes.check_video_disconnect_banner(app)
+        assert app._exited == [True]
+        assert app._settings_menu_active is False
+        assert app._video_disconnect_menu_open is False
+        assert app._video_was_connected is True
+
+    def test_auto_opened_menu_refreshes_banner_while_still_down(self) -> None:
+        """Still disconnected after a second (also-failed) switch: the
+        banner is rewritten to name the CURRENT source, not stale text."""
+        from openfollow.runtime import app_modes
+
+        app = self._make_app(
+            connected=False,
+            menu_auto_opened=True,
+            any_modal=True,
+            already_shown=True,
+            source_type="rtsp",
+            banner="Video source (ndi) is not available. ...",
+            status_marker=SimpleNamespace(
+                source_name="rtsp://10.0.0.5/stream",
+                error_message="Connection refused",
+                reconnect_attempt=0,
+            ),
+        )
+        app_modes.check_video_disconnect_banner(app)
+        assert app._exited == []  # menu stays open
+        assert "(rtsp)" in app._settings_menu_banner
+        assert "Connection refused" in app._settings_menu_banner
+        assert "(ndi)" not in app._settings_menu_banner
+
+    def test_no_close_when_menu_not_auto_opened(self) -> None:
+        """A menu the operator opened (flag False) is never touched on
+        connect – no close, banner left intact."""
+        from openfollow.runtime import app_modes
+
+        app = self._make_app(
+            connected=True,
+            menu_auto_opened=False,
+            any_modal=True,
+            was_connected=True,
+            banner="Operator opened this menu.",
+        )
+        app_modes.check_video_disconnect_banner(app)
+        assert app._exited == []
+        assert app._settings_menu_active is True
+        assert app._settings_menu_banner == "Operator opened this menu."
 
 
 class TestProcessInputAndKeyDispatchShortCircuit:


### PR DESCRIPTION
## Problem

On a Pi booted with **NDI** as the video source, NDI never produced a frame, so the app auto-opened the on-device **Settings menu** with a red banner: *"Video source (ndi) is not available. … Switch source type or edit the URL to recover."* The operator then switched to **RTSP** in the web UI. RTSP rendered correctly in the background, but the NDI "not available" popup stayed on screen.

## Root cause

Switching `video_source_type` in the web UI is a **live in-place swap, not a restart** (`POST /section/video_source` saves config without `?restart=1`; the file-watcher then live-swaps via `swap_video` → `receiver.swap_input`). So the app process – and any open modal – survives the switch.

The popup is the Settings menu opened at startup by `check_video_disconnect_banner` via `_enter_settings_menu(banner=...)`. Its banner text is a **frozen string** captured at open time. When the new source connected, the check latched `_video_was_connected = True` but **nothing closed the already-open menu**, so the stale NDI banner kept rendering over live video.

(The separate "SELECT NDI SOURCE" *source-selection* overlay is receiver-derived and recomputed every frame; a successful swap already clears it. The frozen Settings-menu banner was the only survivor.)

## Fix

Treat the auto-opened disconnect menu as **live, self-managing state** instead of a frozen snapshot. While the menu is the one the startup check opened (tracked by a new `_video_disconnect_menu_open` flag), every frame it either:

- **closes** once video is back – recovery is detected via `receiver.connected`, so it self-heals no matter *how* the feed returned (web-UI switch, on-device switch, or NDI coming back on its own); or
- **refreshes** its banner from current state while still down, so a second (also-failed) switch names the *current* source/error instead of leaving stale "ndi" text.

The flag is set only on the startup auto-open and cleared on any menu exit, so operator-opened menus and other banner callers are never touched. This keeps the config-apply/swap layer decoupled from app-modal state.

## Tests

- New cases in `TestVideoDisconnectBanner`: auto-close on recovery, banner refresh while still disconnected (asserts no stale text), and no-close/no-refresh for operator-opened menus; plus a flag-set assertion on the open path.
- `exit_settings_menu` clears the new flag (`tests/test_app_modes.py`).
- Full gate green locally: lint + typecheck + security + **907 passed, 100% coverage** + build.

## Manual verification

Boot with an unavailable NDI source so the banner auto-opens, switch to a working RTSP source in the web UI, and confirm the popup disappears once video shows (previously it stayed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)