### PR TITLE
ci(release): make SBOM collection tolerate the rootless chroot walk

### DIFF
--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -121,10 +121,13 @@ jobs:
       # Attach both the signed bundle (in-app updater path) and the raw .deb
       # (manual apt/dpkg install) to the release. Globs are non-overlapping.
       - name: Attach .deb + bundle to GitHub Release
-        if: github.event_name == 'release'
+        # Also runs on a manual dispatch that passes `version`, so a maintainer can
+        # re-attach assets to an existing release after a transient job failure.
+        if: github.event_name == 'release' || github.event.inputs.version != ''
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" dist/openfollow_*_${{ matrix.arch }}.ofupdate dist/openfollow_*_${{ matrix.arch }}.deb --clobber --repo "$GITHUB_REPOSITORY"
+          TAG: ${{ github.event.release.tag_name || github.event.inputs.version }}
+        run: gh release upload "$TAG" dist/openfollow_*_${{ matrix.arch }}.ofupdate dist/openfollow_*_${{ matrix.arch }}.deb --clobber --repo "$GITHUB_REPOSITORY"
 
   # Build the flashable Raspberry Pi OS Lite (Trixie, arm64) appliance images, with
   # the arm64 .deb from the build job pre-installed, using rpi-image-gen (cloned at a
@@ -213,9 +216,13 @@ jobs:
           OF_DEB_VERSION: ${{ github.event.inputs.version || github.event.release.tag_name }}
         run: |
           set -eu
-          SBOM="$(find "$RUNNER_TEMP/rig-build" -name '*.sbom' -type f -print -quit)"
+          # rpi-image-gen leaves the rootless chroot under rig-build with a few
+          # dirs the runner user can't read; find exits non-zero on those. Swallow
+          # the walk error so set -e can't abort before the match is even tested –
+          # the emptiness checks below still fail loudly if no SBOM was produced.
+          SBOM="$(find "$RUNNER_TEMP/rig-build" -name '*.sbom' -type f -print -quit 2>/dev/null || true)"
           if [ -z "$SBOM" ]; then
-            SBOM_ZST="$(find "$RUNNER_TEMP/rig-build" -name '*.sbom.zst' -type f -print -quit)"
+            SBOM_ZST="$(find "$RUNNER_TEMP/rig-build" -name '*.sbom.zst' -type f -print -quit 2>/dev/null || true)"
             [ -n "$SBOM_ZST" ] || { echo "no SBOM produced by rpi-image-gen under $RUNNER_TEMP/rig-build" >&2; exit 1; }
             SBOM="$RUNNER_TEMP/openfollow.sbom"
             zstd -d -f -o "$SBOM" "$SBOM_ZST"
@@ -241,13 +248,15 @@ jobs:
         run: python3 "$GITHUB_WORKSPACE/packaging/image/check_sbom_compliance.py" "${{ steps.sbom.outputs.path }}"
 
       - name: Attach image to GitHub Release
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || github.event.inputs.version != ''
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" "${{ steps.img.outputs.path }}" --clobber
+          TAG: ${{ github.event.release.tag_name || github.event.inputs.version }}
+        run: gh release upload "$TAG" "${{ steps.img.outputs.path }}" --clobber
 
       - name: Attach SBOM to GitHub Release
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || github.event.inputs.version != ''
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" "${{ steps.sbom.outputs.path }}" --clobber
+          TAG: ${{ github.event.release.tag_name || github.event.inputs.version }}
+        run: gh release upload "$TAG" "${{ steps.sbom.outputs.path }}" --clobber

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Override Debian version (default: read from pyproject.toml)"
+        description: "Release tag / version to build, e.g. v0.4.1 (default: read from pyproject.toml)"
         required: false
         type: string
 
@@ -126,8 +126,12 @@ jobs:
         if: github.event_name == 'release' || github.event.inputs.version != ''
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name || github.event.inputs.version }}
-        run: gh release upload "$TAG" dist/openfollow_*_${{ matrix.arch }}.ofupdate dist/openfollow_*_${{ matrix.arch }}.deb --clobber --repo "$GITHUB_REPOSITORY"
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        # Dispatch input may omit the 'v'; a release event's tag is used verbatim.
+        run: |
+          TAG="${RELEASE_TAG:-v${INPUT_VERSION#v}}"
+          gh release upload "$TAG" dist/openfollow_*_${{ matrix.arch }}.ofupdate dist/openfollow_*_${{ matrix.arch }}.deb --clobber --repo "$GITHUB_REPOSITORY"
 
   # Build the flashable Raspberry Pi OS Lite (Trixie, arm64) appliance images, with
   # the arm64 .deb from the build job pre-installed, using rpi-image-gen (cloned at a
@@ -251,12 +255,18 @@ jobs:
         if: github.event_name == 'release' || github.event.inputs.version != ''
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name || github.event.inputs.version }}
-        run: gh release upload "$TAG" "${{ steps.img.outputs.path }}" --clobber
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          TAG="${RELEASE_TAG:-v${INPUT_VERSION#v}}"
+          gh release upload "$TAG" "${{ steps.img.outputs.path }}" --clobber
 
       - name: Attach SBOM to GitHub Release
         if: github.event_name == 'release' || github.event.inputs.version != ''
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name || github.event.inputs.version }}
-        run: gh release upload "$TAG" "${{ steps.sbom.outputs.path }}" --clobber
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          TAG="${RELEASE_TAG:-v${INPUT_VERSION#v}}"
+          gh release upload "$TAG" "${{ steps.sbom.outputs.path }}" --clobber


### PR DESCRIPTION
## Why v0.4.1 release-deb failed

The `Collect SBOM` step ran `find "$RUNNER_TEMP/rig-build" …` under `set -e`. rpi-image-gen leaves a few dirs in the rootless chroot (`filesystem/home/openfollow`, `var/{lib/apt/lists,cache/apt/archives}/partial`) that the runner user can't read, so `find` printed `Permission denied` and exited non-zero.

Whether the step passed depended purely on **readdir order** inside `chroot-v2.6.0/`: if the sibling `filesystem-v2.6.0.sbom` was visited before `find` descended into `filesystem/`, `-print -quit` fired at exit 0; otherwise `find` hit the unreadable dirs first and exited 1, and `set -e` aborted the step. Every prior release won that race; v0.4.1 lost it and shipped without its Pi images/SBOMs attached.

## Fix

- Swallow the walk error (`2>/dev/null || true`) on both `find` calls; the existing emptiness guards still fail loudly when no SBOM was actually produced.
- Let the three release-attach steps also run on a manual `workflow_dispatch` that passes `version`, resolving the tag from the release event or the input — so maintainers can re-attach assets to an existing release after a transient image-job failure without republishing the tag.

## Recovery

Dispatched this workflow at `version=v0.4.1` from this branch to attach the missing `pi5`/`cm5` images + SBOMs to the existing v0.4.1 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)