### PR TITLE
fix(scene): tilt pitch about the camera axis so yaw stays independent

### DIFF
--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -223,6 +223,12 @@ on the origin with roll ≈ 1°, which hid mul-vs-div swaps on
 pts + centroid`. The kill tests drive `pitch/yaw/roll ∈ {15°, 25°,
 30°, 35°, 45°}` and off-origin corners to expose both.
 
+> **Counts predate the current rotation composition.** `_rotation_matrix`
+> and the Euler extraction in `decompose_homography` have been rewritten
+> since this run, so the per-term mutants below no longer name live code
+> and the survivor totals are indicative rather than measured. Re-run
+> `mutmut` against this file before relying on the numbers.
+
 Remaining survivors grouped by pattern:
 
 | Pattern                                                                | Count | Justification                                                                                                                                                                                                                                                                                 |

--- a/openfollow/scene/solver.py
+++ b/openfollow/scene/solver.py
@@ -64,25 +64,29 @@ def vfov_to_hfov(vfov_deg: float, aspect: float) -> float:
 
 
 def _rotation_matrix(pitch_rad: float, yaw_rad: float, roll_rad: float) -> npt.NDArray[np.float64]:
-    """Build rotation matrix matching pygfx intrinsic XYZ euler convention.
+    """Build the camera→world rotation for a pan-tilt head.
 
-    pygfx euler: (pitch, -yaw, roll) – we receive raw PSN angles and
-    negate yaw internally, same as Camera._apply().
+    The head pans about world up first, then tilts about the camera's **own**
+    right axis, then rolls about its optical axis – so ``pitch`` is the
+    depression below the horizon and ``yaw`` the ground bearing, each
+    independent of the other. Angles arrive in the PSN convention; yaw is
+    negated for the Y-up intermediate frame the projection works in.
+
+    Intrinsic Y-X-Z: ``R = Ry(-yaw) @ Rx(pitch) @ Rz(roll)``.
     """
     a = pitch_rad
-    b = -yaw_rad  # negated, matching Camera._apply()
+    b = -yaw_rad  # PSN yaw turns the opposite way about the Y-up axis
     c = roll_rad
 
     ca, sa = math.cos(a), math.sin(a)
     cb, sb = math.cos(b), math.sin(b)
     cc, sc = math.cos(c), math.sin(c)
 
-    # Intrinsic XYZ: R = Rx(a) @ Ry(b) @ Rz(c)
     return np.array(
         [
-            [cb * cc, -cb * sc, sb],
-            [sa * sb * cc + ca * sc, -sa * sb * sc + ca * cc, -sa * cb],
-            [-ca * sb * cc + sa * sc, ca * sb * sc + sa * cc, ca * cb],
+            [cb * cc + sb * sa * sc, -cb * sc + sb * sa * cc, sb * ca],
+            [ca * sc, ca * cc, -sa],
+            [-sb * cc + cb * sa * sc, sb * sc + cb * sa * cc, cb * ca],
         ],
         dtype=np.float64,
     )
@@ -560,22 +564,20 @@ def decompose_homography(
     pos_y = float(-cam_pygfx[2])
     pos_z = float(cam_pygfx[1])
 
-    # Extract Euler angles from R = Rx(pitch) @ Ry(-yaw) @ Rz(roll).
-    # R[0,2] = sin(-yaw)
-    sb = float(np.clip(R[0, 2], -1.0, 1.0))
-    neg_yaw = math.asin(sb)
-    cb = math.cos(neg_yaw)
+    # Extract Euler angles from R = Ry(-yaw) @ Rx(pitch) @ Rz(roll).
+    # R[1,2] = -sin(pitch)
+    sa = float(np.clip(-R[1, 2], -1.0, 1.0))
+    pitch_rad = math.asin(sa)
+    ca = math.cos(pitch_rad)
 
-    if abs(cb) > 1e-6:
-        pitch_rad = math.atan2(-R[1, 2], R[2, 2])
-        roll_rad = math.atan2(-R[0, 1], R[0, 0])
+    if abs(ca) > 1e-6:
+        neg_yaw = math.atan2(R[0, 2], R[2, 2])
+        roll_rad = math.atan2(R[1, 0], R[1, 1])
     else:
-        # Gimbal lock (yaw ≈ ±90°): set roll = 0.
-        # pragma: no cover – physically requires a side-on camera
-        # (yaw ≈ 90°), incompatible with the calibration overlay's
-        # forward-facing assumption. Kept as a safety net.
-        roll_rad = 0.0  # pragma: no cover
-        pitch_rad = math.atan2(R[1, 0], R[1, 1])  # pragma: no cover
+        # Gimbal lock: a camera pointing straight down has no distinct bearing
+        # and roll, so pin the pan and fold the remaining freedom into roll.
+        neg_yaw = 0.0
+        roll_rad = math.atan2(-R[0, 1], R[0, 0])
 
     yaw_deg = -math.degrees(neg_yaw)
     pitch_deg = math.degrees(pitch_rad)

--- a/openfollow/scene/solver.py
+++ b/openfollow/scene/solver.py
@@ -24,6 +24,13 @@ from openfollow.scene.camera import psn_to_pygfx_array
 _FOV_MIN_DEG = 1.0
 _FOV_MAX_DEG = 179.0
 
+# Below this |cos(pitch)| the camera is within ~0.06° of straight down. There
+# bearing and roll turn the image the same way, and the atan2 pair that
+# separates them runs on a row of the rotation that has gone to zero, so noise
+# decides the split. Wide enough that the degenerate case is a neighbourhood
+# rather than one exact float.
+_GIMBAL_COS_PITCH_EPS = 1e-3
+
 
 def _require_view_inputs(fov: float, canvas_w: float, canvas_h: float) -> None:
     """Reject degenerate projection inputs before any division.
@@ -570,16 +577,17 @@ def decompose_homography(
     pitch_rad = math.asin(sa)
     ca = math.cos(pitch_rad)
 
-    if abs(ca) > 1e-6:
+    if abs(ca) > _GIMBAL_COS_PITCH_EPS:
         neg_yaw = math.atan2(R[0, 2], R[2, 2])
         roll_rad = math.atan2(R[1, 0], R[1, 1])
     else:
-        # Gimbal lock: a camera pointing straight down has no distinct bearing
-        # and roll, so pin the pan and fold the remaining freedom into roll.
+        # Straight down: pin the pan and let roll carry the whole rotation.
         neg_yaw = 0.0
         roll_rad = math.atan2(-R[0, 1], R[0, 0])
 
-    yaw_deg = -math.degrees(neg_yaw)
+    # ``-degrees(0.0)`` is -0.0, which survives round() and would reach the
+    # config file, the JSON response and the form field as "-0.0".
+    yaw_deg = -math.degrees(neg_yaw) + 0.0
     pitch_deg = math.degrees(pitch_rad)
     roll_deg = math.degrees(roll_rad)
 

--- a/openfollow/scene/solver.py
+++ b/openfollow/scene/solver.py
@@ -24,8 +24,8 @@ from openfollow.scene.camera import psn_to_pygfx_array
 _FOV_MIN_DEG = 1.0
 _FOV_MAX_DEG = 179.0
 
-# Below this |cos(pitch)| the camera is within ~0.06° of straight down. There
-# bearing and roll turn the image the same way, and the atan2 pair that
+# Below this |cos(pitch)| the camera is within ~0.06° of straight down, where
+# bearing and roll turn the image the same way and the atan2 pair that
 # separates them runs on a row of the rotation that has gone to zero, so noise
 # decides the split. Wide enough that the degenerate case is a neighbourhood
 # rather than one exact float.

--- a/openfollow/web/help/camera.md
+++ b/openfollow/web/help/camera.md
@@ -14,9 +14,13 @@ Positions are in **metres**, relative to the **Reference Point** – the single 
 
 ## Orientation (Pitch, Yaw, Roll)
 
-- **Pitch** – tilt up or down. Negative looks down at the stage; a front-of-house camera is typically around −20°.
-- **Yaw** – pan left or right. `0` looks straight upstage.
+Think of the camera on a pan-and-tilt head: yaw swings it round to face the stage, then pitch tilts it down into the stage, then roll levels the picture.
+
+- **Pitch** – tilt up or down, measured from the horizon. Negative looks down; a front-of-house camera is typically around −20°. Pitch means the same thing whichever way the camera faces, so a rig behind or beside the stage still tilts down with a negative pitch.
+- **Yaw** – which way the camera faces, as a compass bearing on the stage floor. `0` looks straight upstage, `180` is a camera hung upstage looking back towards the audience, and `−90` / `90` are box-boom positions looking across the stage.
 - **Roll** – rotation around the lens axis. Leave at `0` unless the camera is physically canted.
+
+If your camera has a yaw other than `0` and was calibrated on an older version, re-run the **Setup Wizard** once: yaw and pitch used to interfere with each other, so the stored angles may not describe where the camera actually points. A camera with yaw `0` is unaffected.
 
 ## Lens
 

--- a/openfollow/web/help/camera.md
+++ b/openfollow/web/help/camera.md
@@ -20,7 +20,7 @@ Think of the camera on a pan-and-tilt head: yaw swings it round to face the stag
 - **Yaw** – which way the camera faces, as a compass bearing on the stage floor. `0` looks straight upstage, `180` is a camera hung upstage looking back towards the audience, and `−90` / `90` are box-boom positions looking across the stage.
 - **Roll** – rotation around the lens axis. Leave at `0` unless the camera is physically canted.
 
-If your camera has a yaw other than `0` and was calibrated on an older version, re-run the **Setup Wizard** once: yaw and pitch used to interfere with each other, so the stored angles may not describe where the camera actually points. A camera with yaw `0` is unaffected.
+If the overlay doesn't sit on the video on a camera whose yaw isn't `0`, re-run the **Setup Wizard** – it resolves the orientation from the grid corners rather than from the stored angles.
 
 ## Lens
 

--- a/openfollow/web/templates/wizard.tpl
+++ b/openfollow/web/templates/wizard.tpl
@@ -600,7 +600,7 @@
     </div>
     <div class="group">
       <div class="group-title">Orientation</div>
-      <p class="wizard-help">Enter the camera's angle: Pitch tilts down, Yaw is the direction it faces (0&deg; from the house, 180&deg; from upstage).</p>
+      <p class="wizard-help">Enter the camera's angle: Pitch tilts down, Yaw is the direction it faces (0&deg; looks upstage, 180&deg; looks back at the house).</p>
       <div class="row">
         <div class="field">
           <label for="cam_pitch">Pitch <span style="font-weight:400;text-transform:none;letter-spacing:0;">(down &minus;)</span></label>

--- a/openfollow/web/templates/wizard.tpl
+++ b/openfollow/web/templates/wizard.tpl
@@ -600,7 +600,7 @@
     </div>
     <div class="group">
       <div class="group-title">Orientation</div>
-      <p class="wizard-help">Enter the camera's angle. Start with Pitch &asymp; &minus;30&deg; (looking down) and Roll = 0&deg;. Yaw is the direction the camera faces: 0&deg; from the house, 180&deg; from upstage, &plusmn;90&deg; from a box boom.</p>
+      <p class="wizard-help">Enter the camera's angle: Pitch tilts down, Yaw is the direction it faces (0&deg; from the house, 180&deg; from upstage).</p>
       <div class="row">
         <div class="field">
           <label for="cam_pitch">Pitch <span style="font-weight:400;text-transform:none;letter-spacing:0;">(down &minus;)</span></label>
@@ -1805,6 +1805,9 @@
     // Compute camera viewing direction from pitch/yaw (in degrees)
     // Pitch: 0 = horizontal, -45 = 45° down, -90 = straight down
     // Yaw: 0 = looking along +Y (upstage), negative = left
+    // This camera model must stay in step with scene/solver.py, or the preview
+    // stops describing the overlay. Pinned by TestWizardIllustrationAgreement
+    // in tests/test_solver.py - edit both together.
     var rad = Math.PI / 180;
     var pitchR = pitch * rad;
     var yawR = yaw * rad;

--- a/openfollow/web/templates/wizard.tpl
+++ b/openfollow/web/templates/wizard.tpl
@@ -600,7 +600,7 @@
     </div>
     <div class="group">
       <div class="group-title">Orientation</div>
-      <p class="wizard-help">Enter the camera's angle. If the camera points straight at the stage, start with Pitch &asymp; &minus;30&deg; (looking down), Yaw = 0&deg;, Roll = 0&deg;.</p>
+      <p class="wizard-help">Enter the camera's angle. Start with Pitch &asymp; &minus;30&deg; (looking down) and Roll = 0&deg;. Yaw is the direction the camera faces: 0&deg; from the house, 180&deg; from upstage, &plusmn;90&deg; from a box boom.</p>
       <div class="row">
         <div class="field">
           <label for="cam_pitch">Pitch <span style="font-weight:400;text-transform:none;letter-spacing:0;">(down &minus;)</span></label>

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -7,6 +7,7 @@ behind-camera NaN clipping, and degenerate-fov/canvas rejection."""
 from __future__ import annotations
 
 import math
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -456,6 +457,34 @@ class TestWizardIllustrationAgreement:
     projection sends the operator chasing an overlay that never lines up.
     """
 
+    # The formulas ``_tpl_footprint`` below mirrors. Pinning the template
+    # source is what makes the mirror trustworthy: without it, editing the JS
+    # leaves this suite green and the preview drifts off the projection again.
+    _TPL_CAMERA_MODEL = (
+        "var lookX = Math.cos(pitchR) * Math.sin(yawR);",
+        "var lookY = Math.cos(pitchR) * Math.cos(yawR);",
+        "var lookZ = Math.sin(pitchR);",
+        "var Rv = [Math.cos(yawR), -Math.sin(yawR), 0];",
+        "var Uv = [-Math.sin(yawR) * Math.sin(pitchR), -Math.cos(yawR) * Math.sin(pitchR), Math.cos(pitchR)];",
+        "var vfov = (2 * Math.atan(Math.tan((fov / 2) * rad) * 9 / 16)) / rad;",
+    )
+
+    @staticmethod
+    def _wizard_tpl() -> str:
+        path = Path(__file__).resolve().parent.parent / "openfollow" / "web" / "templates" / "wizard.tpl"
+        return path.read_text(encoding="utf-8")
+
+    def test_template_still_uses_the_mirrored_camera_model(self) -> None:
+        """The preview's own camera model is what the rest of this class mirrors.
+
+        Change one of these lines in ``wizard.tpl`` and the numeric agreement
+        test below silently stops describing the template, so pin them here and
+        update both together.
+        """
+        src = self._wizard_tpl()
+        for line in self._TPL_CAMERA_MODEL:
+            assert line in src, f"wizard.tpl no longer contains {line!r} – update _tpl_footprint to match"
+
     @staticmethod
     def _tpl_footprint(
         pos: tuple[float, float, float],
@@ -548,18 +577,20 @@ class TestSolveAtNonZeroYaw:
         # Yaw is an angle: ±180 name the same heading.
         assert math.cos(math.radians(solved.yaw - yaw)) == pytest.approx(1.0, abs=1e-5)
 
+    @pytest.mark.parametrize("pitch", [-90.0, -89.96])
     @pytest.mark.parametrize("roll", [0.0, 30.0, -45.0])
-    def test_overhead_camera_keeps_its_roll(self, roll: float) -> None:
+    def test_overhead_camera_keeps_its_roll(self, pitch: float, roll: float) -> None:
         """Straight down, bearing and roll stop being separable.
 
         Aimed at the floor there is no heading left to measure – panning the
         head and rolling the lens do the same thing – so the pan is pinned and
         the operator's lens rotation is what survives. Without that the two
         freedoms split arbitrarily and a plumb overhead camera comes back
-        canted.
+        canted. Both a bit-exact −90 and a camera merely near the pole must
+        land here, so the behaviour is a neighbourhood and not one float.
         """
         canvas_w, canvas_h = 1920.0, 1080.0
-        params = np.array([0.0, 0.0, 12.0, -90.0, 0.0, roll, 60.0], dtype=np.float64)
+        params = np.array([0.0, 0.0, 12.0, pitch, 0.0, roll, 60.0], dtype=np.float64)
         world = np.array(self._GRID, dtype=np.float64)
         screen = project_points(params, world, canvas_w, canvas_h)
 
@@ -571,6 +602,24 @@ class TestSolveAtNonZeroYaw:
         )
 
         assert solved is not None
-        assert solved.pitch == pytest.approx(-89.0)  # the straight-down clamp
-        assert solved.yaw == pytest.approx(0.0, abs=1e-9)
+        assert solved.pitch < -88.9  # aimed at the floor
         assert solved.roll == pytest.approx(roll, abs=0.05)
+        assert solved.yaw == pytest.approx(0.0, abs=1e-9)
+        # Signed zero reaches config.toml and the form field verbatim.
+        assert math.copysign(1.0, solved.yaw) > 0.0, "yaw came back as negative zero"
+
+    @pytest.mark.parametrize("pitch", [-90.0, -89.6])
+    def test_plumb_overhead_rig_is_refused_rather_than_approximated(self, pitch: float) -> None:
+        """A camera hung dead overhead is rejected, not silently tilted.
+
+        The solved pitch is clamped one degree off vertical, which shifts the
+        corners further than the reprojection gate allows, so the wizard
+        answers "Invalid perspective" instead of accepting a pose that does not
+        reproduce what the operator pinned. Rigs from −89.5° up solve normally.
+        """
+        canvas_w, canvas_h = 1920.0, 1080.0
+        params = np.array([0.0, 0.0, 12.0, pitch, 0.0, 0.0, 60.0], dtype=np.float64)
+        world = np.array(self._GRID, dtype=np.float64)
+        screen = project_points(params, world, canvas_w, canvas_h)
+
+        assert solve_camera_dlt(self._GRID, [tuple(pt) for pt in screen], canvas_w, canvas_h) is None

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -12,6 +12,8 @@ import numpy as np
 import pytest
 
 from openfollow.scene.solver import (
+    compute_homography,
+    decompose_homography,
     ground_circle_world_ring,
     hfov_to_vfov,
     project_points,
@@ -283,3 +285,292 @@ def test_unproject_at_camera_plane_returns_nan() -> None:
     screen = np.array([[960.0, 540.0]], dtype=np.float64)
     out = unproject_to_plane(params, screen, 1920.0, 1080.0, plane_z_psn=0.0)
     assert np.all(np.isnan(out[0]))
+
+
+# --------------------------------------------------------------------------- #
+# Camera orientation convention
+#
+# The round-trip tests above (project ∘ unproject, project ∘ solve ∘ project)
+# all read the same rotation, so they hold for *any* self-consistent pose
+# convention. The tests below make absolute claims instead: where a given
+# pitch/yaw actually aims the camera in the world.
+# --------------------------------------------------------------------------- #
+
+
+def _centre_floor_hit(params: np.ndarray, canvas_w: float, canvas_h: float) -> np.ndarray:
+    """World point under the centre of frame, i.e. where the camera is aimed.
+
+    The screen centre unprojects along the optical axis, so this is the
+    observable form of "which way is the camera pointing".
+    """
+    centre = np.array([[canvas_w / 2.0, canvas_h / 2.0]], dtype=np.float64)
+    return unproject_to_plane(params, centre, canvas_w, canvas_h, plane_z_psn=0.0)[0]
+
+
+class TestCameraOrientationConvention:
+    """Pitch tilts about the camera's own right axis, after yaw has panned it.
+
+    So ``pitch`` is the depression below the horizon and ``yaw`` is the ground
+    bearing, independently of each other, at every heading.
+    """
+
+    def test_upstage_camera_sees_the_grid(self) -> None:
+        """A camera upstage of the grid, looking downstage and down at it.
+
+        Reported rig: 6.9 m up and 5.25 m upstage of a 6.1 x 3.64 m grid that
+        spans y = 0…3.64, tilted 65° down and panned 180° to face downstage.
+        Every corner is plainly in shot, so every corner must project.
+        """
+        params = np.array([0.5, 5.25, 6.9, -65.0, 180.0, 0.0, 69.09], dtype=np.float64)
+        half_w, half_d = 3.05, 1.82
+        corners = np.array(
+            [
+                (half_w, 0.0, 0.0),
+                (-half_w, 0.0, 0.0),
+                (-half_w, 2 * half_d, 0.0),
+                (half_w, 2 * half_d, 0.0),
+                (0.0, half_d, 0.0),  # grid centre / reference point
+            ],
+            dtype=np.float64,
+        )
+
+        screen = project_points(params, corners, 1280.0, 720.0)
+
+        assert np.all(np.isfinite(screen)), f"corners fell behind the lens: {screen}"
+        assert np.all(screen[:, 0] >= 0.0) and np.all(screen[:, 0] <= 1280.0)
+        assert np.all(screen[:, 1] >= 0.0) and np.all(screen[:, 1] <= 720.0)
+
+    @pytest.mark.parametrize("yaw", list(range(0, 360, 10)))
+    def test_negative_pitch_looks_down_at_every_yaw(self, yaw: int) -> None:
+        """Panning the camera must not change how far below the horizon it aims.
+
+        A camera 8 m up tilted 65° down reaches the floor 8/tan(65°) away no
+        matter which way it faces.
+        """
+        pitch = -65.0
+        params = np.array([0.0, 0.0, 8.0, pitch, float(yaw), 0.0, 60.0], dtype=np.float64)
+
+        hit = _centre_floor_hit(params, 1920.0, 1080.0)
+
+        assert np.all(np.isfinite(hit)), f"optical axis never reaches the floor at yaw={yaw}"
+        assert hit[2] == pytest.approx(0.0, abs=1e-9)
+        reach = math.hypot(hit[0] - 0.0, hit[1] - 0.0)
+        assert reach == pytest.approx(8.0 / math.tan(math.radians(65.0)), abs=1e-6)
+
+    @pytest.mark.parametrize("yaw", [-135.0, -90.0, -45.0, 0.0, 45.0, 90.0, 135.0, 180.0])
+    def test_yaw_is_the_ground_bearing(self, yaw: float) -> None:
+        """Yaw pans the aim point around the camera by exactly that angle.
+
+        Bearing is measured from upstage (+Y) toward stage left (+X), matching
+        the ``Yaw (left −)`` label on the camera form.
+        """
+        params = np.array([2.0, -3.0, 7.0, -50.0, yaw, 0.0, 60.0], dtype=np.float64)
+
+        hit = _centre_floor_hit(params, 1920.0, 1080.0)
+
+        assert np.all(np.isfinite(hit))
+        bearing = math.degrees(math.atan2(hit[0] - 2.0, hit[1] - (-3.0)))
+        assert bearing == pytest.approx(yaw, abs=1e-6)
+
+    @pytest.mark.parametrize("yaw", [-90.0, 90.0])
+    def test_side_on_camera_still_tilts_down(self, yaw: float) -> None:
+        """A box-boom camera looks across the stage *and* down into it.
+
+        Facing along the X axis must not pin the optical axis to the horizon.
+        """
+        params = np.array([-9.0, 1.0, 6.0, -35.0, yaw, 0.0, 60.0], dtype=np.float64)
+
+        hit = _centre_floor_hit(params, 1920.0, 1080.0)
+
+        assert np.all(np.isfinite(hit)), "side-on camera aims at the horizon, never the floor"
+        # Aims across the stage along X, at the depression angle pitch asks for.
+        assert hit[1] == pytest.approx(1.0, abs=1e-6)
+        reach = abs(hit[0] - (-9.0))
+        assert reach == pytest.approx(6.0 / math.tan(math.radians(35.0)), abs=1e-6)
+
+    @pytest.mark.parametrize(
+        ("roll", "expected"),
+        [
+            (
+                0.0,
+                [
+                    (117.6381, 906.6958),
+                    (1465.4171, 906.6958),
+                    (1224.7765, 411.5542),
+                    (518.7058, 411.5542),
+                    (835.2268, 384.8844),
+                ],
+            ),
+            (
+                -12.0,
+                [
+                    (212.2861, 1073.8195),
+                    (1530.6129, 793.6005),
+                    (1192.2851, 359.3109),
+                    (501.6437, 506.1112),
+                    (805.7031, 414.2158),
+                ],
+            ),
+            (
+                25.0,
+                [
+                    (41.5885, 516.3417),
+                    (1263.0911, 1085.9377),
+                    (1254.2526, 535.4879),
+                    (614.3352, 237.0895),
+                    (912.4718, 346.6861),
+                ],
+            ),
+        ],
+    )
+    def test_head_on_camera_projects_to_pinned_pixels(self, roll: float, expected: list[tuple[float, float]]) -> None:
+        """Golden pixels for a yaw-0 camera, the overwhelmingly common rig.
+
+        A camera facing straight upstage is unaffected by how pitch and yaw
+        compose, so these coordinates are the guarantee that a head-on
+        installation keeps projecting exactly where it always did.
+        """
+        params = np.array([1.0, -9.0, 5.5, -27.0, 0.0, roll, 72.0], dtype=np.float64)
+        world = np.array(
+            [
+                (-4.0, -3.0, 0.0),
+                (4.0, -3.0, 0.0),
+                (4.0, 5.0, 0.0),
+                (-4.0, 5.0, 0.0),
+                (0.0, 1.0, 1.8),
+            ],
+            dtype=np.float64,
+        )
+
+        screen = project_points(params, world, 1920.0, 1080.0)
+
+        assert screen == pytest.approx(np.array(expected), abs=1e-4)
+
+
+class TestWizardIllustrationAgreement:
+    """The Setup Wizard's camera-position preview must match what gets drawn.
+
+    Step 4 sketches the ground footprint of the frustum client-side, from its
+    own copy of the camera model (``updateCamIllustration`` in ``wizard.tpl``).
+    Nothing links the two but this test, and a preview that disagrees with the
+    projection sends the operator chasing an overlay that never lines up.
+    """
+
+    @staticmethod
+    def _tpl_footprint(
+        pos: tuple[float, float, float],
+        pitch: float,
+        yaw: float,
+        hfov: float,
+    ) -> list[tuple[float, float]]:
+        """Ground footprint the way ``wizard.tpl`` computes it.
+
+        Mirrors the look vector, camera basis and 16:9 vertical FOV the
+        template derives, then intersects the four frustum corners with the
+        floor. Corner order is top-left, top-right, bottom-right, bottom-left.
+        """
+        cx, cy, cz = pos
+        p, y = math.radians(pitch), math.radians(yaw)
+        look = (math.cos(p) * math.sin(y), math.cos(p) * math.cos(y), math.sin(p))
+        right = (math.cos(y), -math.sin(y), 0.0)
+        up = (-math.sin(y) * math.sin(p), -math.cos(y) * math.sin(p), math.cos(p))
+        th = math.tan(math.radians(hfov) / 2.0)
+        tv = math.tan(math.atan(th * 9 / 16))
+
+        hits = []
+        for sx, sy in ((-1, 1), (1, 1), (1, -1), (-1, -1)):
+            d = tuple(look[i] + sx * th * right[i] + sy * tv * up[i] for i in range(3))
+            t = -cz / d[2]
+            hits.append((cx + d[0] * t, cy + d[1] * t))
+        return hits
+
+    @pytest.mark.parametrize(
+        ("pitch", "yaw"),
+        [(-45.0, 0.0), (-45.0, 180.0), (-50.0, 90.0), (-40.0, -60.0), (-65.0, 137.0)],
+    )
+    def test_footprint_matches_unprojected_frame_corners(self, pitch: float, yaw: float) -> None:
+        canvas_w, canvas_h = 1920.0, 1080.0
+        pos = (1.5, -2.0, 7.0)
+        hfov = 70.0
+        params = np.array([*pos, pitch, yaw, 0.0, hfov], dtype=np.float64)
+        frame_corners = np.array(
+            [(0.0, 0.0), (canvas_w, 0.0), (canvas_w, canvas_h), (0.0, canvas_h)],
+            dtype=np.float64,
+        )
+
+        world = unproject_to_plane(params, frame_corners, canvas_w, canvas_h, plane_z_psn=0.0)
+
+        assert np.all(np.isfinite(world))
+        assert world[:, :2] == pytest.approx(np.array(self._tpl_footprint(pos, pitch, yaw, hfov)), abs=1e-6)
+
+
+class TestSolveAtNonZeroYaw:
+    """``solve_camera_dlt`` has to recover the pose it was handed.
+
+    The decomposition inverts the rotation composition by hand, so a solve is
+    the only thing that catches the two drifting apart.
+    """
+
+    _GRID = [(-5.0, -5.0, 0.0), (5.0, -5.0, 0.0), (5.0, 5.0, 0.0), (-5.0, 5.0, 0.0)]
+
+    @pytest.mark.parametrize(
+        ("pos", "pitch", "yaw", "roll", "fov"),
+        [
+            ((0.0, -11.0, 6.0), -22.0, 0.0, 0.0, 60.0),  # front of house
+            ((0.0, 11.0, 6.0), -30.0, 180.0, 0.0, 60.0),  # upstage, facing downstage
+            ((11.0, 0.0, 6.0), -30.0, -90.0, 0.0, 60.0),  # box boom, stage left
+            ((-11.0, 0.0, 6.0), -30.0, 90.0, 0.0, 60.0),  # box boom, stage right
+            ((-9.0, -9.0, 7.0), -28.0, 45.0, 3.0, 70.0),  # oblique, canted
+            ((8.0, -8.0, 5.0), -25.0, -38.0, -6.0, 55.0),
+        ],
+    )
+    def test_solve_recovers_the_projected_pose(
+        self,
+        pos: tuple[float, float, float],
+        pitch: float,
+        yaw: float,
+        roll: float,
+        fov: float,
+    ) -> None:
+        canvas_w, canvas_h = 1920.0, 1080.0
+        params = np.array([*pos, pitch, yaw, roll, fov], dtype=np.float64)
+        world = np.array(self._GRID, dtype=np.float64)
+        screen = project_points(params, world, canvas_w, canvas_h)
+        assert np.all(np.isfinite(screen)), "fixture camera cannot see its own grid"
+
+        solved = solve_camera_dlt(self._GRID, [tuple(pt) for pt in screen], canvas_w, canvas_h)
+
+        assert solved is not None
+        assert (solved.pos_x, solved.pos_y, solved.pos_z) == pytest.approx(pos, abs=0.01)
+        assert solved.pitch == pytest.approx(pitch, abs=0.05)
+        assert solved.roll == pytest.approx(roll, abs=0.05)
+        assert solved.fov == pytest.approx(fov, abs=0.05)
+        # Yaw is an angle: ±180 name the same heading.
+        assert math.cos(math.radians(solved.yaw - yaw)) == pytest.approx(1.0, abs=1e-5)
+
+    @pytest.mark.parametrize("roll", [0.0, 30.0, -45.0])
+    def test_overhead_camera_keeps_its_roll(self, roll: float) -> None:
+        """Straight down, bearing and roll stop being separable.
+
+        Aimed at the floor there is no heading left to measure – panning the
+        head and rolling the lens do the same thing – so the pan is pinned and
+        the operator's lens rotation is what survives. Without that the two
+        freedoms split arbitrarily and a plumb overhead camera comes back
+        canted.
+        """
+        canvas_w, canvas_h = 1920.0, 1080.0
+        params = np.array([0.0, 0.0, 12.0, -90.0, 0.0, roll, 60.0], dtype=np.float64)
+        world = np.array(self._GRID, dtype=np.float64)
+        screen = project_points(params, world, canvas_w, canvas_h)
+
+        solved = decompose_homography(
+            compute_homography(world[:, :2], screen),
+            canvas_w,
+            canvas_h,
+            0.0,
+        )
+
+        assert solved is not None
+        assert solved.pitch == pytest.approx(-89.0)  # the straight-down clamp
+        assert solved.yaw == pytest.approx(0.0, abs=1e-9)
+        assert solved.roll == pytest.approx(roll, abs=0.05)

--- a/tests/test_solver_mutation.py
+++ b/tests/test_solver_mutation.py
@@ -43,7 +43,13 @@ from openfollow.scene.solver import (
 pytestmark = pytest.mark.unit
 
 # --------------------------------------------------------------------------- #
-# _rotation_matrix – kill cb*cc → cb/cc, -sa*sb*sc → +sa*sb*sc, etc.
+# _rotation_matrix – kill mul-vs-div and sign mutants on the matrix terms.
+#
+# Orthogonality, determinant and column norms hold for any product of proper
+# rotations, so they cannot see a reordered or mis-signed composition. The
+# absolute look-direction assertion below is what pins the composition itself;
+# TestCameraOrientationConvention in test_solver.py covers it through the
+# public projection boundary.
 # --------------------------------------------------------------------------- #
 
 
@@ -103,6 +109,29 @@ class TestRotationMatrixSubstantialAngles:
             assert math.isclose(norm, 1.0, abs_tol=1e-10), (
                 f"column {col} norm = {norm} at pitch={pitch}° yaw={yaw}° roll={roll}°"
             )
+
+    @pytest.mark.parametrize(
+        "pitch, yaw, roll",
+        [(-35.0, 20.0, 30.0), (-45.0, 150.0, 25.0), (-20.0, -95.0, -15.0)],
+    )
+    def test_rotation_matrix_points_the_camera_where_the_angles_say(
+        self, pitch: float, yaw: float, roll: float
+    ) -> None:
+        """Kill reordered / mis-signed compositions, which the norm checks miss.
+
+        The camera looks along -Z, so the third column negated is the forward
+        ray. In PSN it has to be the pan-then-tilt direction for the requested
+        angles, and roll must not move it at all.
+        """
+        R = _rotation_matrix(math.radians(pitch), math.radians(yaw), math.radians(roll))
+        gfx_forward = -R[:, 2]
+        forward_psn = np.array([gfx_forward[0], -gfx_forward[2], gfx_forward[1]])
+
+        p, y = math.radians(pitch), math.radians(yaw)
+        expected = np.array([math.cos(p) * math.sin(y), math.cos(p) * math.cos(y), math.sin(p)])
+        assert np.allclose(forward_psn, expected, atol=1e-12), (
+            f"forward {forward_psn} != {expected} at pitch={pitch}° yaw={yaw}° roll={roll}°"
+        )
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_solver_properties.py
+++ b/tests/test_solver_properties.py
@@ -58,6 +58,27 @@ def _camera_params(draw: st.DrawFn) -> np.ndarray:
     return np.array([pos_x, pos_y, pos_z, pitch, yaw, roll, fov], dtype=np.float64)
 
 
+# The regime above keeps the camera downstage looking upstage. Real rigs also
+# hang upstage, on box booms, and anywhere else around the stage, so this one
+# walks the camera around a ring and aims it back at the grid centre: full
+# 360° of yaw with the grid reliably framed.
+@st.composite
+def _ring_camera_params(draw: st.DrawFn) -> np.ndarray:
+    bearing = draw(_floats(-180.0, 180.0))  # centre → camera, in ground plane
+    distance = draw(_floats(8.0, 30.0))
+    height = draw(_floats(4.0, 20.0))
+    roll = draw(_floats(-15.0, 15.0))
+    fov = draw(_floats(40.0, 100.0))
+
+    theta = math.radians(bearing)
+    pos_x = math.sin(theta) * distance
+    pos_y = math.cos(theta) * distance
+    # Face back down the bearing, tilted to put the grid centre mid-frame.
+    yaw = bearing - 180.0 if bearing > 0.0 else bearing + 180.0
+    pitch = -math.degrees(math.atan2(height, distance))
+    return np.array([pos_x, pos_y, height, pitch, yaw, roll, fov], dtype=np.float64)
+
+
 # A well-spread, non-degenerate coplanar quad at z=0 (the calibration grid
 # plane), the input shape ``solve_camera_dlt`` is designed for.
 @st.composite
@@ -292,6 +313,78 @@ def test_solve_dlt_handles_arbitrary_screen_without_crash_or_nan(
     solved = solve_camera_dlt([tuple(p) for p in corners], screen, w, h)
     if solved is not None:
         assert np.all(np.isfinite(_solved_params(solved)))
+
+
+# --- orientation holds all the way around the stage --------------------------
+
+
+@given(params=_ring_camera_params(), canvas=_CANVASES)
+def test_camera_aims_where_its_angles_say_from_any_heading(
+    params: np.ndarray,
+    canvas: tuple[float, float],
+) -> None:
+    """Pitch and yaw keep their meaning at every heading.
+
+    Each drawn camera stands somewhere on a ring around the grid centre and is
+    given the pitch and yaw that aim it back at that centre. Whatever the
+    heading, the middle of frame has to land on the centre – if panning the
+    camera bent its tilt, the aim point would slide off.
+    """
+    w, h = canvas
+    centre = np.array([[w / 2.0, h / 2.0]], dtype=np.float64)
+
+    hit = unproject_to_plane(params, centre, w, h, plane_z_psn=0.0)[0]
+
+    assert np.all(np.isfinite(hit))
+    assert hit == pytest.approx(np.zeros(3), abs=1e-6)
+
+
+@given(
+    params=_ring_camera_params(),
+    canvas=_CANVASES,
+    plane_z=_floats(0.0, 5.0),
+    xy=st.lists(_XY, min_size=1, max_size=6),
+)
+def test_ring_project_then_unproject_is_identity_on_plane(
+    params: np.ndarray,
+    canvas: tuple[float, float],
+    plane_z: float,
+    xy: list[tuple[float, float]],
+) -> None:
+    w, h = canvas
+    world = np.array([(x, y, plane_z) for x, y in xy], dtype=np.float64)
+    screen = project_points(params, world, w, h)
+    assume(np.all(np.isfinite(screen)))
+    back = unproject_to_plane(params, screen, w, h, plane_z_psn=plane_z)
+    assume(np.all(np.isfinite(back)))
+    assert np.allclose(back, world, atol=1e-4)
+
+
+@given(params=_ring_camera_params(), canvas=_CANVASES, corners=_quad())
+def test_ring_solve_dlt_recovers_the_camera_pose(
+    params: np.ndarray,
+    canvas: tuple[float, float],
+    corners: np.ndarray,
+) -> None:
+    """Calibration reconstructs the pose from any heading, not just head-on.
+
+    The decomposition inverts the rotation composition by hand, so it is the
+    half of the kernel a projection round-trip cannot check.
+    """
+    w, h = canvas
+    screen = project_points(params, corners, w, h)
+    assume(np.all(np.isfinite(screen)))
+    solved = solve_camera_dlt(
+        [tuple(p) for p in corners],
+        [tuple(p) for p in screen],
+        w,
+        h,
+    )
+    assume(solved is not None)
+    assert np.allclose(_solved_params(solved)[:4], params[:4], atol=0.05)
+    assert math.isclose(solved.fov, float(params[6]), abs_tol=0.05)
+    # Yaw wraps: ±180 name the same heading.
+    assert math.isclose(math.cos(math.radians(solved.yaw - float(params[4]))), 1.0, abs_tol=1e-4)
 
 
 # --- unproject robustness ----------------------------------------------------


### PR DESCRIPTION
Closes #57.

## The problem

`_rotation_matrix` composed pitch as the outermost term, so it tilted the camera about a **world** axis rather than the camera's own. The forward vector came out as

```
forward = (sin yaw,  cos pitch · cos yaw,  sin pitch · cos yaw)
```

so `forward.z` scaled with `cos(yaw)`. At pitch −65°:

| yaw | 0 | 45 | 90 | 135 | 180 | 270 |
|---|---|---|---|---|---|---|
| `forward.z` | −0.906 | −0.641 | **0.000** | +0.641 | +0.906 | **0.000** |

Past ±90° of yaw a negative pitch aimed at the ceiling, and at exactly ±90° the optical axis was horizontal for *any* pitch, so a box boom could not tilt down at all.

The reporting operator had a camera 6.9 m up and 5.25 m upstage of the grid, tilted 65° down and panned 180° to face the house. Every grid corner was plainly in the video feed; all four projected to `NaN` and the wizard refused the pose. The HUD looked correct throughout because it is drawn from the same pose the operator views through, so the defect stayed invisible until the wizard tested corner visibility independently.

The issue suggested entering `pitch = +65` as a workaround. That does not work through the wizard: the Step-4 pitch input is hard-limited to `min="-90" max="-0.5"`, so a rear rig could not be entered at all.

## The fix

Pan about world up first, then tilt about the camera's own right axis:

```
R = Ry(-yaw) @ Rx(pitch) @ Rz(roll)
```

giving `forward = (cos pitch · sin yaw, cos pitch · cos yaw, sin pitch)`. Pitch is now the depression below the horizon and yaw the ground bearing, each independent of the other. The homography decomposition inverts the same composition; its singularity moves from a legitimate side-on camera to a plumb overhead one, which is why the old gimbal-lock `pragma: no cover` is gone and covered by a real test instead.

**The wizard already agreed with this.** The Step-4 isometric preview (`updateCamIllustration`) builds its own camera frame from `cos(pitch)·sin(yaw)` / `cos(pitch)·cos(yaw)` / `sin(pitch)`, i.e. intrinsic pan-then-tilt. The operator was being *shown* the correct geometry while the backend projected a different one. This makes Python match the picture rather than inventing a new convention; no JS changed.

## Migration

At yaw 0 the two compositions are **bit-identical**, so a head-on installation is untouched. A rig with a non-zero yaw changes meaning and should be re-run through the Setup Wizard. Documented in the camera help drawer. No config migration and no schema marker.

## Why the suite missed it

Every `_rotation_matrix` test asserted only orthonormality, determinant and unit column norms, all true of *any* rotation product in *any* order. Every projection test was a `project ∘ unproject` or `project ∘ solve ∘ project` round-trip **through the same matrix**, so it stayed green under any self-consistent convention. The one hardcoded pixel snapshot uses yaw 0, and the coordinate-invariant suite uses only a `pitch −90, yaw 0` top-down camera where every convention collapses to the same matrix.

The new tests make **absolute** claims instead:

- the reported rig projects all four corners plus the reference point (fails before this change)
- a negative pitch reaches the floor at `pos_z / tan|pitch|` at every yaw from 0° to 350°
- yaw is the literal ground bearing of the aim point
- a box-boom camera at yaw ±90 still tilts into the stage
- golden pixels for a yaw-0 camera at three roll values, pinning the migration guarantee observably
- the wizard's client-side footprint equals the unprojected frame corners, so preview and projection cannot drift apart again
- `solve_camera_dlt` recovers pose for front / upstage / both box booms / oblique-canted rigs, and keeps roll on an overhead camera
- a Hypothesis ring strategy walks the camera around the stage aiming back at the grid centre, covering the full 360° of yaw the old strategy capped at ±25° (100% of draws reach the assertion)

## Verification

`make ci-remote` green: lint, mypy, bandit, 8676 unit + 969 integration/smoke tests, 100% line + branch coverage, build. No testing Pi was reachable, so the gate ran locally on macOS.