### PR TITLE
feat(net): add the Interface Assignment panel and per-plane interface resolution

### DIFF
--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -57,6 +57,7 @@ pragma without an entry here is treated as a review blocker.
 | [`openfollow/video/media_store.py`][media_store]        | `if match is None: # pragma: no cover - callers pass only regex-matched paths` in `_user_item` | `_user_item` is only ever called with paths already filtered through `_USER_FILE_RE`, so the re-match never fails. The guard is defense-in-depth against a future caller bypassing the filter. |
 | [`openfollow/input/mouse3d.py`][mouse3d]                | `...  # pragma: no cover - Protocol method body, never executed` on `Mouse3DBackend.enumerate` | `typing.Protocol` method body is a type-stub ellipsis – the Protocol registers the signature for structural checks but never executes the body. The concrete implementation (`_PySpaceMouseBackend.enumerate`) is exercised by `tests/test_input_mouse3d.py`. |
 | [`openfollow/input/mouse3d.py`][mouse3d]                | `...  # pragma: no cover - Protocol method body, never executed` on `Mouse3DBackend.open` | Same as above for the `open` stub; `_PySpaceMouseBackend.open` is exercised via a mocked `pyspacemouse.open_by_path` in `tests/test_input_mouse3d.py`. |
+| [`openfollow/web/server.py`][webserver]                 | `except OSError: # pragma: no cover - socket already torn down` in `_QuietHandler.get_environ` | `self.connection.getsockname()` only raises once the peer socket is already torn down – a race between the client disconnecting and WSGI environ assembly, which cannot be provoked from a test without reaching into the handler and faking the socket. The value it guards (the local address the request arrived on, used to badge the interface the browser reached the station over) is exercised through `request_local_iface` in `tests/test_web_server.py`; the except body only omits the key. |
 
 [receiver]: ../openfollow/video/receiver.py
 [gamepad]: ../openfollow/input/gamepad.py
@@ -65,6 +66,7 @@ pragma without an entry here is treated as a review blocker.
 [detection]: ../openfollow/video/detection.py
 [media_store]: ../openfollow/video/media_store.py
 [mouse3d]: ../openfollow/input/mouse3d.py
+[webserver]: ../openfollow/web/server.py
 
 ## Mutation testing
 

--- a/openfollow/configuration.py
+++ b/openfollow/configuration.py
@@ -2943,6 +2943,17 @@ def apply_runtime_config_changes(app: OpenFollowApp, new_config: AppConfig) -> b
         # now-active pin (cleared on a honoured pin, restored on rollback).
         app._refresh_psn_source_advisory()
 
+    # Planes with a blank pin follow the station interface, but each is gated
+    # on its own dataclass differing – which it doesn't when only the Station
+    # default row moved. Covers both iface paths above; the equality check
+    # skips it when either rolled back. Runs on the same pass, so the panel's
+    # address column never advertises an interface a plane isn't on yet.
+    if psn_iface_changed and app._config.psn_source_iface == new_psn_source_iface:
+        _apply(
+            "station_iface_followers",
+            app._runtime_services.apply_station_iface_change,
+        )
+
     # Video pipeline live-swap. Change detection is plugin-driven via the
     # active source's ``config_changed(old, new)`` – covers ``video_source_type``
     # and per-plugin fields (rtsp_url, srt_host, …). Distinct from the

--- a/openfollow/net_utils.py
+++ b/openfollow/net_utils.py
@@ -16,8 +16,11 @@ from typing import Literal
 import psutil
 
 # Status from resolve_source_ip / resolve_plane_source_ip: "iface" (pinned),
-# "station" (fell through to the station-wide pin), "primary" (auto), "none" (offline).
-ResolveStatus = Literal["iface", "station", "primary", "none"]
+# "station" (inherited the station-wide pin), "primary" (auto-detected),
+# "down" (an interface *is* configured but currently has no address – an error
+# state, never a reason to bind elsewhere), "none" (nothing configured and
+# nothing to auto-detect).
+ResolveStatus = Literal["iface", "station", "primary", "down", "none"]
 
 
 def get_primary_local_ipv4(default: str = "N/A") -> str:
@@ -111,36 +114,42 @@ def resolve_source_ip(
     return "", "none"
 
 
+def plane_source_iface(pin: str, station_iface: str = "") -> str:
+    """Return the interface a plane is configured to use, or "" for auto-detect.
+
+    A blank *pin* means "follow the station interface"; a blank station
+    interface in turn means "let the OS choose". This resolves *configuration*
+    only – it never looks at whether the interface currently has an address.
+    """
+    return pin or station_iface
+
+
 def resolve_plane_source_ip(
     pin: str,
     station_iface: str = "",
-    *,
-    fallback: bool = True,
 ) -> tuple[str, ResolveStatus]:
-    """Resolve one network plane's interface pin to a concrete bind IP.
+    """Resolve one network plane's configured interface to a concrete bind IP.
 
-    Tries *pin* first, then *station_iface* (the station-wide default), then
-    auto-detect. A blank *pin* therefore means "follow the station interface",
-    and a blank station interface in turn means "let the OS choose" – so a
-    station that pins nothing behaves exactly as it did before per-plane pins
-    existed.
+    Inheritance happens for an **unset** value only: blank pin follows
+    *station_iface*, blank station interface auto-detects. Once an interface is
+    configured, it is the only one this plane may use – if it currently has no
+    address the result is ``("", "down")`` and the caller must bind nothing,
+    surface the error and retry.
 
-    A pin that is down falls through rather than failing closed, so a stale pin
-    never silently stalls a plane; the returned status says which step actually
-    produced the address, which is what the caller warns on.
+    It deliberately does **not** fall through to another interface. Silently
+    moving PSN onto the office LAN because a lighting VLAN went dark is worse
+    than PSN stopping: a dead output is diagnosable, a misrouted one is not.
+
+    The *address* is free to change – callers re-resolve on every retry so a new
+    DHCP lease on the same interface is picked up automatically. Only the
+    interface is fixed.
     """
-    if pin:
-        ip_for_pin = get_iface_ipv4(pin)
-        if ip_for_pin:
-            return ip_for_pin, "iface"
-
-    if station_iface:
-        ip_for_station = get_iface_ipv4(station_iface)
-        if ip_for_station:
-            return ip_for_station, "station"
-
-    if not fallback:
-        return "", "none"
+    configured = plane_source_iface(pin, station_iface)
+    if configured:
+        resolved = get_iface_ipv4(configured)
+        if resolved:
+            return resolved, "iface" if pin else "station"
+        return "", "down"
 
     primary = get_primary_local_ipv4(default="")
     if primary and not primary.startswith("127."):

--- a/openfollow/net_utils.py
+++ b/openfollow/net_utils.py
@@ -15,8 +15,9 @@ from typing import Literal
 
 import psutil
 
-# Status from resolve_source_ip: "iface" (pinned), "primary" (auto), "none" (offline).
-ResolveStatus = Literal["iface", "primary", "none"]
+# Status from resolve_source_ip / resolve_plane_source_ip: "iface" (pinned),
+# "station" (fell through to the station-wide pin), "primary" (auto), "none" (offline).
+ResolveStatus = Literal["iface", "station", "primary", "none"]
 
 
 def get_primary_local_ipv4(default: str = "N/A") -> str:
@@ -100,6 +101,43 @@ def resolve_source_ip(
             return ip_for_iface, "iface"
         # Pinned iface is down / missing – fall through to fallback
         # rather than failing closed.
+
+    if not fallback:
+        return "", "none"
+
+    primary = get_primary_local_ipv4(default="")
+    if primary and not primary.startswith("127."):
+        return primary, "primary"
+    return "", "none"
+
+
+def resolve_plane_source_ip(
+    pin: str,
+    station_iface: str = "",
+    *,
+    fallback: bool = True,
+) -> tuple[str, ResolveStatus]:
+    """Resolve one network plane's interface pin to a concrete bind IP.
+
+    Tries *pin* first, then *station_iface* (the station-wide default), then
+    auto-detect. A blank *pin* therefore means "follow the station interface",
+    and a blank station interface in turn means "let the OS choose" – so a
+    station that pins nothing behaves exactly as it did before per-plane pins
+    existed.
+
+    A pin that is down falls through rather than failing closed, so a stale pin
+    never silently stalls a plane; the returned status says which step actually
+    produced the address, which is what the caller warns on.
+    """
+    if pin:
+        ip_for_pin = get_iface_ipv4(pin)
+        if ip_for_pin:
+            return ip_for_pin, "iface"
+
+    if station_iface:
+        ip_for_station = get_iface_ipv4(station_iface)
+        if ip_for_station:
+            return ip_for_station, "station"
 
     if not fallback:
         return "", "none"

--- a/openfollow/services.py
+++ b/openfollow/services.py
@@ -854,20 +854,39 @@ class AppRuntimeServices:
         overlay.state = state
 
     def _resolved_source_ip(self) -> str:
-        """Return the concrete IP to bind PSN/marker-sync sockets to.
+        """Return the concrete IP to bind the station's own sockets to.
 
-        Central resolution point for the iface-pin model. Resolves the
-        active ``psn_source_iface`` with fallback enabled so a stale pin
-        never disables PSN: when the pinned interface isn't live, the
-        auto-detected primary wins and the app keeps running.
-        ``init_psn`` / ``init_psn_receiver`` / the marker-catalog sync
-        all route through here so they agree on the same validated IP.
+        Central resolution point for the iface-pin model: ``init_psn`` /
+        ``init_psn_receiver`` / the marker-catalog sync all route through here
+        so they agree on the same validated address.
+
+        Fail-closed, like every per-plane pin. A configured station interface
+        with no address returns ``""``, which callers must read as "do not
+        start" rather than passing on - every downstream socket treats an empty
+        source as *auto-detect* and would put this station's identity on
+        whatever interface happens to be up. Use :meth:`station_source_ip_or_none`
+        when the distinction matters.
         """
-        from openfollow.net_utils import resolve_source_ip
+        return self.station_source_ip_or_none() or ""
 
-        resolved, _status = resolve_source_ip(
-            self._app._config.psn_source_iface,
-        )
+    def station_source_ip_or_none(self) -> str | None:
+        """Station bind address, or ``None`` when its interface has no address.
+
+        ``None`` and ``""`` are different: ``""`` means nothing is configured
+        and auto-detect found nothing, while ``None`` means the operator chose
+        an interface that is currently down - which must stop the plane, not
+        move it.
+        """
+        from openfollow.net_utils import resolve_plane_source_ip
+
+        resolved, status = resolve_plane_source_ip("", self._app._config.psn_source_iface)
+        if status == "down":
+            logger.error(
+                "Configured psn_source_iface '%s' has no address; PSN stays down until it "
+                "returns (it will not be sent on another interface).",
+                self._app._config.psn_source_iface,
+            )
+            return None
         return resolved
 
     def init_online_sync(self) -> None:
@@ -902,7 +921,11 @@ class AppRuntimeServices:
         return self._app._config.web_bind or "0.0.0.0"
 
     def init_psn(self) -> None:
-        source_ip = self._resolved_source_ip()
+        source_ip = self.station_source_ip_or_none()
+        if source_ip is None:
+            # Configured station interface has no address. Binding "" would
+            # send PSN via the OS routing table.
+            return
         server = PsnServer(
             system_name=self._app._config.psn_system_name,
             mcast_ip=self._app._config.psn_mcast_ip,
@@ -963,15 +986,17 @@ class AppRuntimeServices:
             marker.set_pos(*default_pos)
         self._app._selected_id = self._app._controlled_ids[0] if self._app._controlled_ids else None
 
-    def _resolved_plane_source_ip(self, pin: str, *, label: str) -> str:
+    def _resolved_plane_source_ip(self, pin: str, *, label: str) -> str | None:
         """Resolve one plane's configured interface to a concrete bind IP.
 
         A blank *pin* follows ``psn_source_iface`` (the station-wide default),
         which in turn auto-detects – inheritance for an *unset* value only.
-        Once an interface is configured it is the only one this plane may use:
-        when it has no address the result is empty and the caller binds nothing
-        rather than moving the plane onto a different network. *label* names the
-        config field in the error.
+        Once an interface is configured it is the only one this plane may use.
+        When it has no address the result is ``None`` and the caller must not
+        start the service at all - an empty string would be wrong, because
+        every downstream socket reads "" as *auto-detect* and would send on
+        whatever interface the OS picks. *label* names the config field in the
+        error.
         """
         from openfollow.net_utils import plane_source_iface, resolve_plane_source_ip
 
@@ -988,17 +1013,24 @@ class AppRuntimeServices:
                 configured,
                 label,
             )
+            return None
         return resolved
 
     def init_otp(self) -> None:
         cfg = self._app._config.otp_output
         if not cfg.enabled:
             return
+        source_ip = self._resolved_plane_source_ip(cfg.source_iface, label="otp_output.source_iface")
+        if source_ip is None:
+            # Configured interface has no address. Starting with "" would bind
+            # via the OS routing table, i.e. send stage data on whatever NIC
+            # happens to be up - the outcome the pin exists to prevent.
+            return
         self._app._otp_server = OtpServer(
             system_name=self._app._config.psn_system_name,
             system_number=cfg.system_number,
             port=cfg.port,
-            source_ip=self._resolved_plane_source_ip(cfg.source_iface, label="otp_output.source_iface"),
+            source_ip=source_ip,
             priority=cfg.priority,
         )
         server = self._app._server
@@ -1336,12 +1368,18 @@ class AppRuntimeServices:
             old_port = server._port
             old_source_ip = server._source_ip
             old_priority = server._priority
+            new_source_ip = self._resolved_plane_source_ip(new_cfg.source_iface, label="otp_output.source_iface")
+            if new_source_ip is None:
+                # Configured interface has no address: stop rather than
+                # restart, because "" would rebind via the OS routing table.
+                server.stop()
+                return
             try:
                 server.restart(
                     system_name=self._app._config.psn_system_name,
                     system_number=new_cfg.system_number,
                     port=new_cfg.port,
-                    source_ip=self._resolved_plane_source_ip(new_cfg.source_iface, label="otp_output.source_iface"),
+                    source_ip=new_source_ip,
                     priority=new_cfg.priority,
                 )
             except Exception:

--- a/openfollow/services.py
+++ b/openfollow/services.py
@@ -1918,6 +1918,7 @@ class AppRuntimeServices:
             # Web write path: raw editable config snapshot for the form +
             # apply / renew handlers (broker-elevated, serialised).
             network_config_provider=self._network_config_provider,
+            network_interfaces_provider=self._network_interfaces_provider,
             network_apply_handler=self._handle_network_apply,
             network_renew_handler=self._handle_network_renew,
             # Privilege capability snapshot for the diagnostics bundle.
@@ -2164,6 +2165,53 @@ class AppRuntimeServices:
             lease_display=_format_lease_remaining(lease_seconds),
         )
         return base
+
+    def _network_interfaces_provider(self) -> list[dict[str, Any]]:
+        """Every non-loopback interface with its address, method and up-state.
+
+        The single-interface form only ever showed one adapter at a time, so
+        there was nowhere to see a multi-NIC (or tagged-VLAN) station's layout.
+        This backs the interface list that replaced its picker.
+
+        One ``get_state`` per interface means one backend call each – on the
+        NetworkManager adapter that is an ``nmcli`` subprocess – so the caller
+        is expected to cache it rather than resolve on every render.
+        """
+        from openfollow.network.adapter import is_loopback
+        from openfollow.network.validate import prefix_to_mask
+
+        adapter = getattr(self, "_network_adapter", None)
+        if adapter is None:
+            return []
+        rows: list[dict[str, Any]] = []
+        for iface in adapter.list_interfaces():
+            if is_loopback(iface):
+                continue
+            row: dict[str, Any] = {
+                "name": iface.name,
+                "is_up": iface.is_up,
+                "address": "",
+                "prefix": None,
+                "subnet_mask": "",
+                "method": "dhcp",
+            }
+            # A per-interface read can fail (interface disappearing mid-scan,
+            # backend hiccup) without invalidating the rest of the list, so
+            # degrade that row instead of dropping the whole panel.
+            try:
+                state = adapter.get_state(iface.name)
+            except Exception:  # noqa: BLE001
+                logger.exception("Network state read failed for %s", iface.name)
+                state = None
+            if state is not None:
+                row.update(
+                    address=state.ipv4.address or "",
+                    prefix=state.ipv4.prefix,
+                    subnet_mask=prefix_to_mask(state.ipv4.prefix) or "",
+                    method=state.ipv4.method.value,
+                )
+            rows.append(row)
+        return rows
 
     def _handle_network_apply(
         self,

--- a/openfollow/services.py
+++ b/openfollow/services.py
@@ -963,23 +963,29 @@ class AppRuntimeServices:
             marker.set_pos(*default_pos)
         self._app._selected_id = self._app._controlled_ids[0] if self._app._controlled_ids else None
 
-    @staticmethod
-    def _resolved_otp_source_ip(cfg: OtpOutputConfig) -> str:
-        """Resolve the OTP output's pinned interface to a concrete bind IP.
+    def _resolved_plane_source_ip(self, pin: str, *, label: str) -> str:
+        """Resolve one plane's interface pin to a concrete bind IP.
 
-        Mirrors PSN (``_resolved_source_ip``): a pinned interface that's down –
-        or unset – falls back to the primary interface so a stale pin never
-        silently stalls multicast output. Empty result lets the OS pick.
+        A blank *pin* follows ``psn_source_iface`` (the station-wide default),
+        which in turn falls back to auto-detect – so a station that pins
+        nothing behaves exactly as it did before per-plane pins existed. A pin
+        that's down falls through rather than failing closed, so a stale pin
+        never silently stalls the plane; *label* names the config field in the
+        warning that surfaces when the pin isn't honoured.
         """
-        from openfollow.net_utils import resolve_source_ip
+        from openfollow.net_utils import resolve_plane_source_ip
 
-        resolved, status = resolve_source_ip(cfg.source_iface, fallback=True)
-        if cfg.source_iface and status != "iface":
+        resolved, status = resolve_plane_source_ip(
+            pin,
+            self._app._config.psn_source_iface,
+        )
+        if pin and status != "iface":
             logger.warning(
-                "Configured otp_output.source_iface '%s' is unavailable; "
-                "falling back to %s. OTP multicast may use the wrong interface.",
-                cfg.source_iface,
+                "Configured %s '%s' is unavailable; falling back to %s. %s may use the wrong interface.",
+                label,
+                pin,
                 resolved or "OS default",
+                label,
             )
         return resolved
 
@@ -991,7 +997,7 @@ class AppRuntimeServices:
             system_name=self._app._config.psn_system_name,
             system_number=cfg.system_number,
             port=cfg.port,
-            source_ip=self._resolved_otp_source_ip(cfg),
+            source_ip=self._resolved_plane_source_ip(cfg.source_iface, label="otp_output.source_iface"),
             priority=cfg.priority,
         )
         server = self._app._server
@@ -1334,7 +1340,7 @@ class AppRuntimeServices:
                     system_name=self._app._config.psn_system_name,
                     system_number=new_cfg.system_number,
                     port=new_cfg.port,
-                    source_ip=self._resolved_otp_source_ip(new_cfg),
+                    source_ip=self._resolved_plane_source_ip(new_cfg.source_iface, label="otp_output.source_iface"),
                     priority=new_cfg.priority,
                 )
             except Exception:

--- a/openfollow/services.py
+++ b/openfollow/services.py
@@ -964,27 +964,28 @@ class AppRuntimeServices:
         self._app._selected_id = self._app._controlled_ids[0] if self._app._controlled_ids else None
 
     def _resolved_plane_source_ip(self, pin: str, *, label: str) -> str:
-        """Resolve one plane's interface pin to a concrete bind IP.
+        """Resolve one plane's configured interface to a concrete bind IP.
 
         A blank *pin* follows ``psn_source_iface`` (the station-wide default),
-        which in turn falls back to auto-detect – so a station that pins
-        nothing behaves exactly as it did before per-plane pins existed. A pin
-        that's down falls through rather than failing closed, so a stale pin
-        never silently stalls the plane; *label* names the config field in the
-        warning that surfaces when the pin isn't honoured.
+        which in turn auto-detects – inheritance for an *unset* value only.
+        Once an interface is configured it is the only one this plane may use:
+        when it has no address the result is empty and the caller binds nothing
+        rather than moving the plane onto a different network. *label* names the
+        config field in the error.
         """
-        from openfollow.net_utils import resolve_plane_source_ip
+        from openfollow.net_utils import plane_source_iface, resolve_plane_source_ip
 
         resolved, status = resolve_plane_source_ip(
             pin,
             self._app._config.psn_source_iface,
         )
-        if pin and status != "iface":
-            logger.warning(
-                "Configured %s '%s' is unavailable; falling back to %s. %s may use the wrong interface.",
+        if status == "down":
+            configured = plane_source_iface(pin, self._app._config.psn_source_iface)
+            logger.error(
+                "Configured %s '%s' has no address; %s stays down until it returns "
+                "(it will not be sent on another interface).",
                 label,
-                pin,
-                resolved or "OS default",
+                configured,
                 label,
             )
         return resolved
@@ -1465,6 +1466,22 @@ class AppRuntimeServices:
         # hot-reload branch needs a parallel sync. Keeping it outside
         # ``manager.restart`` keeps the manager registry-agnostic.
         self._sync_osc_binding_conflicts()
+
+    def apply_station_iface_change(self) -> None:
+        """Rebind every plane that inherits the station interface.
+
+        A plane with a blank pin follows ``psn_source_iface``, so changing only
+        the Station default row moves it – but the hot-reload dispatcher gates
+        each plane on its *own* dataclass differing, which it doesn't here.
+        Without this the panel would immediately render the new address for a
+        plane still sending from the old interface until a restart.
+
+        PSN itself is not included: the dispatcher pairs this with
+        ``apply_psn_source_ip_change``, which owns the receiver/server rebind.
+        """
+        otp_cfg = self._app._config.otp_output
+        if self._app._otp_server is not None and otp_cfg.enabled and not otp_cfg.source_iface:
+            self.apply_otp_output_change(otp_cfg)
 
     def apply_psn_source_ip_change(
         self,

--- a/openfollow/web/help/general-interface-assignment.md
+++ b/openfollow/web/help/general-interface-assignment.md
@@ -1,0 +1,25 @@
+# Interface Assignment
+
+Which network each function uses. **Network Settings** above answers "what address does this adapter have"; this panel answers "which adapter does each function go out on".
+
+Useful when lighting, video, and management traffic live on separate networks – a dedicated adapter each, or tagged VLANs on one Ethernet run. Pinning keeps each protocol on its intended network: no PSN leaking onto the office LAN, no need for one flat network just because the tracker only binds one way.
+
+## How a row is resolved
+
+Interfaces are pinned **by name** (`eth0`, `wlan0`, `eth0.10`), not by IP address, so a pin survives a DHCP renewal or a venue change. The **Address** column shows the address that name currently resolves to, so you can see where a function will actually send before you save.
+
+- **Station default** – the interface everything else falls back to. Leave it on `Auto-detect` and the system picks the primary outbound adapter.
+- **Follow station interface** – the default for every other row. That row uses whatever Station default resolves to, so on a single-adapter station you never have to touch this panel.
+- A specific interface – that function uses it regardless of what the station default is.
+
+If a pinned interface is down or missing, the function falls back to the station interface rather than going silent, and the log records that the pin wasn't honoured. A stale pin degrades output onto the wrong network; it never stops it.
+
+## Rows that can't be pinned
+
+**PSN in / out** and **Discovery / marker sync** always follow the station interface and are shown read-only. They carry this station's identity on the network – the address other stations and consoles see it at – so splitting them from the station default would mean the box advertised one address and answered on another.
+
+## Saving
+
+Save applies immediately to the running station. PSN, OTP, and the other data planes rebind their sockets in place – no restart, and no interruption to anything on an interface you didn't change.
+
+**Scan** re-reads the adapter list from the system. Use it after plugging in a USB Ethernet adapter or creating a VLAN so the new interface appears in the dropdowns.

--- a/openfollow/web/help/general-interface-assignment.md
+++ b/openfollow/web/help/general-interface-assignment.md
@@ -12,7 +12,15 @@ Interfaces are pinned **by name** (`eth0`, `wlan0`, `eth0.10`), not by IP addres
 - **Follow station interface** – the default for every other row. That row uses whatever Station default resolves to, so on a single-adapter station you never have to touch this panel.
 - A specific interface – that function uses it regardless of what the station default is.
 
-If a pinned interface is down or missing, the function falls back to the station interface rather than going silent, and the log records that the pin wasn't honoured. A stale pin degrades output onto the wrong network; it never stops it.
+## When a configured interface is unavailable
+
+A function stays on the interface you gave it, always. If that interface has no address – cable out, switch port down, VLAN gone – the function **stops** and the Address column says so. It does not move to another interface.
+
+That is deliberate. During a show, output that has stopped is something you can see and diagnose; output that quietly reappeared on the office LAN is not. It also means nothing this station sends can end up on a network you didn't choose.
+
+The function resumes on its own as soon as the interface has an address again – no restart, no re-save. Nothing about your configuration changes while the interface is away.
+
+The **address** is allowed to change. If the interface is on DHCP and comes back with a different address than before, that is normal and the function follows it. Only the interface itself is fixed.
 
 ## Rows that can't be pinned
 

--- a/openfollow/web/help/general-network-interface.md
+++ b/openfollow/web/help/general-network-interface.md
@@ -2,7 +2,11 @@
 
 The station's IPv4 configuration – the same settings the on-device **Settings → Network** screen writes.
 
-**Interface** – the adapter to configure (often just `eth0`). Switching it reloads the form for that adapter.
+**Interfaces on this station** – every network adapter the station can see, with its address, subnet method, and whether it currently holds an address. **Configure** opens that adapter's settings underneath its own row; opening a different row moves the form there.
+
+A **This session** marker means your browser reached the station over that adapter. Changing its address will drop the page you are reading – the station stays reachable by name (`<station-name>.local`) and from the on-screen **Settings → Network** menu, but you will need to reconnect. The marker only appears when the station can tell which adapter you arrived on; with some setups it can't, so its absence is not a guarantee.
+
+**Scan** re-reads the adapter list. Use it after plugging in a USB Ethernet adapter so it appears without waiting.
 
 **Method**:
 

--- a/openfollow/web/help/general-network-interface.md
+++ b/openfollow/web/help/general-network-interface.md
@@ -4,7 +4,7 @@ The station's IPv4 configuration – the same settings the on-device **Settings 
 
 **Interfaces on this station** – every network adapter the station can see, with its address, subnet method, and whether it currently holds an address. **Configure** opens that adapter's settings underneath its own row; opening a different row moves the form there.
 
-A **This session** marker means your browser reached the station over that adapter. Changing its address will drop the page you are reading – the station stays reachable by name (`<station-name>.local`) and from the on-screen **Settings → Network** menu, but you will need to reconnect. The marker only appears when the station can tell which adapter you arrived on; with some setups it can't, so its absence is not a guarantee.
+A **This session** marker means your browser reached the station over that adapter. Changing its address will drop the page you are reading – the station stays reachable by the name shown on its own screen (`Web address`, e.g. `openfollow-noble-bear.local`) and from the on-screen **Settings → Network** menu, but you will need to reconnect. The marker only appears when the station can tell which adapter you arrived on; with some setups it can't, so its absence is not a guarantee.
 
 **Scan** re-reads the adapter list. Use it after plugging in a USB Ethernet adapter so it appears without waiting.
 

--- a/openfollow/web/help/otp_output.md
+++ b/openfollow/web/help/otp_output.md
@@ -11,7 +11,7 @@ Sends tracked marker positions as ANSI E1.59 Object Transform Protocol (OTP) mul
 - **Multicast addresses** – read-only display of the two addresses derived automatically from System Number, per ANSI E1.59 Table 15-19. **Transform** carries the position data (e.g. `239.159.1.1` for System Number 1); **Advertisement** carries discovery packets (`239.159.2.1`). Adjust System Number to change the group.
 - **UDP Port** – port the transmitter binds to and sends from, 1–65535. Default: `5568`.
 - **Priority** – OTP priority value sent in each packet, 0 – 200. When multiple OTP sources are present, receivers use priority to resolve conflicts – higher values win. Default: `100`.
-- **Source Interface (optional)** – selects which network interface the multicast packets are sent from, pinned by name (`eth0` / `wlan0`) like the PSN source interface, so the pin survives a DHCP lease change. Leave blank (Auto) on a single-NIC station; on a host with both Ethernet and Wi-Fi, pin it to the interface on the show network so packets reach the right subnet. A pinned interface that's down falls back to the primary interface. Click **Scan** to refresh the detected interfaces.
+- **Source Interface** – read-only here; it reports which interface OTP multicast currently leaves from. Set it under **General → Interface Assignment**, where every protocol's interface is chosen in one place. `Follows station interface` (the default) is right on a single-adapter station; on a host with both Ethernet and Wi-Fi, pin it to the adapter on the lighting network so packets reach the right subnet. A pinned interface that's down falls back to the station interface rather than going silent.
 
 ## Saving
 

--- a/openfollow/web/help/psn.md
+++ b/openfollow/web/help/psn.md
@@ -8,7 +8,7 @@ Configures the PosiStageNet (PSN) multicast stream that carries live marker posi
 
 - **PSN Multicast IP** – the multicast group the stream is sent to. Standard PSN group is `236.10.10.10`; change only for a non-standard group or to isolate multiple PSN sources on the same VLAN.
 
-- **PSN Network Interface** – pins the transmitter to a specific interface (for example `eth0` or `wlan0`). Leave blank to auto-select the primary outbound interface. With both Ethernet and Wi-Fi active, pinning to the wired interface is strongly recommended so multicast doesn't leave on the wrong NIC. Press **Scan** to refresh the interface list.
+- **Network Interface** – read-only here; it reports which interface PSN is currently bound to. Set it under **General → Interface Assignment**, where every protocol's interface is chosen in one place. PSN follows the *Station default* row: it carries this station's identity on the network, so it uses the same interface as peer discovery and marker sync. With both Ethernet and Wi-Fi active, pinning the station to the wired interface is strongly recommended so multicast doesn't leave on the wrong NIC.
 
 > On managed switches, PSN multicast requires IGMP snooping with a querier active on the relevant VLAN. If a console can't see the stream, verify the switch fabric isn't silently dropping multicast to the `236.10.10.10` group.
 

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -4863,8 +4863,11 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
 
     @app.get("/section/interface_assignment")
     def get_interface_assignment() -> Any:
-        """Render the panel. Also the ``Scan`` path – the addresses are
-        re-resolved on every render, so a plain re-fetch refreshes them."""
+        """Render the panel. Also the ``Scan`` path: addresses are re-resolved
+        here and each picker re-reads the live interface list on load, so a
+        plain re-fetch refreshes both. Re-rendering (rather than refreshing the
+        pickers in place) is what keeps Scan from reverting an unsaved
+        selection to the value on disk."""
         return _render_interface_assignment(_request_scoped_config())
 
     @app.post("/section/interface_assignment")

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -198,6 +198,7 @@ VALID_SECTIONS = {
     "trigger_zones",
     "osc_bindings",
     "osc_destinations",
+    "interface_assignment",
 }
 _WEB_STATIC_DIR = Path(__file__).with_name("static")
 
@@ -966,8 +967,108 @@ def strip_device_local_fields(
     return {k: v for k, v in data.items() if k not in drop}
 
 
+# Editable rows of the Interface Assignment panel, in render order. Each maps
+# the form field name to the config attribute that owns it: ``None`` for a
+# top-level ``AppConfig`` field, otherwise the sub-config attribute. Storage
+# stays per-section (so the existing save / hot-reload / device-local
+# machinery applies unchanged); only the editing surface is central.
+_INTERFACE_ASSIGNMENT_TARGETS: dict[str, tuple[str | None, str]] = {
+    "psn_source_iface": (None, "psn_source_iface"),
+    "otp_output.source_iface": ("otp_output", "source_iface"),
+}
+
+
+def _apply_interface_assignment(cfg: AppConfig, data: Mapping[str, Any]) -> None:
+    """Write the Interface Assignment panel's pins onto their owning configs.
+
+    Each pin is stripped to mirror its ``__post_init__``, then every touched
+    dataclass has ``__post_init__`` re-run so a crafted POST can't bypass
+    validation a hand-edited TOML would trip.
+    """
+    touched: set[str | None] = set()
+    for form_key, (attr, field_name) in _INTERFACE_ASSIGNMENT_TARGETS.items():
+        if form_key not in data:
+            continue
+        target = cfg if attr is None else getattr(cfg, attr)
+        setattr(
+            target,
+            field_name,
+            _as_str(data[form_key], getattr(target, field_name)).strip(),
+        )
+        touched.add(attr)
+    for attr in touched:
+        # ``AppConfig.__post_init__`` is expensive and re-normalises unrelated
+        # fields, but it is also the only thing that validates a top-level pin
+        # – run it only when a top-level row actually changed.
+        (cfg if attr is None else getattr(cfg, attr)).__post_init__()
+
+
+def build_interface_assignment_rows(cfg: AppConfig) -> list[dict[str, Any]]:
+    """Rows for the Interface Assignment panel, in render order.
+
+    Every row carries the address the plane will actually bind, resolved
+    through the same ``pin → station → auto`` chain the runtime uses – so a
+    row left on "Follow station interface" visibly shows where it points
+    rather than an empty cell.
+
+    Planes with no pin of their own (PSN, discovery, marker sync) render
+    read-only: they follow ``psn_source_iface``, which the Station default row
+    owns, so giving them their own dropdown would imply an independence they
+    don't have.
+    """
+    from openfollow.net_utils import resolve_plane_source_ip
+
+    station = cfg.psn_source_iface
+    station_ip, _status = resolve_plane_source_ip("", station)
+
+    def _addr(pin: str) -> str:
+        resolved, _ = resolve_plane_source_ip(pin, station)
+        return resolved
+
+    return [
+        {
+            "key": "psn_source_iface",
+            "label": "Station default",
+            "value": station,
+            "address": station_ip,
+            "editable": True,
+            "blank": "auto",
+        },
+        {
+            "key": "",
+            "label": "PSN in / out",
+            "value": "",
+            "address": station_ip,
+            "editable": False,
+            "blank": "",
+            "note": "Follows station interface",
+        },
+        {
+            "key": "otp_output.source_iface",
+            "label": "OTP output",
+            "value": cfg.otp_output.source_iface,
+            "address": _addr(cfg.otp_output.source_iface),
+            "editable": True,
+            "blank": "station",
+        },
+        {
+            "key": "",
+            "label": "Discovery / marker sync",
+            "value": "",
+            "address": station_ip,
+            "editable": False,
+            "blank": "",
+            "note": "Follows station interface",
+        },
+    ]
+
+
 def apply_section_data(cfg: AppConfig, section: str, data: Mapping[str, Any]) -> bool:
     """Apply section updates in-place. Returns False for unknown sections."""
+    if section == "interface_assignment":
+        _apply_interface_assignment(cfg, data)
+        return True
+
     if section == "video_source":
         if "video_source_type" in data:
             from openfollow.video.inputs import get_available_input_ids
@@ -4644,6 +4745,31 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         # this code path.
         template_name = "partials/gamepad" if name == "controller" else f"partials/{name}"
         return template(template_name, config=config, **extra)
+
+    def _render_interface_assignment(cfg: AppConfig, *, saved: bool = False) -> Any:
+        return template(
+            "partials/interface_assignment",
+            config=cfg,
+            saved=saved,
+            assignment_rows=build_interface_assignment_rows(cfg),
+        )
+
+    @app.get("/section/interface_assignment")
+    def get_interface_assignment() -> Any:
+        """Render the panel. Also the ``Scan`` path – the addresses are
+        re-resolved on every render, so a plain re-fetch refreshes them."""
+        return _render_interface_assignment(_request_scoped_config())
+
+    @app.post("/section/interface_assignment")
+    def update_interface_assignment() -> Any:
+        """Save every pin, then let the config file-watcher live-apply them.
+
+        Each row's field lives on the sub-config that owns its protocol, so
+        the existing per-section hot-reload orchestrators pick the changes up
+        with no dispatch of this panel's own – nothing here needs a restart.
+        """
+        cfg = _save_section_from_form("interface_assignment")
+        return _render_interface_assignment(cfg, saved=True)
 
     @app.post("/section/video_source")
     def update_video_source() -> Any:

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -918,6 +918,13 @@ def get_section_data(cfg: AppConfig, section: str) -> dict[str, Any] | None:
             "web_pin": cfg.web_pin,
             "update_service_name": cfg.update_service_name,
         }
+    if section == "interface_assignment":
+        # Mirrors what the panel POSTs, so GET and POST agree on the section's
+        # shape instead of GET 404ing while POST silently writes.
+        return {
+            form_key: getattr(cfg if attr is None else getattr(cfg, attr), field_name)
+            for form_key, (attr, field_name) in _INTERFACE_ASSIGNMENT_TARGETS.items()
+        }
     section_attr = _SECTION_CONFIG_ATTRS.get(section)
     if section_attr is None:
         return None
@@ -931,6 +938,12 @@ def get_section_data(cfg: AppConfig, section: str) -> dict[str, Any] | None:
 # or full-config-import. ``psn_source_iface`` pins the local NIC and only
 # makes sense for this device. Stripped at both ends (broadcaster-forward
 # and peer-receive) so an out-of-date peer can't poison this device.
+# Interface Assignment form key -> (sub-config attr or None for top-level, field).
+_INTERFACE_ASSIGNMENT_TARGETS: dict[str, tuple[str | None, str]] = {
+    "psn_source_iface": (None, "psn_source_iface"),
+    "otp_output.source_iface": ("otp_output", "source_iface"),
+}
+
 _DEVICE_LOCAL_FIELDS_BY_SECTION: dict[str, frozenset[str]] = {
     "psn": frozenset({"psn_source_iface"}),
     # ``web_pin`` (login credential) and ``web_port`` (local bind) are
@@ -950,6 +963,11 @@ _DEVICE_LOCAL_FIELDS_BY_SECTION: dict[str, frozenset[str]] = {
     # form save path applies this field, so the section broadcast/receive must
     # strip it (matching the full export/import redaction).
     "video_source": frozenset({"testpattern_selected_media"}),
+    # Every row of the Interface Assignment panel names a NIC on THIS box, so
+    # the whole section is device-local. The section is also refused outright
+    # by ``_BROADCAST_EXCLUDED_SECTIONS``; this entry is the peer-receive half,
+    # covering a direct POST from an out-of-date sender.
+    "interface_assignment": frozenset(_INTERFACE_ASSIGNMENT_TARGETS),
 }
 
 
@@ -972,12 +990,6 @@ def strip_device_local_fields(
 # top-level ``AppConfig`` field, otherwise the sub-config attribute. Storage
 # stays per-section (so the existing save / hot-reload / device-local
 # machinery applies unchanged); only the editing surface is central.
-_INTERFACE_ASSIGNMENT_TARGETS: dict[str, tuple[str | None, str]] = {
-    "psn_source_iface": (None, "psn_source_iface"),
-    "otp_output.source_iface": ("otp_output", "source_iface"),
-}
-
-
 def _apply_interface_assignment(cfg: AppConfig, data: Mapping[str, Any]) -> None:
     """Write the Interface Assignment panel's pins onto their owning configs.
 
@@ -1033,23 +1045,31 @@ def build_interface_assignment_rows(cfg: AppConfig) -> list[dict[str, Any]]:
     """Rows for the Interface Assignment panel, in render order.
 
     Every row carries the address the plane will actually bind, resolved
-    through the same ``pin → station → auto`` chain the runtime uses – so a
-    row left on "Follow station interface" visibly shows where it points
-    rather than an empty cell.
+    through the same chain the runtime uses – so a row left on "Follow station
+    interface" visibly shows where it points rather than an empty cell.
+
+    A configured interface with no address renders as an explicit error rather
+    than as some other interface's address: the plane will not send there, and a
+    row showing a working address for a plane that is down would be a lie.
 
     Planes with no pin of their own (PSN, discovery, marker sync) render
     read-only: they follow ``psn_source_iface``, which the Station default row
     owns, so giving them their own dropdown would imply an independence they
     don't have.
     """
-    from openfollow.net_utils import resolve_plane_source_ip
+    from openfollow.net_utils import plane_source_iface, resolve_plane_source_ip
+
+    def _plane_address(pin: str, station_iface: str) -> str:
+        resolved, status = resolve_plane_source_ip(pin, station_iface)
+        if status == "down":
+            return f"{plane_source_iface(pin, station_iface)} is down"
+        return resolved
 
     station = cfg.psn_source_iface
-    station_ip, _status = resolve_plane_source_ip("", station)
+    station_ip = _plane_address(station, "")
 
     def _addr(pin: str) -> str:
-        resolved, _ = resolve_plane_source_ip(pin, station)
-        return resolved
+        return _plane_address(pin, station)
 
     return [
         {
@@ -2411,7 +2431,9 @@ def _config_dict_redacted(cfg: AppConfig) -> dict[str, Any]:
 # ``destination_id`` and its target move together) but are NEVER real-time
 # shared between stations: each station keeps its own OSC routing + zones.
 _BROADCAST_EXCLUDED_SECTIONS = frozenset(
-    {"osc_destinations", "osc_transmitters", "trigger_zones"},
+    # ``interface_assignment`` names NICs on this box; copying it to a peer
+    # would repin that peer's PSN and OTP to an interface it may not have.
+    {"osc_destinations", "osc_transmitters", "trigger_zones", "interface_assignment"},
 )
 
 

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -1003,6 +1003,32 @@ def _apply_interface_assignment(cfg: AppConfig, data: Mapping[str, Any]) -> None
         (cfg if attr is None else getattr(cfg, attr)).__post_init__()
 
 
+def request_local_iface(environ: Mapping[str, Any]) -> str:
+    """Interface a request arrived on, or "" when it can't be told.
+
+    Drives the "this session" marker in the Network Settings interface list,
+    so an operator can see which adapter they are connected through before
+    editing its address and cutting their own session.
+
+    Reads the accepted connection's local address (put in the environ by the
+    WSGI handler) rather than the Host header: with the default wildcard bind
+    the operator usually arrives via ``<slug>.local``, so the header holds a
+    name, not the address avahi resolved it to.
+
+    Returns "" rather than guessing when the address is loopback, absent, or
+    not one of this host's addresses. A missing marker is a missed warning; a
+    wrong one would point at the wrong adapter, which is worse.
+    """
+    from openfollow.web.server import LOCAL_ADDR_ENVIRON_KEY
+
+    local_addr = str(environ.get(LOCAL_ADDR_ENVIRON_KEY) or "").strip()
+    if not local_addr or local_addr.startswith("127."):
+        return ""
+    from openfollow.net_utils import get_iface_for_ip
+
+    return get_iface_for_ip(local_addr)
+
+
 def build_interface_assignment_rows(cfg: AppConfig) -> list[dict[str, Any]]:
     """Rows for the Interface Assignment panel, in render order.
 
@@ -4294,6 +4320,11 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
     # ----------------------------------------------------------------------
 
     _NETWORK_METHODS = ("dhcp", "dhcp_manual", "static")
+    _NETWORK_METHOD_LABELS = {
+        "dhcp": "DHCP",
+        "dhcp_manual": "DHCP + manual",
+        "static": "Static",
+    }
 
     def _network_method_value(raw: str) -> str:
         return raw if raw in _NETWORK_METHODS else "dhcp"
@@ -4334,6 +4365,33 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
             "lease_display": cfg.get("lease_display"),
             "banner": banner,
         }
+        # The interface list replaced the old single picker, so the card can
+        # show a multi-NIC (or tagged-VLAN) station's whole layout. ``Scan``
+        # forces a re-read; ordinary renders come off the TTL cache.
+        rows = server.get_network_interfaces(force=bool(request.query.get("scan")))
+        if not rows:
+            # No richer provider wired (or it failed): synthesise the list from
+            # the single-interface snapshot so the card still renders every
+            # adapter. Only the open interface has address / method detail,
+            # which is exactly what the card showed before the list existed.
+            rows = [
+                {
+                    "name": name,
+                    "address": net["address"] if name == net["active_interface"] else "",
+                    "prefix": net["prefix"] if name == net["active_interface"] else None,
+                    "method": net["method"] if name == net["active_interface"] else "",
+                }
+                for name in net["interfaces"]
+            ]
+        net["iface_rows"] = [
+            {**row, "method_label": _NETWORK_METHOD_LABELS.get(row.get("method", ""), row.get("method", ""))}
+            for row in rows
+        ]
+        net["session_iface"] = request_local_iface(request.environ)
+        # One interface is always the current one – the same interface the card
+        # showed before the list existed – so its detail is expanded by default
+        # and picking another row moves the expansion.
+        net["editing_iface"] = net["active_interface"]
         if method is not None:
             net["method"] = _network_method_value(method)
         if overrides:
@@ -4397,6 +4455,33 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         return template(
             "partials/network",
             net=_build_network_form_context(editable=True),
+        )
+
+    @app.get("/section/network/status/<iface>")
+    def get_network_status_iface(iface: str) -> Any:
+        """Expand one interface's details read-only.
+
+        The list shows address and method; DNS and lease live in the detail,
+        so View mode can open a row too rather than forcing the operator into
+        Edit mode just to read a value.
+        """
+        return template(
+            "partials/network",
+            net=_build_network_form_context(iface=iface, editable=False),
+        )
+
+    @app.get("/section/network/edit/<iface>")
+    def get_network_edit_iface(iface: str) -> Any:
+        """Open one interface's editor, expanded under its row in the list.
+
+        The interface is named in the path rather than carried in a picker, so
+        which adapter is being edited is never ambiguous.
+        ``_build_network_form_context`` sanitises it against the adapter's live
+        list, falling back to the active interface if it's unknown.
+        """
+        return template(
+            "partials/network",
+            net=_build_network_form_context(iface=iface, editable=True),
         )
 
     @app.post("/section/network")

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -284,6 +284,15 @@ _WEB_HELP_DIR = Path(__file__).with_name("help")
 _HELP_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 _SERVICE_NAME_RE = re.compile(r"^[A-Za-z0-9_.@-]+$")
 _GITHUB_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+# Wording for the empty option in an interface picker, keyed by ``?blank=``.
+# Allow-listed rather than interpolated: the label is rendered into HTML.
+# "auto" = nothing to fall back to (the station picker itself); "station" =
+# an empty pin follows ``psn_source_iface`` (every per-plane picker).
+_BLANK_IFACE_LABELS = {
+    "auto": "-- Auto-detect --",
+    "station": "-- Follow station interface --",
+}
+
 _SECTION_CONFIG_ATTRS = {
     "camera": "camera",
     "grid": "grid",
@@ -6995,6 +7004,13 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         selects that iface in the rendered list; without it the route
         defaults to ``psn_source_iface`` so the PSN picker keeps working
         with a plain ``hx-get``.
+
+        ``?blank=station`` labels the empty option "Follow station interface"
+        instead of "Auto-detect". Per-plane pickers use it because an empty
+        pin follows ``psn_source_iface``, while the station picker itself has
+        nothing to follow and keeps the auto-detect wording. Unknown values
+        fall back to auto-detect – the label is allow-listed, never
+        interpolated from the query.
         """
         from openfollow.net_utils import list_iface_ipv4
 
@@ -7002,8 +7018,9 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         # ``?current=`` present (even empty) overrides; absent → PSN default. An
         # empty OTP pin must stay empty (auto-detect), not fall back to PSN's.
         current = request.query.current if "current" in request.query else cfg.psn_source_iface
+        blank_label = _BLANK_IFACE_LABELS.get(request.query.blank, _BLANK_IFACE_LABELS["auto"])
         ifaces = list_iface_ipv4()
-        options = ['<option value="">-- Auto-detect --</option>']
+        options = [f'<option value="">{blank_label}</option>']
         names = {name for name, _ in ifaces}
         for name, ip in ifaces:
             selected = "selected" if name == current else ""

--- a/openfollow/web/server.py
+++ b/openfollow/web/server.py
@@ -54,6 +54,11 @@ _FALLBACK_PORTS: tuple[int, ...] = (8080, 2010)
 # paths and the resolver enumerates interfaces, so an IP change is picked up
 # within this window rather than re-resolving on every request.
 _LOCAL_IP_REFRESH_TTL = 5.0
+# How long the Network Settings interface list is reused before re-reading.
+# Enumerating every adapter costs one backend call each (an ``nmcli``
+# subprocess on the NetworkManager backend), and addresses don't change on a
+# sub-second cadence. ``Scan`` bypasses this.
+_NETWORK_IFACES_TTL = 5.0
 
 _REQUEST_BUSY_BODY = b"Server busy; retry"
 _REQUEST_BUSY_RESPONSE = (
@@ -64,9 +69,30 @@ _REQUEST_BUSY_RESPONSE = (
 )
 
 
+# WSGI environ key carrying the local (server-side) address of the accepted
+# connection, i.e. the station address this request actually arrived on.
+LOCAL_ADDR_ENVIRON_KEY = "openfollow.local_addr"
+
+
 class _QuietHandler(WSGIRequestHandler):
     def log_request(self, *args: object, **kwargs: object) -> None:
         pass
+
+    def get_environ(self) -> dict[str, Any]:
+        """Add the connection's local address to the environ.
+
+        Needed to answer "which interface did this operator reach us on",
+        which guards them from editing that interface's address and cutting
+        their own session. The Host header can't answer it: with a wildcard
+        bind the operator usually arrives via ``<slug>.local``, so the header
+        holds a name, not the address avahi resolved it to.
+        """
+        environ: dict[str, Any] = super().get_environ()
+        try:
+            environ[LOCAL_ADDR_ENVIRON_KEY] = self.connection.getsockname()[0]
+        except OSError:  # pragma: no cover - socket already torn down
+            pass
+        return environ
 
 
 class _ThreadingWSGIServer(ThreadingMixIn, WSGIServer):
@@ -162,6 +188,9 @@ class ConfigWebServer:
         network_state_provider: Callable[[], dict[str, Any] | None] | None = None,
         # Web write path: config snapshot + apply/renew handlers; optional for tests.
         network_config_provider: (Callable[[str | None], dict[str, Any] | None] | None) = None,
+        # Every interface at once, for the Network Settings list. Costs one
+        # backend call per interface, so the result is TTL-cached here.
+        network_interfaces_provider: (Callable[[], list[dict[str, Any]]] | None) = None,
         network_apply_handler: Callable[[str, Any], ApplyResult] | None = None,
         network_renew_handler: Callable[[str], ApplyResult] | None = None,
         # Privilege capability snapshot for the diagnostics bundle; optional for tests.
@@ -229,6 +258,13 @@ class ConfigWebServer:
         self._log_ring = log_ring
         self._network_state_provider = network_state_provider
         self._network_config_provider = network_config_provider
+        self._network_interfaces_provider = network_interfaces_provider
+        # TTL cache for the interface list: enumerating every adapter's method
+        # costs one backend call each, and the General tab re-renders often.
+        # ``Scan`` bypasses it, so a freshly plugged NIC never needs a wait.
+        self._network_ifaces_cache: list[dict[str, Any]] = []
+        self._network_ifaces_ts = 0.0  # monotonic; 0 = never populated
+        self._network_ifaces_lock = threading.Lock()
         self._network_apply_handler = network_apply_handler
         self._network_renew_handler = network_renew_handler
         self._psn_source_advisory_provider = psn_source_advisory_provider
@@ -360,6 +396,38 @@ class ConfigWebServer:
         except Exception:  # noqa: BLE001
             logger.exception("Network config provider raised")
             return None
+
+    def get_network_interfaces(self, *, force: bool = False) -> list[dict[str, Any]]:
+        """Every interface with address / method / up-state, TTL-cached.
+
+        ``force=True`` is the ``Scan`` path: it re-reads immediately so a
+        just-plugged adapter (or a just-created VLAN) shows up without waiting
+        out the TTL.
+
+        The provider is called outside the lock: it shells out per interface,
+        and holding the lock across that would serialise every render behind
+        one slow backend read. A concurrent caller may duplicate the work, but
+        both write the same snapshot, which is cheaper than the contention.
+        """
+        if self._network_interfaces_provider is None:
+            return []
+        now = time.monotonic()
+        if not force:
+            with self._network_ifaces_lock:
+                if self._network_ifaces_ts and now - self._network_ifaces_ts < _NETWORK_IFACES_TTL:
+                    return list(self._network_ifaces_cache)
+        try:
+            rows = self._network_interfaces_provider()
+        except Exception:  # noqa: BLE001
+            logger.exception("Network interfaces provider raised")
+            # Serve the last good snapshot rather than blanking the list on a
+            # transient backend failure.
+            with self._network_ifaces_lock:
+                return list(self._network_ifaces_cache)
+        with self._network_ifaces_lock:
+            self._network_ifaces_cache = list(rows)
+            self._network_ifaces_ts = time.monotonic()
+        return list(rows)
 
     def apply_network(self, iface: str, config: Any) -> ApplyResult:
         """Apply IPv4 config to iface; always returns ApplyResult."""

--- a/openfollow/web/server.py
+++ b/openfollow/web/server.py
@@ -139,6 +139,15 @@ class _ThreadingWSGIServer(ThreadingMixIn, WSGIServer):
             sem.release()
 
 
+def _copy_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Copy the list *and* each row.
+
+    Copying only the list leaves every caller holding the cached dicts, so a
+    template helper decorating a row corrupts what the next render reads.
+    """
+    return [dict(row) for row in rows]
+
+
 class ConfigWebServer:
     """Threaded web server for configuration UI with peer discovery."""
 
@@ -415,7 +424,7 @@ class ConfigWebServer:
         if not force:
             with self._network_ifaces_lock:
                 if self._network_ifaces_ts and now - self._network_ifaces_ts < _NETWORK_IFACES_TTL:
-                    return list(self._network_ifaces_cache)
+                    return _copy_rows(self._network_ifaces_cache)
         try:
             rows = self._network_interfaces_provider()
         except Exception:  # noqa: BLE001
@@ -423,11 +432,11 @@ class ConfigWebServer:
             # Serve the last good snapshot rather than blanking the list on a
             # transient backend failure.
             with self._network_ifaces_lock:
-                return list(self._network_ifaces_cache)
+                return _copy_rows(self._network_ifaces_cache)
         with self._network_ifaces_lock:
-            self._network_ifaces_cache = list(rows)
+            self._network_ifaces_cache = _copy_rows(rows)
             self._network_ifaces_ts = time.monotonic()
-        return list(rows)
+        return _copy_rows(rows)
 
     def apply_network(self, iface: str, config: Any) -> ApplyResult:
         """Apply IPv4 config to iface; always returns ApplyResult."""

--- a/openfollow/web/templates/base.tpl
+++ b/openfollow/web/templates/base.tpl
@@ -822,6 +822,25 @@
  .ia-assign select { width: 100%; max-width: 22rem; margin: 0; }
  .ia-addr { font-variant-numeric: tabular-nums; color: var(--muted); white-space: nowrap; }
  .ia-readonly th[scope="row"] { font-weight: 500; }
+ /* Read-only pointer shown by each protocol section now that the pin itself
+ is edited centrally in Interface Assignment. Dashed border marks it as a
+ report rather than a control. */
+ .ia-pointer {
+ display: flex;
+ flex-direction: column;
+ gap: 0.2rem;
+ padding: 0.5rem 0.7rem;
+ border: 1px dashed var(--border);
+ border-radius: 10px;
+ background: var(--surface);
+ }
+ .ia-pointer-value { font-size: 0.86rem; }
+ .ia-link {
+ color: var(--accent);
+ text-decoration: none;
+ font-size: 0.8rem;
+ }
+ .ia-link:hover { text-decoration: underline; }
  @media (max-width: 720px) {
  .ia-table thead { display: none; }
  .ia-table, .ia-table tbody, .ia-table tr, .ia-table th, .ia-table td { display: block; width: 100%; }

--- a/openfollow/web/templates/base.tpl
+++ b/openfollow/web/templates/base.tpl
@@ -794,6 +794,41 @@
  /* Full-width within its container (e.g. the login Unlock button). */
  .btn-block { width: 100%; }
  /* Network form: compact label:value grid matching the read-only status table. */
+ /* Interface Assignment: function -> interface rows. Built from the existing
+ tokens so it inherits the surrounding look with no new palette. */
+ .ia-table {
+ width: 100%;
+ border-collapse: collapse;
+ font-size: 0.86rem;
+ }
+ .ia-table th, .ia-table td {
+ text-align: left;
+ padding: 0.42rem 0.6rem;
+ border-bottom: 1px solid var(--border-soft);
+ vertical-align: middle;
+ }
+ .ia-table thead th {
+ font-size: 0.72rem;
+ text-transform: uppercase;
+ letter-spacing: 0.06em;
+ color: var(--muted);
+ font-weight: 700;
+ border-bottom: 1px solid var(--border);
+ }
+ .ia-table tbody tr:last-child th,
+ .ia-table tbody tr:last-child td { border-bottom: 0; }
+ .ia-table tbody th[scope="row"] { font-weight: 600; white-space: nowrap; }
+ .ia-assign td:nth-child(2) { width: 46%; min-width: 220px; }
+ .ia-assign select { width: 100%; max-width: 22rem; margin: 0; }
+ .ia-addr { font-variant-numeric: tabular-nums; color: var(--muted); white-space: nowrap; }
+ .ia-readonly th[scope="row"] { font-weight: 500; }
+ @media (max-width: 720px) {
+ .ia-table thead { display: none; }
+ .ia-table, .ia-table tbody, .ia-table tr, .ia-table th, .ia-table td { display: block; width: 100%; }
+ .ia-table tbody tr { border-bottom: 1px solid var(--border-soft); padding: 0.45rem 0; }
+ .ia-table th, .ia-table td { border-bottom: 0; padding: 0.2rem 0; }
+ .ia-assign td:nth-child(2) { width: 100%; }
+ }
  .network-grid {
  display: grid;
  grid-template-columns: minmax(7rem, 9rem) 1fr;

--- a/openfollow/web/templates/base.tpl
+++ b/openfollow/web/templates/base.tpl
@@ -3549,6 +3549,17 @@
  });
  writeStorage('psnfs:active-tab:' + location.pathname, tabId);
  }
+ // Cross-tab pointer links. A bare href="#id" does nothing when the target
+ // sits in an inactive tab, because .tab-content is display:none - so switch
+ // to the owning tab first, then scroll once layout has settled.
+ function goToSection(tabId, targetId) {
+   switchTab(tabId);
+   var el = document.getElementById(targetId);
+   if (!el) { return; }
+   requestAnimationFrame(function () {
+     el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+   });
+ }
  function initTabs() {
  var stored = readStorage('psnfs:active-tab:' + location.pathname);
  var first = document.querySelector('.tab-btn');

--- a/openfollow/web/templates/base.tpl
+++ b/openfollow/web/templates/base.tpl
@@ -835,6 +835,50 @@
  background: var(--surface);
  }
  .ia-pointer-value { font-size: 0.86rem; }
+ /* Interface list in Network Settings: status dot, session badge, and the
+ per-interface editor that expands under its own row. */
+ .ia-nics td:first-child, .ia-nics th:first-child { width: 1.4rem; padding-right: 0; }
+ .ia-actions { text-align: right; white-space: nowrap; }
+ .ia-dot {
+ display: inline-block;
+ width: 8px; height: 8px;
+ border-radius: 50%;
+ background: var(--ok);
+ box-shadow: 0 0 0 3px rgba(125, 229, 159, 0.14);
+ }
+ .ia-dot.down { background: rgba(247, 245, 233, 0.3); box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.05); }
+ .ia-badge {
+ display: inline-block;
+ margin-left: 0.3rem;
+ padding: 0.06rem 0.45rem;
+ border-radius: 999px;
+ font-size: 0.66rem;
+ font-weight: 800;
+ letter-spacing: 0.05em;
+ text-transform: uppercase;
+ white-space: nowrap;
+ }
+ .ia-badge.session {
+ color: var(--ok);
+ background: rgba(125, 229, 159, 0.12);
+ border: 1px solid rgba(125, 229, 159, 0.35);
+ }
+ .ia-legend {
+ display: flex;
+ align-items: center;
+ gap: 1rem;
+ margin-top: 0.6rem;
+ font-size: 0.75rem;
+ color: var(--muted);
+ }
+ .ia-legend .ia-dot { margin-right: 0.3rem; }
+ .ia-legend-actions { margin-left: auto; display: inline-flex; gap: 0.4rem; }
+ .ia-nics tr.is-configuring > td { background: var(--accent-soft); }
+ .ia-editor-row > td { padding: 0 !important; background: var(--bg-soft); }
+ .ia-editor { padding: 0.9rem 1rem 1rem; border-left: 3px solid var(--accent); }
+ .ia-editor-head { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.7rem; }
+ .ia-editor-head .group-title { margin: 0; }
+ .ia-editor .group:last-of-type { border-bottom: 0; }
  .ia-link {
  color: var(--accent);
  text-decoration: none;

--- a/openfollow/web/templates/partials/general.tpl
+++ b/openfollow/web/templates/partials/general.tpl
@@ -156,6 +156,17 @@
 </div>
 
 %# ------------------------------------------------------------------
+%# 2b. Interface Assignment – which network each function uses. Sits
+%# below Network Settings ("what address does this NIC have") and reads
+%# the same interface list. Lazy-loaded like the network region so the
+%# General render doesn't pay for the address resolution.
+%# ------------------------------------------------------------------
+<div id="interface-assignment" hx-get="/section/interface_assignment" hx-trigger="load"
+     hx-target="this" hx-swap="innerHTML">
+    <p class="muted">Loading interface assignment…</p>
+</div>
+
+%# ------------------------------------------------------------------
 %# 3. Software Update – GitHub Releases signed-bundle (.ofupdate) installer.
 %#
 %# Default-collapsed: most operators rarely update manually. Hidden on

--- a/openfollow/web/templates/partials/interface_assignment.tpl
+++ b/openfollow/web/templates/partials/interface_assignment.tpl
@@ -31,9 +31,15 @@
                     %# Interface names are stable across DHCP renewals; the
                     %# option list (and its blank-option wording) comes from the
                     %# shared route so every picker stays consistent.
-                    <select name="{{row['key']}}"
+                    %#
+                    %# ``load`` only: ``current`` is baked in at render time, so
+                    %# re-fetching on Scan would re-mark the SAVED value as
+                    %# selected and silently discard an unsaved choice. Scan
+                    %# re-renders the whole panel instead, which refreshes both
+                    %# the option lists and the resolved addresses.
+                    <select name="{{row['key']}}" aria-label="{{row['label']}} interface"
                             hx-get="/network/interfaces/by_name?blank={{row['blank']}}&current={{row['value']}}"
-                            hx-trigger="load, click from:#refresh-iface-assignment"
+                            hx-trigger="load"
                             hx-target="this" hx-swap="innerHTML">
                         <option value="{{row['value']}}">{{row['value'] or '-- Loading... --'}}</option>
                     </select>
@@ -49,6 +55,8 @@
 
     <div class="actions">
         <button type="submit" class="save-btn">Save</button>
-        <button type="button" id="refresh-iface-assignment" class="secondary">Scan</button>
+        <button type="button" id="refresh-iface-assignment" class="secondary"
+                hx-get="/section/interface_assignment"
+                hx-target="#interface-assignment-section" hx-swap="outerHTML">Scan</button>
     </div>
 </form>

--- a/openfollow/web/templates/partials/interface_assignment.tpl
+++ b/openfollow/web/templates/partials/interface_assignment.tpl
@@ -1,0 +1,54 @@
+%# Interface Assignment – which network each function uses.
+%#
+%# Storage stays per-section (each pin lives on the sub-config that owns the
+%# protocol); this panel is only the editing surface, so the protocol sections
+%# show a read-only pointer here instead of their own picker.
+%#
+%# Rows come from ``build_interface_assignment_rows``: ``editable`` rows render
+%# an interface picker, the rest render their ``note`` (they follow the station
+%# pin and have no independent setting).
+% rows = assignment_rows if defined('assignment_rows') else []
+<form id="interface-assignment-section" class="section {{'saved' if defined('saved') and saved else ''}}"
+      data-fold-key="general-interface-assignment" data-help="general-interface-assignment"
+      data-fold-default="expanded"
+      hx-post="/section/interface_assignment" hx-target="#interface-assignment-section"
+      hx-swap="outerHTML" hx-trigger="submit">
+    <div class="section-head">
+        <h2>Interface Assignment</h2>
+        <span class="section-note">Which network each function uses</span>
+    </div>
+
+    <table class="ia-table ia-assign">
+        <thead>
+            <tr><th>Function</th><th>Interface</th><th>Address</th></tr>
+        </thead>
+        <tbody>
+            % for row in rows:
+            <tr class="{{'ia-readonly' if not row['editable'] else ''}}">
+                <th scope="row">{{row['label']}}</th>
+                % if row['editable']:
+                <td>
+                    %# Interface names are stable across DHCP renewals; the
+                    %# option list (and its blank-option wording) comes from the
+                    %# shared route so every picker stays consistent.
+                    <select name="{{row['key']}}"
+                            hx-get="/network/interfaces/by_name?blank={{row['blank']}}&current={{row['value']}}"
+                            hx-trigger="load, click from:#refresh-iface-assignment"
+                            hx-target="this" hx-swap="innerHTML">
+                        <option value="{{row['value']}}">{{row['value'] or '-- Loading... --'}}</option>
+                    </select>
+                </td>
+                % else:
+                <td class="muted">{{row.get('note', '')}}</td>
+                % end
+                <td class="ia-addr {{'muted' if not row['editable'] else ''}}">{{row['address'] or '--'}}</td>
+            </tr>
+            % end
+        </tbody>
+    </table>
+
+    <div class="actions">
+        <button type="submit" class="save-btn">Save</button>
+        <button type="button" id="refresh-iface-assignment" class="secondary">Scan</button>
+    </div>
+</form>

--- a/openfollow/web/templates/partials/network.tpl
+++ b/openfollow/web/templates/partials/network.tpl
@@ -6,9 +6,9 @@
 %# being edited is never ambiguous.
 %#
 %# Two modes, as before: VIEW (editable=false) disables the fields and
-%# live-polls every 5s; EDIT adds Apply / Renew / Cancel. The poll is
-%# suppressed while an interface is expanded so it can't collapse the form
-%# mid-edit.
+%# live-polls every 5s; EDIT adds Apply / Renew / Cancel. The poll carries the
+%# expanded interface in its path – dropping it would re-render the card on the
+%# active interface every 5s and collapse the row the operator is reading.
 %#
 %# Rendered into the #network-interface region (heading + fold live in
 %# general.tpl), swapped in place on toggle / apply / renew.
@@ -31,7 +31,7 @@
       hx-swap="innerHTML" hx-trigger="submit"
       hx-on:submit="netScheduleReload(this)"
 % elif _polls:
-      hx-get="/section/network/status" hx-trigger="every 5s"
+      hx-get="/section/network/status{{'/' + _editing if _editing else ''}}" hx-trigger="every 5s"
       hx-target="#network-interface" hx-swap="innerHTML"
 % end
       >
@@ -194,8 +194,12 @@
                                 hx-post="/section/network/renew" hx-target="#network-interface"
                                 hx-swap="innerHTML" hx-include="closest form">Renew DHCP lease</button>
                         % end
+                        %# Back to View mode on the same row. Targeting /edit
+                        %# would re-render the editor, leaving no way out of
+                        %# Edit mode short of a page reload.
                         <button type="button" class="ghost-btn"
-                                hx-get="/section/network/edit" hx-target="#network-interface"
+                                hx-get="/section/network/status{{'/' + _editing if _editing else ''}}"
+                                hx-target="#network-interface"
                                 hx-swap="innerHTML">Cancel</button>
                     </div>
                     % end
@@ -209,8 +213,11 @@
             <span><span class="ia-dot up"></span> up with an address</span>
             <span><span class="ia-dot down"></span> no address</span>
             <span class="ia-legend-actions">
+                %# Keeps the open interface in the path so re-reading the
+                %# adapter list doesn't move the expansion (and, in Edit mode,
+                %# doesn't discard what the operator has typed).
                 <button type="button" class="secondary small"
-                        hx-get="{{'/section/network/edit' if _editable else '/section/network/status'}}?scan=1"
+                        hx-get="{{'/section/network/edit' if _editable else '/section/network/status'}}{{'/' + _editing if _editing else ''}}?scan=1"
                         hx-target="#network-interface" hx-swap="innerHTML">Scan</button>
             </span>
         </div>

--- a/openfollow/web/templates/partials/network.tpl
+++ b/openfollow/web/templates/partials/network.tpl
@@ -1,8 +1,15 @@
-%# Network Interface configuration. One layout, two modes (read-only and
-%# editable) both use compact label:value grid. VIEW (editable=false): disabled
-%# fields, top "Switch to edit view" mode bar, live-polls every 5s.
-%#   * EDIT (``editable`` true): the same fields are enabled, with
-%#     Apply / Renew / Cancel.
+%# Network Interface configuration.
+%#
+%# The card opens on the list of every interface on the station – the layout
+%# view the old single ``Interface`` picker had nowhere to show. ``Configure``
+%# expands that interface's settings under its own row, so which adapter is
+%# being edited is never ambiguous.
+%#
+%# Two modes, as before: VIEW (editable=false) disables the fields and
+%# live-polls every 5s; EDIT adds Apply / Renew / Cancel. The poll is
+%# suppressed while an interface is expanded so it can't collapse the form
+%# mid-edit.
+%#
 %# Rendered into the #network-interface region (heading + fold live in
 %# general.tpl), swapped in place on toggle / apply / renew.
 %#
@@ -14,12 +21,16 @@
 % _method = _net.get("method", "dhcp")
 % _dis = '' if _editable else 'disabled'
 % _banner = _net.get("banner")
+% _rows = _net.get("iface_rows", [])
+% _session = _net.get("session_iface", "")
+% _editing = _net.get("editing_iface", "")
+% _polls = _net.get("available") and not _editable
 <form id="network-config-section" class="network-config"
 % if _editable:
       hx-post="/section/network/apply" hx-target="#network-interface"
       hx-swap="innerHTML" hx-trigger="submit"
       hx-on:submit="netScheduleReload(this)"
-% elif _net.get("available"):
+% elif _polls:
       hx-get="/section/network/status" hx-trigger="every 5s"
       hx-target="#network-interface" hx-swap="innerHTML"
 % end
@@ -55,93 +66,155 @@
     </div>
     % end
 
+    %# The interface being configured still travels with the form so /apply
+    %# and /renew receive it exactly as before – it just comes from the row
+    %# the operator opened rather than from a dropdown.
+    <input type="hidden" name="iface" value="{{_net.get('active_interface', '')}}">
+
     <div class="group">
-        <h4 class="group-title">Connection</h4>
-        <div class="network-grid">
-            <label for="net-iface">Interface</label>
-            <select id="net-iface" name="iface" {{_dis}}
-                    % if _editable:
-                    hx-post="/section/network" hx-target="#network-config-section"
-                    hx-swap="outerHTML" hx-trigger="change" hx-include="closest form"
+        <h4 class="group-title">Interfaces on this station</h4>
+        % if not _rows:
+        <p class="muted">No network interfaces detected.</p>
+        % else:
+        <table class="ia-table ia-nics">
+            <thead>
+                <tr><th></th><th>Interface</th><th>Address</th><th>Method</th><th></th></tr>
+            </thead>
+            <tbody>
+                % for row in _rows:
+                % _name = row.get("name", "")
+                % _addr = row.get("address", "")
+                % _prefix = row.get("prefix")
+                % _open = bool(_name) and _name == _editing
+                <tr class="{{'is-configuring' if _open else ''}}">
+                    <td><span class="ia-dot {{'up' if _addr else 'down'}}"></span></td>
+                    <td>
+                        <code>{{_name}}</code>
+                        % if _name and _name == _session:
+                        %# Guards the operator against editing the adapter
+                        %# their own session is arriving on.
+                        <span class="ia-badge session" title="Your browser reached this station over this interface">This session</span>
+                        % end
+                    </td>
+                    <td class="{{'' if _addr else 'muted'}}">{{(_addr + ('/' + str(_prefix) if _prefix else '')) if _addr else '(no address)'}}</td>
+                    <td class="muted">{{row.get('method_label', '')}}</td>
+                    <td class="ia-actions">
+                        %# The open row is the one being configured, so it
+                        %# needs no button – picking another row moves the
+                        %# expansion there.
+                        % if not _open:
+                        <button type="button" class="secondary small"
+                                hx-get="{{('/section/network/edit/' if _editable else '/section/network/status/') + _name}}"
+                                hx-target="#network-interface" hx-swap="innerHTML">Configure</button>
+                        % end
+                    </td>
+                </tr>
+
+                % if _open:
+                <tr class="ia-editor-row"><td colspan="5"><div class="ia-editor">
+                    <div class="ia-editor-head">
+                        <h4 class="group-title">Configure <code>{{_name}}</code></h4>
+                    </div>
+
+                    % if _name == _session:
+                    <div class="notice warning" role="status">
+                        <strong>You are connected over this interface.</strong>
+                        Changing its address will drop this web session. The station stays
+                        reachable by name and from the on-screen <em>Settings &rsaquo; Network</em> menu.
+                    </div>
                     % end
-                    >
-                % for name in _net.get("interfaces", []):
-                <option value="{{name}}" {{'selected' if name == _net.get('active_interface') else ''}}>{{name}}</option>
+
+                    <div class="network-grid">
+                        <label for="net-method">Method</label>
+                        <select id="net-method" name="method" {{_dis}}
+                                % if _editable:
+                                hx-post="/section/network" hx-target="#network-config-section"
+                                hx-swap="outerHTML" hx-trigger="change" hx-include="closest form"
+                                % end
+                                >
+                            <option value="dhcp" {{'selected' if _method == 'dhcp' else ''}}>DHCP (automatic)</option>
+                            <option value="dhcp_manual" {{'selected' if _method == 'dhcp_manual' else ''}}>DHCP with manual address</option>
+                            <option value="static" {{'selected' if _method == 'static' else ''}}>Static</option>
+                        </select>
+                    </div>
+
+                    %# Addressing. Read-only view shows current IP/subnet/router
+                    %# (including the DHCP lease address); the edit form shows
+                    %# only the fields the chosen method lets you set.
+                    % if (not _editable) or _method in ("static", "dhcp_manual"):
+                    <div class="group">
+                        <h4 class="group-title">Addressing</h4>
+                        <div class="network-grid">
+                            <label for="net-address">IP address</label>
+                            <input id="net-address" type="text" name="address" value="{{_net.get('address', '')}}"
+                                   placeholder="192.168.1.50" {{_dis}}>
+                            % if (not _editable) or _method == "static":
+                            <label for="net-subnet">Subnet mask</label>
+                            <input id="net-subnet" type="text" name="subnet_mask"
+                                   value="{{_net.get('subnet_mask', '')}}"
+                                   placeholder="255.255.255.0" {{_dis}}>
+                            <label for="net-router">Router (optional)</label>
+                            <input id="net-router" type="text" name="router" value="{{_net.get('router', '')}}"
+                                   placeholder="192.168.1.1" {{_dis}}>
+                            % end
+                        </div>
+                    </div>
+                    % end
+
+                    <div class="group">
+                        <h4 class="group-title">DNS</h4>
+                        <div class="network-grid">
+                            % _dns = _net.get("dns", [])
+                            % for i in range(3):
+                            <label for="net-dns{{i + 1}}">Server {{i + 1}}</label>
+                            <input id="net-dns{{i + 1}}" type="text" name="dns{{i + 1}}"
+                                   value="{{_dns[i] if i < len(_dns) else ''}}"
+                                   placeholder="1.1.1.1" {{_dis}}>
+                            % end
+                        </div>
+                    </div>
+
+                    % _lease = _net.get("lease_display")
+                    % if _lease:
+                    <div class="group">
+                        <h4 class="group-title">Lease</h4>
+                        <div class="network-grid">
+                            <label>Remaining</label>
+                            <span class="network-grid-value">{{_lease}}</span>
+                        </div>
+                    </div>
+                    % end
+
+                    % if _editable:
+                    <div class="actions">
+                        <button type="submit" class="save-btn">Apply</button>
+                        %# Renew only for DHCP; static has no lease.
+                        % if _method in ("dhcp", "dhcp_manual"):
+                        <button type="button" class="secondary"
+                                hx-post="/section/network/renew" hx-target="#network-interface"
+                                hx-swap="innerHTML" hx-include="closest form">Renew DHCP lease</button>
+                        % end
+                        <button type="button" class="ghost-btn"
+                                hx-get="/section/network/edit" hx-target="#network-interface"
+                                hx-swap="innerHTML">Cancel</button>
+                    </div>
+                    % end
+                </div></td></tr>
                 % end
-            </select>
-            <label for="net-method">Method</label>
-            <select id="net-method" name="method" {{_dis}}
-                    % if _editable:
-                    hx-post="/section/network" hx-target="#network-config-section"
-                    hx-swap="outerHTML" hx-trigger="change" hx-include="closest form"
-                    % end
-                    >
-                <option value="dhcp" {{'selected' if _method == 'dhcp' else ''}}>DHCP (automatic)</option>
-                <option value="dhcp_manual" {{'selected' if _method == 'dhcp_manual' else ''}}>DHCP with manual address</option>
-                <option value="static" {{'selected' if _method == 'static' else ''}}>Static</option>
-            </select>
-        </div>
-    </div>
+                % end
+            </tbody>
+        </table>
 
-    %# Addressing. Read-only view shows current IP/subnet/router (including DHCP
-    %# lease address). EDIT form shows only operator-settable fields per method.
-    % if (not _editable) or _method in ("static", "dhcp_manual"):
-    <div class="group">
-        <h4 class="group-title">Addressing</h4>
-        <div class="network-grid">
-            <label for="net-address">IP address</label>
-            <input id="net-address" type="text" name="address" value="{{_net.get('address', '')}}"
-                   placeholder="192.168.1.50" {{_dis}}>
-            % if (not _editable) or _method == "static":
-            <label for="net-subnet">Subnet mask</label>
-            <input id="net-subnet" type="text" name="subnet_mask"
-                   value="{{_net.get('subnet_mask', '')}}"
-                   placeholder="255.255.255.0" {{_dis}}>
-            <label for="net-router">Router (optional)</label>
-            <input id="net-router" type="text" name="router" value="{{_net.get('router', '')}}"
-                   placeholder="192.168.1.1" {{_dis}}>
-            % end
+        <div class="ia-legend">
+            <span><span class="ia-dot up"></span> up with an address</span>
+            <span><span class="ia-dot down"></span> no address</span>
+            <span class="ia-legend-actions">
+                <button type="button" class="secondary small"
+                        hx-get="{{'/section/network/edit' if _editable else '/section/network/status'}}?scan=1"
+                        hx-target="#network-interface" hx-swap="innerHTML">Scan</button>
+            </span>
         </div>
-    </div>
-    % end
-
-    <div class="group">
-        <h4 class="group-title">DNS</h4>
-        <div class="network-grid">
-            % _dns = _net.get("dns", [])
-            % for i in range(3):
-            <label for="net-dns{{i + 1}}">Server {{i + 1}}</label>
-            <input id="net-dns{{i + 1}}" type="text" name="dns{{i + 1}}"
-                   value="{{_dns[i] if i < len(_dns) else ''}}"
-                   placeholder="1.1.1.1" {{_dis}}>
-            % end
-        </div>
-    </div>
-
-    % _lease = _net.get("lease_display")
-    % if _lease:
-    <div class="group">
-        <h4 class="group-title">Lease</h4>
-        <div class="network-grid">
-            <label>Remaining</label>
-            <span class="network-grid-value">{{_lease}}</span>
-        </div>
-    </div>
-    % end
-
-    % if _editable:
-    <div class="actions">
-        <button type="submit" class="save-btn">Apply</button>
-        %# Renew only for DHCP; static has no lease.
-        % if _method in ("dhcp", "dhcp_manual"):
-        <button type="button" class="secondary"
-                hx-post="/section/network/renew" hx-target="#network-interface"
-                hx-swap="innerHTML" hx-include="closest form">Renew DHCP lease</button>
         % end
-        <button type="button" class="ghost-btn"
-                hx-get="/section/network/status" hx-target="#network-interface"
-                hx-swap="innerHTML">Cancel</button>
     </div>
-    % end
     % end
 </form>

--- a/openfollow/web/templates/partials/otp_output.tpl
+++ b/openfollow/web/templates/partials/otp_output.tpl
@@ -46,15 +46,12 @@
                 <span id="otp-output-priority-error" class="field-error"></span>
             </div>
             <div class="field">
-                <label>Source Interface (optional)</label>
-                <div class="input-with-button">
-                    %# Pin stable interface name (eth0/wlan0), not IP – resolved
-                    %# to a bind IP at runtime, like psn_source_iface.
-                    <select name="source_iface" hx-get="/network/interfaces/by_name?current={{config.otp_output.source_iface}}" hx-trigger="load, click from:#refresh-iface-otp"
-                            hx-target="this" hx-swap="innerHTML">
-                        <option value="{{config.otp_output.source_iface}}">{{config.otp_output.source_iface or '-- Loading... --'}}</option>
-                    </select>
-                    <button type="button" id="refresh-iface-otp" class="secondary">Scan</button>
+                <label>Source Interface</label>
+                %# Read-only pointer – the pin is edited centrally in
+                %# General > Interface Assignment, alongside every other plane.
+                <div class="ia-pointer">
+                    <span class="ia-pointer-value">{{config.otp_output.source_iface or 'Follows station interface'}}</span>
+                    <a class="ia-link" href="#interface-assignment-section">Change in General &rsaquo; Interface Assignment</a>
                 </div>
             </div>
         </div>

--- a/openfollow/web/templates/partials/otp_output.tpl
+++ b/openfollow/web/templates/partials/otp_output.tpl
@@ -51,7 +51,8 @@
                 %# General > Interface Assignment, alongside every other plane.
                 <div class="ia-pointer">
                     <span class="ia-pointer-value">{{config.otp_output.source_iface or 'Follows station interface'}}</span>
-                    <a class="ia-link" href="#interface-assignment-section">Change in General &rsaquo; Interface Assignment</a>
+                    <a class="ia-link" href="#interface-assignment"
+                       onclick="goToSection('general', 'interface-assignment'); return false;">Change in General &rsaquo; Interface Assignment</a>
                 </div>
             </div>
         </div>

--- a/openfollow/web/templates/partials/psn.tpl
+++ b/openfollow/web/templates/partials/psn.tpl
@@ -29,21 +29,20 @@
                 <span id="psn-psn-mcast-ip-error" class="field-error"></span>
             </div>
             <div class="field">
-                <label>PSN Network Interface</label>
+                <label>Network Interface</label>
+                %# Read-only pointer: the pin is edited in one place for every
+                %# protocol (General > Interface Assignment), so this section
+                %# reports where PSN is bound rather than offering a second
+                %# control for the same field.
                 %# Startup advisory: pinned iface wasn't live at boot, so
                 %# auto-detected working IP. Rendered only when pin missed.
                 % _adv = psn_source_advisory if defined('psn_source_advisory') and psn_source_advisory else {}
                 % if _adv.get('banner'):
                 <div class="notice warning" role="status">{{_adv['banner']}}</div>
                 % end
-                <div class="input-with-button">
-                    %# Pin stable interface name (eth0/wlan0, not IP).
-                    %# Iface stable across DHCP/venue changes.
-                    <select name="psn_source_iface" hx-get="/network/interfaces/by_name" hx-trigger="load, click from:#refresh-iface-psn"
-                            hx-target="this" hx-swap="innerHTML">
-                        <option value="{{config.psn_source_iface}}">{{config.psn_source_iface or '-- Loading... --'}}</option>
-                    </select>
-                    <button type="button" id="refresh-iface-psn" class="secondary">Scan</button>
+                <div class="ia-pointer">
+                    <span class="ia-pointer-value">{{config.psn_source_iface or 'Auto-detect'}}</span>
+                    <a class="ia-link" href="#interface-assignment-section">Change in General &rsaquo; Interface Assignment</a>
                 </div>
             </div>
         </div>

--- a/openfollow/web/templates/partials/psn.tpl
+++ b/openfollow/web/templates/partials/psn.tpl
@@ -42,7 +42,8 @@
                 % end
                 <div class="ia-pointer">
                     <span class="ia-pointer-value">{{config.psn_source_iface or 'Auto-detect'}}</span>
-                    <a class="ia-link" href="#interface-assignment-section">Change in General &rsaquo; Interface Assignment</a>
+                    <a class="ia-link" href="#interface-assignment"
+                       onclick="goToSection('general', 'interface-assignment'); return false;">Change in General &rsaquo; Interface Assignment</a>
                 </div>
             </div>
         </div>

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -60,6 +60,7 @@ class _DummyRuntimeServices:
         self.psn_source_ip_changes: list[str] = []
         self.psn_mcast_ip_changes: list[str] = []
         self.psn_combined_changes: list[tuple[str, str]] = []
+        self.station_iface_follow_calls = 0
         self.psn_system_name_changes: list[str] = []
         self.detection_changes: list[DetectionConfig] = []
         self.detection_swaps: list[DetectionConfig] = []
@@ -88,6 +89,9 @@ class _DummyRuntimeServices:
             self.psn_combined_changes.append(
                 (new_source_ip, str(new_mcast_ip)),
             )
+
+    def apply_station_iface_change(self) -> None:
+        self.station_iface_follow_calls += 1
 
     def apply_psn_mcast_ip_change(self, new_mcast_ip: str) -> None:
         self.psn_mcast_ip_changes.append(new_mcast_ip)
@@ -1449,6 +1453,59 @@ def test_apply_runtime_rebinds_on_psn_source_iface_change(monkeypatch) -> None:
     assert app._config.psn_source_iface == "eth0"
     assert app._runtime_services.psn_source_ip_changes == ["192.168.178.59"]
     assert app._web_commands.restart_requested is False
+
+
+def test_station_iface_change_repoints_the_planes_that_follow_it(monkeypatch) -> None:
+    """A plane with a blank pin follows the station interface, but its own
+    dataclass is unchanged – so nothing else in the dispatcher re-applies it.
+    Without this the panel renders the new address for a plane still sending
+    from the old interface until a restart."""
+    import socket as _socket
+    from types import SimpleNamespace
+
+    import openfollow.net_utils as net_utils_module
+
+    monkeypatch.setattr(
+        net_utils_module.psutil,
+        "net_if_addrs",
+        lambda: {
+            "eth0": [SimpleNamespace(family=_socket.AF_INET, address="192.168.1.5")],
+            "eth1": [SimpleNamespace(family=_socket.AF_INET, address="10.0.0.9")],
+        },
+    )
+    app = _DummyApp(AppConfig(psn_source_iface="eth0"))
+    apply_runtime_config_changes(app, AppConfig(psn_source_iface="eth1"))
+
+    assert app._runtime_services.station_iface_follow_calls == 1
+
+
+def test_station_iface_rollback_does_not_repoint_followers(monkeypatch) -> None:
+    """The PSN rebind failed and the iface reverted, so the followers are
+    still correctly on the old interface – repointing them would move them
+    to an interface the station isn't actually using."""
+    import socket as _socket
+    from types import SimpleNamespace
+
+    import openfollow.net_utils as net_utils_module
+
+    monkeypatch.setattr(
+        net_utils_module.psutil,
+        "net_if_addrs",
+        lambda: {
+            "eth0": [SimpleNamespace(family=_socket.AF_INET, address="192.168.1.5")],
+            "eth1": [SimpleNamespace(family=_socket.AF_INET, address="10.0.0.9")],
+        },
+    )
+    app = _DummyApp(AppConfig(psn_source_iface="eth0"))
+
+    def _boom(*_a: object, **_kw: object) -> None:
+        raise OSError("bind failed")
+
+    app._runtime_services.apply_psn_source_ip_change = _boom  # type: ignore[method-assign]
+    apply_runtime_config_changes(app, AppConfig(psn_source_iface="eth1"))
+
+    assert app._config.psn_source_iface == "eth0"
+    assert app._runtime_services.station_iface_follow_calls == 0
 
 
 def test_apply_runtime_strips_whitespace_from_psn_source_iface() -> None:

--- a/tests/test_net_utils.py
+++ b/tests/test_net_utils.py
@@ -467,8 +467,9 @@ class TestResolveSourceIp:
 
 class TestResolvePlaneSourceIp:
     """``resolve_plane_source_ip(pin, station_iface)`` resolves one network
-    plane's pin, falling through to the station-wide pin and then to
-    auto-detect. A blank plane pin means "follow the station interface"."""
+    plane's *configured* interface. Inheritance happens for an unset value
+    only – a configured interface that is down reports ``down`` and the plane
+    binds nothing rather than moving to a different network."""
 
     @staticmethod
     def _ifaces(monkeypatch, spec: dict[str, list[tuple[int, str]]]) -> None:
@@ -503,27 +504,35 @@ class TestResolvePlaneSourceIp:
         )
         assert resolve_plane_source_ip("", "eth0") == ("192.168.1.5", "station")
 
-    def test_down_plane_pin_falls_through_to_station(self, monkeypatch) -> None:
-        """A plane pinned to an interface that's gone must not fail closed:
-        it degrades to the station interface, and the non-"iface" status is
-        what makes the caller warn."""
+    def test_down_plane_pin_does_not_move_to_the_station_interface(self, monkeypatch) -> None:
+        """The load-bearing rule: a pinned plane whose interface is gone stops.
+        Rebinding it to the station interface would put show data on whatever
+        network that happens to be – silently, mid-show."""
         self._ifaces(monkeypatch, {"eth0": [(socket.AF_INET, "192.168.1.5")]})
-        assert resolve_plane_source_ip("eth9", "eth0") == ("192.168.1.5", "station")
+        assert resolve_plane_source_ip("eth9", "eth0") == ("", "down")
 
-    def test_both_pins_down_falls_through_to_primary(self, monkeypatch) -> None:
-        """Plane pin and station pin both unavailable → auto-detect rather
-        than an empty bind."""
+    def test_down_station_interface_does_not_auto_detect(self, monkeypatch) -> None:
+        """Same rule one level up: an explicitly configured station interface
+        that is down must not silently become the OS primary."""
         self._ifaces(monkeypatch, {"eth0": [(socket.AF_INET, "192.168.1.5")]})
         monkeypatch.setattr(
             net_utils_module,
             "get_primary_local_ipv4",
             lambda default="": "172.16.4.20",
         )
-        assert resolve_plane_source_ip("eth9", "eth8") == ("172.16.4.20", "primary")
+        assert resolve_plane_source_ip("", "eth8") == ("", "down")
+
+    def test_a_new_address_on_the_configured_interface_is_followed(self, monkeypatch) -> None:
+        """Only the interface is fixed. A reconnect that yields a different
+        DHCP lease on the same NIC must resolve to the new address."""
+        self._ifaces(monkeypatch, {"eth0": [(socket.AF_INET, "192.168.1.5")]})
+        assert resolve_plane_source_ip("eth0", "") == ("192.168.1.5", "iface")
+        self._ifaces(monkeypatch, {"eth0": [(socket.AF_INET, "192.168.1.77")]})
+        assert resolve_plane_source_ip("eth0", "") == ("192.168.1.77", "iface")
 
     def test_no_pins_at_all_is_auto_detect(self, monkeypatch) -> None:
-        """The pre-existing default config: nothing pinned anywhere, so the
-        result must match what ``resolve_source_ip("")`` already returned."""
+        """Nothing configured anywhere is not an error – auto-detect is the
+        chosen behaviour, so it still resolves."""
         self._ifaces(monkeypatch, {})
         monkeypatch.setattr(
             net_utils_module,
@@ -532,22 +541,16 @@ class TestResolvePlaneSourceIp:
         )
         assert resolve_plane_source_ip("", "") == ("192.168.1.50", "primary")
 
-    def test_fallback_disabled_reports_none(self, monkeypatch) -> None:
-        """``fallback=False`` refuses to auto-detect, for callers that would
-        rather wait for the pinned interface than bind the wrong one."""
-        self._ifaces(monkeypatch, {"eth0": [(socket.AF_INET, "192.168.1.5")]})
-        assert resolve_plane_source_ip("eth9", "eth8", fallback=False) == ("", "none")
-
-    def test_offline_reports_none(self, monkeypatch) -> None:
-        """No usable address anywhere – an empty bind lets the OS pick, which
-        is the documented meaning of an empty source IP downstream."""
+    def test_offline_with_nothing_configured_reports_none(self, monkeypatch) -> None:
+        """Distinct from ``down``: nothing was configured, so nothing is
+        broken – there is simply no address to auto-detect yet."""
         self._ifaces(monkeypatch, {})
         monkeypatch.setattr(
             net_utils_module,
             "get_primary_local_ipv4",
             lambda default="": "",
         )
-        assert resolve_plane_source_ip("eth9", "eth8") == ("", "none")
+        assert resolve_plane_source_ip("", "") == ("", "none")
 
     def test_loopback_only_primary_is_rejected(self, monkeypatch) -> None:
         """A loopback primary is not a usable bind for LAN multicast, so it
@@ -560,9 +563,9 @@ class TestResolvePlaneSourceIp:
         )
         assert resolve_plane_source_ip("", "") == ("", "none")
 
-    def test_station_pin_skipped_when_it_has_no_address(self, monkeypatch) -> None:
-        """A station interface that exists but holds only IPv6 / loopback is
-        not a usable IPv4 bind – fall through instead of returning ""."""
+    def test_configured_interface_without_ipv4_is_down(self, monkeypatch) -> None:
+        """An interface holding only IPv6 / loopback has no usable IPv4 bind.
+        It is configured, so it is ``down`` – not a reason to auto-detect."""
         self._ifaces(
             monkeypatch,
             {
@@ -574,7 +577,18 @@ class TestResolvePlaneSourceIp:
             "get_primary_local_ipv4",
             lambda default="": "10.1.1.4",
         )
-        assert resolve_plane_source_ip("", "eth0") == ("10.1.1.4", "primary")
+        assert resolve_plane_source_ip("", "eth0") == ("", "down")
+
+
+class TestPlaneSourceIface:
+    def test_pin_wins(self) -> None:
+        assert net_utils_module.plane_source_iface("eth1", "eth0") == "eth1"
+
+    def test_blank_pin_inherits_the_station(self) -> None:
+        assert net_utils_module.plane_source_iface("", "eth0") == "eth0"
+
+    def test_nothing_configured_is_empty(self) -> None:
+        assert net_utils_module.plane_source_iface("", "") == ""
 
 
 class TestWaitForSourceIp:

--- a/tests/test_net_utils.py
+++ b/tests/test_net_utils.py
@@ -17,6 +17,7 @@ from openfollow.net_utils import (
     get_primary_local_ipv4,
     list_iface_ipv4,
     resolve_iface_ip,
+    resolve_plane_source_ip,
     resolve_source_ip,
 )
 
@@ -462,6 +463,118 @@ class TestResolveSourceIp:
             lambda default="": "",
         )
         assert resolve_source_ip("") == ("", "none")
+
+
+class TestResolvePlaneSourceIp:
+    """``resolve_plane_source_ip(pin, station_iface)`` resolves one network
+    plane's pin, falling through to the station-wide pin and then to
+    auto-detect. A blank plane pin means "follow the station interface"."""
+
+    @staticmethod
+    def _ifaces(monkeypatch, spec: dict[str, list[tuple[int, str]]]) -> None:
+        monkeypatch.setattr(
+            net_utils_module.psutil,
+            "net_if_addrs",
+            lambda: _fake_addrs(spec),
+        )
+
+    def test_plane_pin_wins_over_station(self, monkeypatch) -> None:
+        """A live plane pin is honoured even when the station pins a
+        different, equally live interface – that's the whole point of
+        splitting a plane onto its own network."""
+        self._ifaces(
+            monkeypatch,
+            {
+                "eth0": [(socket.AF_INET, "192.168.1.5")],
+                "eth1": [(socket.AF_INET, "10.0.0.9")],
+            },
+        )
+        assert resolve_plane_source_ip("eth1", "eth0") == ("10.0.0.9", "iface")
+
+    def test_blank_pin_follows_station(self, monkeypatch) -> None:
+        """Blank pin = "follow station interface" – the default for every
+        plane, and what keeps a single-NIC station behaving as before."""
+        self._ifaces(
+            monkeypatch,
+            {
+                "eth0": [(socket.AF_INET, "192.168.1.5")],
+                "eth1": [(socket.AF_INET, "10.0.0.9")],
+            },
+        )
+        assert resolve_plane_source_ip("", "eth0") == ("192.168.1.5", "station")
+
+    def test_down_plane_pin_falls_through_to_station(self, monkeypatch) -> None:
+        """A plane pinned to an interface that's gone must not fail closed:
+        it degrades to the station interface, and the non-"iface" status is
+        what makes the caller warn."""
+        self._ifaces(monkeypatch, {"eth0": [(socket.AF_INET, "192.168.1.5")]})
+        assert resolve_plane_source_ip("eth9", "eth0") == ("192.168.1.5", "station")
+
+    def test_both_pins_down_falls_through_to_primary(self, monkeypatch) -> None:
+        """Plane pin and station pin both unavailable → auto-detect rather
+        than an empty bind."""
+        self._ifaces(monkeypatch, {"eth0": [(socket.AF_INET, "192.168.1.5")]})
+        monkeypatch.setattr(
+            net_utils_module,
+            "get_primary_local_ipv4",
+            lambda default="": "172.16.4.20",
+        )
+        assert resolve_plane_source_ip("eth9", "eth8") == ("172.16.4.20", "primary")
+
+    def test_no_pins_at_all_is_auto_detect(self, monkeypatch) -> None:
+        """The pre-existing default config: nothing pinned anywhere, so the
+        result must match what ``resolve_source_ip("")`` already returned."""
+        self._ifaces(monkeypatch, {})
+        monkeypatch.setattr(
+            net_utils_module,
+            "get_primary_local_ipv4",
+            lambda default="": "192.168.1.50",
+        )
+        assert resolve_plane_source_ip("", "") == ("192.168.1.50", "primary")
+
+    def test_fallback_disabled_reports_none(self, monkeypatch) -> None:
+        """``fallback=False`` refuses to auto-detect, for callers that would
+        rather wait for the pinned interface than bind the wrong one."""
+        self._ifaces(monkeypatch, {"eth0": [(socket.AF_INET, "192.168.1.5")]})
+        assert resolve_plane_source_ip("eth9", "eth8", fallback=False) == ("", "none")
+
+    def test_offline_reports_none(self, monkeypatch) -> None:
+        """No usable address anywhere – an empty bind lets the OS pick, which
+        is the documented meaning of an empty source IP downstream."""
+        self._ifaces(monkeypatch, {})
+        monkeypatch.setattr(
+            net_utils_module,
+            "get_primary_local_ipv4",
+            lambda default="": "",
+        )
+        assert resolve_plane_source_ip("eth9", "eth8") == ("", "none")
+
+    def test_loopback_only_primary_is_rejected(self, monkeypatch) -> None:
+        """A loopback primary is not a usable bind for LAN multicast, so it
+        must report "none" rather than pinning traffic to 127.x."""
+        self._ifaces(monkeypatch, {})
+        monkeypatch.setattr(
+            net_utils_module,
+            "get_primary_local_ipv4",
+            lambda default="": "127.0.0.1",
+        )
+        assert resolve_plane_source_ip("", "") == ("", "none")
+
+    def test_station_pin_skipped_when_it_has_no_address(self, monkeypatch) -> None:
+        """A station interface that exists but holds only IPv6 / loopback is
+        not a usable IPv4 bind – fall through instead of returning ""."""
+        self._ifaces(
+            monkeypatch,
+            {
+                "eth0": [(socket.AF_INET6, "fe80::1"), (socket.AF_INET, "127.0.0.1")],
+            },
+        )
+        monkeypatch.setattr(
+            net_utils_module,
+            "get_primary_local_ipv4",
+            lambda default="": "10.1.1.4",
+        )
+        assert resolve_plane_source_ip("", "eth0") == ("10.1.1.4", "primary")
 
 
 class TestWaitForSourceIp:

--- a/tests/test_services_init_and_updates.py
+++ b/tests/test_services_init_and_updates.py
@@ -612,7 +612,7 @@ class TestInitOtp:
         monkeypatch.setattr(
             net_utils,
             "resolve_plane_source_ip",
-            lambda pin, station="", *, fallback=True: ("", "none"),
+            lambda pin, station="": ("", "none"),
         )
 
     def test_blank_source_iface_follows_station_interface(
@@ -712,7 +712,7 @@ class TestInitOtp:
         monkeypatch.setattr(
             net_utils,
             "resolve_plane_source_ip",
-            lambda pin, station="", *, fallback=True: ("192.168.1.5", "iface"),
+            lambda pin, station="": ("192.168.1.5", "iface"),
         )
         monkeypatch.setattr(services_module, "OtpServer", _FakeOtpServer)
 
@@ -746,9 +746,20 @@ class TestInitOtp:
         services.init_otp()
         assert services._app._otp_server.registered == []
 
-    def test_enabled_source_iface_unavailable_falls_back_and_warns(
-        self, services: AppRuntimeServices, monkeypatch: pytest.MonkeyPatch, caplog
+    def test_enabled_source_iface_unavailable_stays_down_and_errors(
+        self,
+        services: AppRuntimeServices,
+        monkeypatch,
+        caplog,
     ) -> None:
+        """A pinned interface that is gone must not put OTP on another network.
+
+        The operator chose that interface; sending stage data out of whatever
+        NIC happens to be up instead is worse than sending nothing, because a
+        stopped output is visible and a misrouted one is not.
+        """
+        from dataclasses import replace
+
         cfg = replace(
             services._app._config,
             otp_output=OtpOutputConfig(
@@ -765,19 +776,20 @@ class TestInitOtp:
 
         from openfollow import net_utils
 
-        # Pinned iface is down → falls back to the primary, status "primary".
         monkeypatch.setattr(
             net_utils,
             "resolve_plane_source_ip",
-            lambda pin, station="", *, fallback=True: ("192.168.1.9", "primary"),
+            lambda pin, station="": ("", "down"),
         )
         monkeypatch.setattr(services_module, "OtpServer", _FakeOtpServer)
 
-        with caplog.at_level("WARNING"):
+        with caplog.at_level("ERROR"):
             services.init_otp()
-        # Output stays alive on the fallback IP, with a warning about the dead pin.
-        assert services._app._otp_server._source_ip == "192.168.1.9"
-        assert any("otp_output.source_iface" in r.message for r in caplog.records)
+        assert services._app._otp_server._source_ip == ""
+        record = next(r for r in caplog.records if "otp_output.source_iface" in r.message)
+        assert record.levelname == "ERROR"
+        # Names the interface the operator configured, not the one it fell to.
+        assert "eth9_gone" in record.message
 
 
 # --------------------------------------------------------------------------- #
@@ -1770,14 +1782,19 @@ class TestApplyOtpOutputChange:
     """Four-state matrix: (currently_running × new_enabled)."""
 
     @pytest.fixture(autouse=True)
-    def _stub_resolve_source_ip(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Keep the forward-restart iface→IP resolution hermetic."""
+    def _stub_resolve_plane_source_ip(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Keep the forward-restart iface→IP resolution hermetic.
+
+        Stubs the resolver the OTP path actually calls – stubbing
+        ``resolve_source_ip`` instead left these tests resolving a real host
+        address and opening a real UDP socket.
+        """
         from openfollow import net_utils
 
         monkeypatch.setattr(
             net_utils,
-            "resolve_source_ip",
-            lambda iface, *, fallback=True: ("", "none"),
+            "resolve_plane_source_ip",
+            lambda pin, station="": ("", "none"),
         )
 
     def _enabled_cfg(self, **overrides: Any) -> OtpOutputConfig:
@@ -3870,3 +3887,55 @@ class TestSwapDetector:
 
         with pytest.raises(RuntimeError, match="not initialised"):
             services.swap_detector(new_cfg)
+
+
+# --------------------------------------------------------------------------- #
+# apply_station_iface_change – planes that inherit the station interface
+# --------------------------------------------------------------------------- #
+
+
+class TestApplyStationIfaceChange:
+    """Only planes with a blank pin follow the station default; a plane with
+    its own pin must not be touched when the station moves."""
+
+    def _services_with_otp(self, services: AppRuntimeServices, source_iface: str, *, enabled: bool = True):
+        from dataclasses import replace
+
+        services._app._config = replace(
+            services._app._config,
+            otp_output=OtpOutputConfig(
+                enabled=enabled,
+                system_number=1,
+                port=5568,
+                source_iface=source_iface,
+            ),
+        )
+        calls: list[OtpOutputConfig] = []
+        services.apply_otp_output_change = calls.append  # type: ignore[method-assign]
+        return calls
+
+    def test_blank_pin_is_repointed(self, services: AppRuntimeServices) -> None:
+        services._app._otp_server = _FakeOtpServer()
+        calls = self._services_with_otp(services, "")
+        services.apply_station_iface_change()
+        assert len(calls) == 1
+
+    def test_own_pin_is_left_alone(self, services: AppRuntimeServices) -> None:
+        """OTP pinned to its own interface is unaffected by the station moving –
+        repointing it would silently override the operator's choice."""
+        services._app._otp_server = _FakeOtpServer()
+        calls = self._services_with_otp(services, "eth1")
+        services.apply_station_iface_change()
+        assert calls == []
+
+    def test_disabled_output_is_left_alone(self, services: AppRuntimeServices) -> None:
+        services._app._otp_server = _FakeOtpServer()
+        calls = self._services_with_otp(services, "", enabled=False)
+        services.apply_station_iface_change()
+        assert calls == []
+
+    def test_no_running_server_is_a_no_op(self, services: AppRuntimeServices) -> None:
+        services._app._otp_server = None
+        calls = self._services_with_otp(services, "")
+        services.apply_station_iface_change()
+        assert calls == []

--- a/tests/test_services_init_and_updates.py
+++ b/tests/test_services_init_and_updates.py
@@ -17,6 +17,7 @@ between ``OpenFollowApp.run()`` and the per-subsystem classes:
 
 from __future__ import annotations
 
+import socket
 from dataclasses import replace
 from types import SimpleNamespace
 from typing import Any
@@ -31,6 +32,7 @@ from openfollow.configuration import (
     OtpOutputConfig,
     RttrpmOutputConfig,
 )
+from openfollow.net_utils import resolve_plane_source_ip as _REAL_RESOLVE_PLANE_SOURCE_IP
 from openfollow.psn.server import _UNCHANGED as _UNCHANGED_SENTINEL
 from openfollow.runtime.services_marker_visuals import _resolve_marker_color
 from openfollow.services import AppRuntimeServices
@@ -609,9 +611,52 @@ class TestInitOtp:
 
         monkeypatch.setattr(
             net_utils,
-            "resolve_source_ip",
-            lambda iface, *, fallback=True: ("", "none"),
+            "resolve_plane_source_ip",
+            lambda pin, station="", *, fallback=True: ("", "none"),
         )
+
+    def test_blank_source_iface_follows_station_interface(
+        self, services: AppRuntimeServices, monkeypatch: pytest.MonkeyPatch, caplog
+    ) -> None:
+        """A blank ``otp_output.source_iface`` means "follow the station
+        interface", so a station pinned to eth0 sends OTP out eth0 instead of
+        whatever the OS routing table picks. Exercises the real resolver
+        against faked interfaces rather than a stubbed seam, because the
+        pin → station → auto chain is the behaviour under test."""
+        import openfollow.net_utils as net_utils_module
+
+        # Undo the class-level stub: this test is about the real
+        # pin → station → auto chain, driven by faked interfaces.
+        monkeypatch.setattr(
+            net_utils_module,
+            "resolve_plane_source_ip",
+            _REAL_RESOLVE_PLANE_SOURCE_IP,
+        )
+        monkeypatch.setattr(
+            net_utils_module.psutil,
+            "net_if_addrs",
+            lambda: {
+                "eth0": [SimpleNamespace(family=socket.AF_INET, address="192.168.1.5")],
+                "eth1": [SimpleNamespace(family=socket.AF_INET, address="10.0.0.9")],
+            },
+        )
+        cfg = replace(
+            services._app._config,
+            psn_source_iface="eth0",
+            otp_output=OtpOutputConfig(enabled=True, source_iface=""),
+        )
+        services._app._config = cfg
+        services._app._server = _FakePsnServer()
+        services._app._controlled_ids = []
+        monkeypatch.setattr(services_module, "OtpServer", _FakeOtpServer)
+
+        with caplog.at_level("WARNING"):
+            services.init_otp()
+
+        assert services._app._otp_server._source_ip == "192.168.1.5"
+        # Following the station is the documented default, not a degraded
+        # state – it must not warn.
+        assert not [r for r in caplog.records if "source_iface" in r.message]
 
     def test_disabled_is_no_op(self, services: AppRuntimeServices) -> None:
         # Default config has otp_output.enabled=False.
@@ -664,7 +709,11 @@ class TestInitOtp:
         from openfollow import net_utils
 
         # Pinned iface is live → resolves to its own IP, status "iface".
-        monkeypatch.setattr(net_utils, "resolve_source_ip", lambda iface, *, fallback=True: ("192.168.1.5", "iface"))
+        monkeypatch.setattr(
+            net_utils,
+            "resolve_plane_source_ip",
+            lambda pin, station="", *, fallback=True: ("192.168.1.5", "iface"),
+        )
         monkeypatch.setattr(services_module, "OtpServer", _FakeOtpServer)
 
         with caplog.at_level("WARNING"):
@@ -717,7 +766,11 @@ class TestInitOtp:
         from openfollow import net_utils
 
         # Pinned iface is down → falls back to the primary, status "primary".
-        monkeypatch.setattr(net_utils, "resolve_source_ip", lambda iface, *, fallback=True: ("192.168.1.9", "primary"))
+        monkeypatch.setattr(
+            net_utils,
+            "resolve_plane_source_ip",
+            lambda pin, station="", *, fallback=True: ("192.168.1.9", "primary"),
+        )
         monkeypatch.setattr(services_module, "OtpServer", _FakeOtpServer)
 
         with caplog.at_level("WARNING"):

--- a/tests/test_services_init_and_updates.py
+++ b/tests/test_services_init_and_updates.py
@@ -512,10 +512,12 @@ class TestInitPsn:
         assert factory.instances[0].start_called is True
         assert factory.last_kwargs["source_ip"] == "10.0.0.1"
 
-    def test_stale_iface_falls_back_to_primary(
+    def test_stale_iface_stops_psn_rather_than_moving_it(
         self, services: AppRuntimeServices, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """When the pinned iface is down/missing, init_psn falls back to the auto-detected primary."""
+        """A configured station interface that is down must not put PSN on
+        whatever else is up. Passing "" would do exactly that, because every
+        downstream socket reads an empty source as auto-detect."""
         cfg = replace(services._app._config, psn_source_iface="ghost0")
         services._app._config = cfg
 
@@ -536,7 +538,8 @@ class TestInitPsn:
         monkeypatch.setattr(services_module, "PsnServer", factory)
 
         services.init_psn()
-        assert factory.last_kwargs["source_ip"] == "10.0.0.1"
+        assert factory.last_kwargs == {}
+        assert services._app._server is None
 
     def _stub_primary_ip(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import socket as _socket
@@ -785,7 +788,9 @@ class TestInitOtp:
 
         with caplog.at_level("ERROR"):
             services.init_otp()
-        assert services._app._otp_server._source_ip == ""
+        # Not started at all. Constructing it with "" would bind via the OS
+        # routing table, which is the leak the pin exists to prevent.
+        assert services._app._otp_server is None
         record = next(r for r in caplog.records if "otp_output.source_iface" in r.message)
         assert record.levelname == "ERROR"
         # Names the interface the operator configured, not the one it fell to.

--- a/tests/test_services_init_and_updates.py
+++ b/tests/test_services_init_and_updates.py
@@ -3944,3 +3944,40 @@ class TestApplyStationIfaceChange:
         calls = self._services_with_otp(services, "")
         services.apply_station_iface_change()
         assert calls == []
+
+
+class TestOtpLiveRestartOnADownInterface:
+    """The live path has the same hole as init: restarting with "" rebinds via
+    the OS routing table, so a save while the interface is dark would move the
+    output rather than stop it."""
+
+    def test_stops_instead_of_restarting(self, services: AppRuntimeServices, monkeypatch) -> None:
+        from openfollow import net_utils
+
+        monkeypatch.setattr(
+            net_utils,
+            "resolve_plane_source_ip",
+            lambda pin, station="": ("", "down"),
+        )
+
+        class _Server:
+            def __init__(self) -> None:
+                self.stopped = 0
+                self.restarts = 0
+                self._system_number = 1
+                self._port = 5568
+                self._source_ip = "192.168.1.5"
+                self._priority = 100
+
+            def stop(self) -> None:
+                self.stopped += 1
+
+            def restart(self, **_kwargs: Any) -> None:
+                self.restarts += 1
+
+        server = _Server()
+        services._app._otp_server = server
+        services.apply_otp_output_change(
+            OtpOutputConfig(enabled=True, system_number=1, port=5568, source_iface="eth_gone")
+        )
+        assert (server.stopped, server.restarts) == (1, 0)

--- a/tests/test_services_startup.py
+++ b/tests/test_services_startup.py
@@ -681,3 +681,132 @@ def test_handle_network_renew_no_adapter(monkeypatch) -> None:
     services._network_adapter = None
     result = services._handle_network_renew("eth0")
     assert result.ok is False and "No network adapter" in result.message
+
+
+# --------------------------------------------------------------------------- #
+# _network_interfaces_provider – backs the Network Settings interface list
+# --------------------------------------------------------------------------- #
+
+
+def _ifrow(name: str, *, is_up: bool = True, kind: str = "ethernet"):
+    from openfollow.network.adapter import NetworkInterface
+
+    return NetworkInterface(name=name, mac="aa:bb", kind=kind, is_up=is_up)
+
+
+def _ifrow_state(iface: str, *, address: str, prefix: int | None, method_value: str):
+    from openfollow.network.adapter import Ipv4Config, Ipv4Method, NetworkState
+
+    return NetworkState(
+        interface=_ifrow(iface),
+        ipv4=Ipv4Config(method=Ipv4Method(method_value), address=address, prefix=prefix),
+        lease=None,
+    )
+
+
+def test_network_interfaces_provider_returns_empty_without_adapter(monkeypatch) -> None:
+    services = _build_services_with_psutil_backend(monkeypatch)
+    services._network_adapter = None
+    assert services._network_interfaces_provider() == []
+
+
+def test_network_interfaces_provider_lists_every_interface(monkeypatch) -> None:
+    """The old form showed one adapter at a time; this backs the list that
+    replaced it, so every adapter carries its own address and method."""
+    services = _build_services_with_psutil_backend(monkeypatch)
+
+    class _FakeAdapter:
+        backend_name = "fake"
+
+        def list_interfaces(self):
+            return [_ifrow("eth0"), _ifrow("eth1")]
+
+        def is_writable(self):
+            return True
+
+        def get_state(self, iface):
+            if iface == "eth0":
+                return _ifrow_state(iface, address="192.168.1.5", prefix=24, method_value="dhcp")
+            return _ifrow_state(iface, address="10.0.0.9", prefix=16, method_value="static")
+
+    services._network_adapter = _FakeAdapter()
+    rows = {r["name"]: r for r in services._network_interfaces_provider()}
+    assert rows["eth0"]["address"] == "192.168.1.5"
+    assert rows["eth0"]["method"] == "dhcp"
+    assert rows["eth0"]["subnet_mask"] == "255.255.255.0"
+    assert rows["eth1"]["address"] == "10.0.0.9"
+    assert rows["eth1"]["method"] == "static"
+    assert rows["eth1"]["prefix"] == 16
+
+
+def test_network_interfaces_provider_skips_loopback(monkeypatch) -> None:
+    services = _build_services_with_psutil_backend(monkeypatch)
+
+    class _FakeAdapter:
+        backend_name = "fake"
+
+        def list_interfaces(self):
+            return [_ifrow("lo", kind="loopback"), _ifrow("eth0")]
+
+        def is_writable(self):
+            return True
+
+        def get_state(self, iface):
+            return _ifrow_state(iface, address="192.168.1.5", prefix=24, method_value="dhcp")
+
+    services._network_adapter = _FakeAdapter()
+    assert [r["name"] for r in services._network_interfaces_provider()] == ["eth0"]
+
+
+def test_network_interfaces_provider_reports_an_addressless_interface(monkeypatch) -> None:
+    """An interface with no state still has to appear – "wlan0 has no address"
+    is exactly what the operator needs to see."""
+    services = _build_services_with_psutil_backend(monkeypatch)
+
+    class _FakeAdapter:
+        backend_name = "fake"
+
+        def list_interfaces(self):
+            return [_ifrow("wlan0", is_up=False)]
+
+        def is_writable(self):
+            return True
+
+        def get_state(self, _iface):
+            return None
+
+    services._network_adapter = _FakeAdapter()
+    (row,) = services._network_interfaces_provider()
+    assert row == {
+        "name": "wlan0",
+        "is_up": False,
+        "address": "",
+        "prefix": None,
+        "subnet_mask": "",
+        "method": "dhcp",
+    }
+
+
+def test_network_interfaces_provider_degrades_one_failing_row(monkeypatch) -> None:
+    """One adapter read failing (interface vanishing mid-scan, backend hiccup)
+    must degrade that row, not drop the whole list."""
+    services = _build_services_with_psutil_backend(monkeypatch)
+
+    class _FakeAdapter:
+        backend_name = "fake"
+
+        def list_interfaces(self):
+            return [_ifrow("eth0"), _ifrow("eth1")]
+
+        def is_writable(self):
+            return True
+
+        def get_state(self, iface):
+            if iface == "eth0":
+                raise RuntimeError("nmcli exploded")
+            return _ifrow_state(iface, address="10.0.0.9", prefix=24, method_value="dhcp")
+
+    services._network_adapter = _FakeAdapter()
+    rows = {r["name"]: r for r in services._network_interfaces_provider()}
+    assert rows["eth0"]["address"] == ""
+    assert rows["eth1"]["address"] == "10.0.0.9"

--- a/tests/test_web_helpers.py
+++ b/tests/test_web_helpers.py
@@ -67,6 +67,34 @@ def test_strip_device_local_fields_drops_detection_storage_path() -> None:
     assert scrubbed["model"] == "yolov8n.onnx"  # non-local fields kept
 
 
+def test_interface_assignment_is_device_local_in_full() -> None:
+    """Every row names a NIC on this box. A pin copied to a peer would repin
+    that peer's PSN and OTP to an interface it may not even have."""
+    from openfollow.web.routes import _INTERFACE_ASSIGNMENT_TARGETS
+
+    payload = dict.fromkeys(_INTERFACE_ASSIGNMENT_TARGETS, "eth1")
+    assert strip_device_local_fields("interface_assignment", payload) == {}
+
+
+def test_interface_assignment_is_not_broadcastable() -> None:
+    from openfollow.web.routes import _BROADCAST_EXCLUDED_SECTIONS
+
+    assert "interface_assignment" in _BROADCAST_EXCLUDED_SECTIONS
+
+
+def test_interface_assignment_get_matches_what_post_accepts() -> None:
+    """GET used to 404 while POST silently wrote – the two must agree."""
+    from openfollow.web.routes import _INTERFACE_ASSIGNMENT_TARGETS, get_section_data
+
+    cfg = AppConfig(psn_source_iface="eth0")
+    cfg.otp_output.source_iface = "eth1"
+    data = get_section_data(cfg, "interface_assignment")
+    assert data is not None
+    assert set(data) == set(_INTERFACE_ASSIGNMENT_TARGETS)
+    assert data["psn_source_iface"] == "eth0"
+    assert data["otp_output.source_iface"] == "eth1"
+
+
 def test_general_section_rejects_invalid_web_pin_and_port() -> None:
     cfg = AppConfig(web_pin="1234", web_port=80)
     apply_section_data(cfg, "general", {"web_pin": "abcd", "web_port": 99999})

--- a/tests/test_web_network_write.py
+++ b/tests/test_web_network_write.py
@@ -586,3 +586,124 @@ def test_renew_network_swallows_handler_error(tmp_path) -> None:
     srv = _make_server(tmp_path, network_renew_handler=_boom)
     result = srv.renew_network("eth0")
     assert result.ok is False and "nope" in result.message
+
+
+# --------------------------------------------------------------------------- #
+# Interface list (replaced the single Interface picker)
+# --------------------------------------------------------------------------- #
+
+
+def test_status_lists_every_interface(net_server) -> None:
+    """The old picker showed one adapter at a time, so a multi-NIC station's
+    layout was invisible. Every interface is now on screen at once."""
+    _fake, base = net_server
+    status, body = _get(base, "/section/network/status")
+    assert status == 200
+    assert "Interfaces on this station" in body
+    assert "<code>eth0</code>" in body
+    assert "<code>wlan0</code>" in body
+
+
+def test_active_interface_is_expanded_and_others_offer_configure(net_server) -> None:
+    """One interface is always the current one, so its detail is open; the
+    others carry the button that moves the expansion to them."""
+    _fake, base = net_server
+    _status, body = _get(base, "/section/network/status")
+    # eth0 is FakeNetwork's active interface: expanded, so no button of its own.
+    assert "Configure <code>eth0</code>" in body
+    assert "/section/network/status/wlan0" in body
+    assert "/section/network/status/eth0" not in body
+
+
+def test_configure_expands_the_named_interface(net_server) -> None:
+    """The interface is named in the path, so which adapter is being edited
+    can't be ambiguous."""
+    _fake, base = net_server
+    status, body = _get(base, "/section/network/edit/wlan0")
+    assert status == 200
+    assert "Configure <code>wlan0</code>" in body
+    # ... and the form still carries it to /apply exactly as before.
+    assert 'name="iface" value="wlan0"' in body
+
+
+def test_unknown_interface_falls_back_to_active(net_server) -> None:
+    """A stale or forged interface name must not reach the privileged write
+    path – it sanitises to the active interface, as the picker did."""
+    _fake, base = net_server
+    status, body = _get(base, "/section/network/edit/../../etc/passwd")
+    assert status in (200, 404)
+    if status == 200:
+        assert 'name="iface" value="eth0"' in body
+
+
+def test_no_interfaces_renders_empty_list_not_a_crash(tmp_path, monkeypatch) -> None:
+    """A host with no adapters must render the card, not raise."""
+    for attr in ("BeaconSender", "BeaconReceiver"):
+        monkeypatch.setattr(getattr(discovery_module, attr), "start", lambda self: None)
+        monkeypatch.setattr(getattr(discovery_module, attr), "stop", lambda self: None)
+    fake = FakeNetwork(interfaces=())
+    port = _find_free_tcp_port()
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("controlled_marker_ids = [1]\n", encoding="utf-8")
+    server = ConfigWebServer(
+        config_path=str(config_path),
+        host="127.0.0.1",
+        port=port,
+        system_name="TestSystem",
+        network_config_provider=fake.config_provider,
+    )
+    server.start()
+    try:
+        assert _wait_for_port(port)
+        status, body = _get(f"http://127.0.0.1:{port}", "/section/network/status")
+        assert status == 200
+        assert "unavailable" in body
+    finally:
+        server.stop()
+
+
+def test_interface_list_uses_the_richer_provider_when_wired(tmp_path, monkeypatch) -> None:
+    """With the multi-interface provider wired, every row carries its own
+    address and method – not just the active one."""
+    for attr in ("BeaconSender", "BeaconReceiver"):
+        monkeypatch.setattr(getattr(discovery_module, attr), "start", lambda self: None)
+        monkeypatch.setattr(getattr(discovery_module, attr), "stop", lambda self: None)
+    fake = FakeNetwork()
+    calls: list[int] = []
+
+    def _interfaces() -> list[dict]:
+        calls.append(1)
+        return [
+            {"name": "eth0", "address": "10.0.0.5", "prefix": 24, "method": "dhcp", "is_up": True},
+            {"name": "wlan0", "address": "172.16.4.20", "prefix": 24, "method": "static", "is_up": True},
+        ]
+
+    port = _find_free_tcp_port()
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("controlled_marker_ids = [1]\n", encoding="utf-8")
+    server = ConfigWebServer(
+        config_path=str(config_path),
+        host="127.0.0.1",
+        port=port,
+        system_name="TestSystem",
+        network_config_provider=fake.config_provider,
+        network_interfaces_provider=_interfaces,
+    )
+    server.start()
+    try:
+        assert _wait_for_port(port)
+        base = f"http://127.0.0.1:{port}"
+        _status, body = _get(base, "/section/network/status")
+        # wlan0 is not the active interface, yet its own address is shown.
+        assert "172.16.4.20" in body
+        assert "Static" in body
+        # A second render inside the TTL window reuses the snapshot rather
+        # than shelling out to the backend again.
+        before = len(calls)
+        _get(base, "/section/network/status")
+        assert len(calls) == before
+        # Scan bypasses the cache so a freshly plugged NIC appears at once.
+        _get(base, "/section/network/status?scan=1")
+        assert len(calls) == before + 1
+    finally:
+        server.stop()

--- a/tests/test_web_network_write.py
+++ b/tests/test_web_network_write.py
@@ -74,6 +74,7 @@ class FakeNetwork:
         self.renewed: list[str] = []
         self.apply_result = ApplyResult(ok=True)
         self.renew_result = ApplyResult(ok=True)
+        self.provide_rows = True
 
     def config_provider(self, iface: str | None = None) -> dict | None:
         if not self.interfaces:
@@ -98,8 +99,11 @@ class FakeNetwork:
 
         Wired into the fixture so the list tests exercise the real row shape
         instead of the synthesised fallback ``_build_network_form_context``
-        falls back to when no provider is present.
+        falls back to when no provider is present. Set ``provide_rows=False``
+        to exercise that fallback.
         """
+        if not self.provide_rows:
+            return []
         return [
             {
                 "name": name,
@@ -785,4 +789,18 @@ def test_interface_rows_come_from_the_provider(net_server) -> None:
     _fake, base = net_server
     _status, body = _get(base, "/section/network/status")
     assert "eth0" in body and "wlan0" in body
+    assert "10.0.0.5" in body
+
+
+def test_card_synthesises_rows_when_no_interface_provider_is_wired(net_server) -> None:
+    """A build without the richer provider (or one whose backend read failed)
+    still has to render every adapter - the card degrades to the single-
+    interface snapshot rather than showing an empty list."""
+    fake, base = net_server
+    fake.provide_rows = False
+    # ?scan=1 bypasses the TTL cache the earlier requests populated.
+    status, body = _get(base, "/section/network/status?scan=1")
+    assert status == 200
+    assert "eth0" in body and "wlan0" in body
+    # Only the open interface carries detail on this path.
     assert "10.0.0.5" in body

--- a/tests/test_web_network_write.py
+++ b/tests/test_web_network_write.py
@@ -615,6 +615,17 @@ def test_active_interface_is_expanded_and_others_offer_configure(net_server) -> 
     assert "/section/network/status/eth0" not in body
 
 
+def test_view_mode_can_expand_an_interface_read_only(net_server) -> None:
+    """DNS and lease live in the detail, so View mode has to be able to open a
+    row - otherwise reading a value would mean entering Edit mode."""
+    _fake, base = net_server
+    status, body = _get(base, "/section/network/status/wlan0")
+    assert status == 200
+    assert "Configure <code>wlan0</code>" in body
+    assert "disabled" in body
+    assert ">Apply<" not in body
+
+
 def test_configure_expands_the_named_interface(net_server) -> None:
     """The interface is named in the path, so which adapter is being edited
     can't be ambiguous."""

--- a/tests/test_web_network_write.py
+++ b/tests/test_web_network_write.py
@@ -93,6 +93,25 @@ class FakeNetwork:
             "lease_display": self.lease_display,
         }
 
+    def interfaces_provider(self) -> list[dict]:
+        """What the services layer emits for the interface list.
+
+        Wired into the fixture so the list tests exercise the real row shape
+        instead of the synthesised fallback ``_build_network_form_context``
+        falls back to when no provider is present.
+        """
+        return [
+            {
+                "name": name,
+                "is_up": True,
+                "address": self.address if name == self.interfaces[0] else "",
+                "prefix": self.prefix if name == self.interfaces[0] else None,
+                "subnet_mask": self.subnet_mask if name == self.interfaces[0] else "",
+                "method": self.method,
+            }
+            for name in self.interfaces
+        ]
+
     def apply_handler(self, iface: str, config: object) -> ApplyResult:
         self.applied.append((iface, config))
         return self.apply_result
@@ -171,6 +190,7 @@ def net_server(tmp_path, monkeypatch):
         port=port,
         system_name="TestSystem",
         network_config_provider=fake.config_provider,
+        network_interfaces_provider=fake.interfaces_provider,
         network_apply_handler=fake.apply_handler,
         network_renew_handler=fake.renew_handler,
     )
@@ -611,8 +631,12 @@ def test_active_interface_is_expanded_and_others_offer_configure(net_server) -> 
     _status, body = _get(base, "/section/network/status")
     # eth0 is FakeNetwork's active interface: expanded, so no button of its own.
     assert "Configure <code>eth0</code>" in body
-    assert "/section/network/status/wlan0" in body
-    assert "/section/network/status/eth0" not in body
+    # Assert on the button, not the bare path – the 5s poll also carries the
+    # expanded interface in its URL, so a substring check would match that.
+    assert '/section/network/status/wlan0"' in body
+    buttons = [seg for seg in body.split("<button") if ">Configure</button>" in seg]
+    assert any("/section/network/status/wlan0" in b for b in buttons)
+    assert not any("/section/network/status/eth0" in b for b in buttons)
 
 
 def test_view_mode_can_expand_an_interface_read_only(net_server) -> None:
@@ -718,3 +742,47 @@ def test_interface_list_uses_the_richer_provider_when_wired(tmp_path, monkeypatc
         assert len(calls) == before + 1
     finally:
         server.stop()
+
+
+# --------------------------------------------------------------------------- #
+# Expanded-row survival: poll, Cancel and Scan must not move the expansion
+# --------------------------------------------------------------------------- #
+
+
+def test_view_poll_carries_the_expanded_interface(net_server) -> None:
+    """The 5s poll used to GET the iface-less route, so a row opened in View
+    mode collapsed back to the active interface every five seconds and could
+    not be read."""
+    _fake, base = net_server
+    status, body = _get(base, "/section/network/status/wlan0")
+    assert status == 200
+    assert "/section/network/status/wlan0" in body
+    assert "every 5s" in body
+
+
+def test_cancel_returns_to_view_mode_on_the_same_row(net_server) -> None:
+    """Cancel targeted /section/network/edit, which re-rendered the editor –
+    leaving Edit mode with no exit short of a page reload."""
+    _fake, base = net_server
+    status, body = _get(base, "/section/network/edit/wlan0")
+    assert status == 200
+    cancel = body[body.index(">Cancel<") - 400 : body.index(">Cancel<")]
+    assert "/section/network/status/wlan0" in cancel
+    assert "/section/network/edit" not in cancel
+
+
+def test_scan_keeps_the_open_interface(net_server) -> None:
+    """Scan dropped the iface segment, so re-reading the adapter list moved the
+    expansion and discarded anything typed into the editor."""
+    _fake, base = net_server
+    _status, body = _get(base, "/section/network/edit/wlan0")
+    assert "/section/network/edit/wlan0?scan=1" in body
+
+
+def test_interface_rows_come_from_the_provider(net_server) -> None:
+    """Exercises the real provider row shape rather than the synthesised
+    fallback the card uses when no provider is wired."""
+    _fake, base = net_server
+    _status, body = _get(base, "/section/network/status")
+    assert "eth0" in body and "wlan0" in body
+    assert "10.0.0.5" in body

--- a/tests/test_web_routes_unit.py
+++ b/tests/test_web_routes_unit.py
@@ -1190,3 +1190,52 @@ class TestApplyInterfaceAssignment:
         cfg.otp_output.port = 999999
         apply_section_data(cfg, "interface_assignment", {"psn_source_iface": "eth0"})
         assert cfg.otp_output.port == 999999
+
+
+class TestRequestLocalIface:
+    """``request_local_iface`` answers "which adapter did this operator reach
+    us on", which guards them from editing that adapter and dropping their own
+    session. It reads the connection's local address, not the Host header:
+    with the default wildcard bind the operator usually arrives via
+    ``<slug>.local``, so the header holds a name."""
+
+    KEY = "openfollow.local_addr"
+
+    def test_resolves_a_local_address_to_its_interface(self, monkeypatch) -> None:
+        import socket
+        from types import SimpleNamespace
+
+        import openfollow.net_utils as net_utils_module
+
+        monkeypatch.setattr(
+            net_utils_module.psutil,
+            "net_if_addrs",
+            lambda: {
+                "eth0": [SimpleNamespace(family=socket.AF_INET, address="192.168.1.5")],
+                "eth1": [SimpleNamespace(family=socket.AF_INET, address="10.0.0.9")],
+            },
+        )
+        assert routes_module.request_local_iface({self.KEY: "10.0.0.9"}) == "eth1"
+
+    def test_missing_key_yields_no_marker(self) -> None:
+        """Any WSGI server that doesn't supply the address (a test harness, a
+        future front-end) must degrade to no marker, not raise."""
+        assert routes_module.request_local_iface({}) == ""
+
+    @pytest.mark.parametrize("addr", ["", "   ", None])
+    def test_blank_address_yields_no_marker(self, addr: object) -> None:
+        assert routes_module.request_local_iface({self.KEY: addr}) == ""
+
+    def test_loopback_yields_no_marker(self) -> None:
+        """A loopback connection is the on-screen embedded browser, which no
+        interface change can disconnect – marking one would be misleading."""
+        assert routes_module.request_local_iface({self.KEY: "127.0.0.1"}) == ""
+
+    def test_unknown_address_yields_no_marker(self, monkeypatch) -> None:
+        """Rather than guess when the address matches no local interface: a
+        missing marker is a missed warning, a wrong one points at the wrong
+        adapter."""
+        import openfollow.net_utils as net_utils_module
+
+        monkeypatch.setattr(net_utils_module.psutil, "net_if_addrs", dict)
+        assert routes_module.request_local_iface({self.KEY: "203.0.113.7"}) == ""

--- a/tests/test_web_routes_unit.py
+++ b/tests/test_web_routes_unit.py
@@ -66,6 +66,7 @@ from openfollow.web.routes import (
     _swap_for_direction,
     _wizard_camera_params,
     apply_section_data,
+    build_interface_assignment_rows,
     strip_device_local_fields,
 )
 
@@ -1043,3 +1044,149 @@ class TestOperatorMessagesSection:
             {"btn_clear_messages": "START"},
         )
         assert cfg.controller.btn_clear_messages == "START"
+
+
+# ---------------------------------------------------------------------------
+# Interface Assignment panel
+# ---------------------------------------------------------------------------
+
+
+class TestInterfaceAssignmentRows:
+    """``build_interface_assignment_rows`` resolves every row's live address
+    through the same pin -> station -> auto chain the runtime uses, so the
+    panel shows where a plane will actually bind rather than just its pin."""
+
+    @staticmethod
+    def _ifaces(monkeypatch, spec: dict[str, str]) -> None:
+        import socket
+        from types import SimpleNamespace
+
+        import openfollow.net_utils as net_utils_module
+
+        monkeypatch.setattr(
+            net_utils_module.psutil,
+            "net_if_addrs",
+            lambda: {name: [SimpleNamespace(family=socket.AF_INET, address=addr)] for name, addr in spec.items()},
+        )
+
+    def test_station_row_owns_psn_source_iface(self, monkeypatch) -> None:
+        self._ifaces(monkeypatch, {"eth0": "192.168.1.5"})
+        cfg = AppConfig(psn_source_iface="eth0")
+        rows = {r["label"]: r for r in build_interface_assignment_rows(cfg)}
+        station = rows["Station default"]
+        assert station["key"] == "psn_source_iface"
+        assert station["value"] == "eth0"
+        assert station["address"] == "192.168.1.5"
+        # The station picker has nothing to follow, so it keeps auto-detect.
+        assert station["blank"] == "auto"
+
+    def test_blank_plane_pin_shows_the_station_address(self, monkeypatch) -> None:
+        """An OTP row left on "follow station" must display where it actually
+        points – an empty cell would hide the indirection entirely."""
+        self._ifaces(monkeypatch, {"eth0": "192.168.1.5", "eth1": "10.0.0.9"})
+        cfg = AppConfig(psn_source_iface="eth0")
+        cfg.otp_output.source_iface = ""
+        rows = {r["label"]: r for r in build_interface_assignment_rows(cfg)}
+        assert rows["OTP output"]["value"] == ""
+        assert rows["OTP output"]["address"] == "192.168.1.5"
+        assert rows["OTP output"]["blank"] == "station"
+
+    def test_pinned_plane_shows_its_own_address(self, monkeypatch) -> None:
+        self._ifaces(monkeypatch, {"eth0": "192.168.1.5", "eth1": "10.0.0.9"})
+        cfg = AppConfig(psn_source_iface="eth0")
+        cfg.otp_output.source_iface = "eth1"
+        rows = {r["label"]: r for r in build_interface_assignment_rows(cfg)}
+        assert rows["OTP output"]["address"] == "10.0.0.9"
+
+    def test_station_followers_are_read_only(self, monkeypatch) -> None:
+        """PSN and discovery carry the station's identity on the network, so
+        they follow the station pin and must not offer their own dropdown –
+        a picker would imply an independence they don't have."""
+        self._ifaces(monkeypatch, {"eth0": "192.168.1.5"})
+        cfg = AppConfig(psn_source_iface="eth0")
+        rows = {r["label"]: r for r in build_interface_assignment_rows(cfg)}
+        for label in ("PSN in / out", "Discovery / marker sync"):
+            assert rows[label]["editable"] is False
+            assert rows[label]["key"] == ""
+            assert rows[label]["address"] == "192.168.1.5"
+
+    def test_every_editable_row_maps_to_a_known_target(self, monkeypatch) -> None:
+        """Guards the panel against growing a control the save path can't
+        write – the row list and the target map have to stay in step."""
+        self._ifaces(monkeypatch, {"eth0": "192.168.1.5"})
+        rows = build_interface_assignment_rows(AppConfig())
+        editable = {r["key"] for r in rows if r["editable"]}
+        assert editable == set(routes_module._INTERFACE_ASSIGNMENT_TARGETS)
+
+
+class TestApplyInterfaceAssignment:
+    """The panel writes across several owning dataclasses in one save."""
+
+    def test_writes_top_level_and_sub_config_pins(self) -> None:
+        cfg = AppConfig()
+        apply_section_data(
+            cfg,
+            "interface_assignment",
+            {"psn_source_iface": "eth0", "otp_output.source_iface": "eth1"},
+        )
+        assert cfg.psn_source_iface == "eth0"
+        assert cfg.otp_output.source_iface == "eth1"
+
+    def test_strips_whitespace_like_post_init(self) -> None:
+        """A stray-space pin would compare unequal to the stored value on
+        every hot-reload pass and trigger a needless socket rebind."""
+        cfg = AppConfig()
+        apply_section_data(
+            cfg,
+            "interface_assignment",
+            {"psn_source_iface": "  eth0  ", "otp_output.source_iface": "\teth1 "},
+        )
+        assert cfg.psn_source_iface == "eth0"
+        assert cfg.otp_output.source_iface == "eth1"
+
+    def test_absent_key_leaves_current_value(self) -> None:
+        cfg = AppConfig(psn_source_iface="eth0")
+        cfg.otp_output.source_iface = "eth1"
+        apply_section_data(cfg, "interface_assignment", {"psn_source_iface": "eth2"})
+        assert cfg.psn_source_iface == "eth2"
+        assert cfg.otp_output.source_iface == "eth1"
+
+    def test_blank_clears_a_pin(self) -> None:
+        """Selecting "follow station interface" has to be able to undo a pin."""
+        cfg = AppConfig()
+        cfg.otp_output.source_iface = "eth1"
+        apply_section_data(cfg, "interface_assignment", {"otp_output.source_iface": ""})
+        assert cfg.otp_output.source_iface == ""
+
+    def test_none_pin_preserves_current(self) -> None:
+        cfg = AppConfig(psn_source_iface="eth0")
+        apply_section_data(cfg, "interface_assignment", {"psn_source_iface": None})
+        assert cfg.psn_source_iface == "eth0"
+
+    @pytest.mark.parametrize("bad", [0, True, ["eth0"]])
+    def test_non_string_pin_still_stores_a_string(self, bad: object) -> None:
+        """A crafted POST must never leave a non-string in a field the runtime
+        hands to socket binding. Matching the existing ``psn`` / ``otp_output``
+        save paths, the value is stringified rather than rejected: the result
+        is a nonsense interface name that resolves to nothing and falls through
+        to the station pin, so output degrades rather than crashing."""
+        cfg = AppConfig(psn_source_iface="eth0")
+        apply_section_data(cfg, "interface_assignment", {"psn_source_iface": bad})
+        assert isinstance(cfg.psn_source_iface, str)
+
+    def test_post_init_reruns_on_touched_configs(self) -> None:
+        """The re-run is what stops a crafted POST bypassing validation a
+        hand-edited TOML would trip – prove it by smuggling an out-of-range
+        sibling field past the parser and watching it get clamped."""
+        cfg = AppConfig()
+        cfg.otp_output.port = 999999
+        apply_section_data(cfg, "interface_assignment", {"otp_output.source_iface": "eth1"})
+        assert cfg.otp_output.port == 65535
+
+    def test_untouched_config_is_not_renormalised(self) -> None:
+        """``__post_init__`` runs only on the dataclasses the save touched, so
+        a panel save can't silently rewrite an unrelated section."""
+        cfg = AppConfig()
+        cfg.otp_output.port = 999999
+        apply_section_data(cfg, "interface_assignment", {"psn_source_iface": "eth0"})
+        assert cfg.otp_output.port == 999999

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -624,6 +624,46 @@ def test_network_interfaces_by_name_empty_current_does_not_fall_back_to_psn(
     assert "selected" not in body
 
 
+def test_psn_save_preserves_pin_now_that_the_picker_moved(live_server) -> None:
+    """The PSN section no longer posts ``psn_source_iface`` – its picker moved
+    to Interface Assignment. Saving PSN must leave the pin alone rather than
+    clearing it, which is the silent-data-loss trap of dropping a form field."""
+    server, base = live_server
+    cfg = load_config(server.config_path)
+    cfg.psn_source_iface = "eth0"
+    save_config(cfg, server.config_path)
+
+    status, _body = _post_form(
+        base,
+        "/section/psn",
+        {"psn_system_name": "Stage Left", "psn_mcast_ip": "236.10.10.10"},
+    )
+    assert status == 200
+
+    saved = load_config(server.config_path)
+    assert saved.psn_system_name == "Stage Left"
+    assert saved.psn_source_iface == "eth0"
+
+
+def test_otp_save_preserves_pin_now_that_the_picker_moved(live_server) -> None:
+    """Same guard for OTP: its Save posts no ``source_iface`` any more."""
+    server, base = live_server
+    cfg = load_config(server.config_path)
+    cfg.otp_output.source_iface = "eth1"
+    save_config(cfg, server.config_path)
+
+    status, _body = _post_form(
+        base,
+        "/section/otp_output",
+        {"port": "5568", "system_number": "3", "priority": "100"},
+    )
+    assert status == 200
+
+    saved = load_config(server.config_path)
+    assert saved.otp_output.system_number == 3
+    assert saved.otp_output.source_iface == "eth1"
+
+
 def test_interface_assignment_renders_rows_with_resolved_addresses(
     live_server,
     monkeypatch,

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -624,6 +624,56 @@ def test_network_interfaces_by_name_empty_current_does_not_fall_back_to_psn(
     assert "selected" not in body
 
 
+def test_network_interfaces_by_name_blank_station_relabels_empty_option(
+    live_server,
+    monkeypatch,
+) -> None:
+    """Per-plane pickers ask for ``?blank=station``: an empty pin there means
+    "follow the station interface", not "let the OS choose", and the label has
+    to say so or the indirection is invisible."""
+    import socket as _socket
+    from types import SimpleNamespace
+
+    from openfollow import net_utils as net_utils_mod
+
+    monkeypatch.setattr(
+        net_utils_mod.psutil,
+        "net_if_addrs",
+        lambda: {"eth0": [SimpleNamespace(family=_socket.AF_INET, address="192.168.178.59")]},
+    )
+    _server, base = live_server
+
+    status, body = _get(base, "/network/interfaces/by_name?blank=station&current=")
+    assert status == 200
+    assert "Follow station interface" in body
+    assert "Auto-detect" not in body
+
+
+def test_network_interfaces_by_name_unknown_blank_falls_back_to_auto_detect(
+    live_server,
+    monkeypatch,
+) -> None:
+    """The blank label is allow-listed, never interpolated – an unknown (or
+    crafted) ``?blank=`` renders the default wording rather than reaching the
+    HTML."""
+    import socket as _socket
+    from types import SimpleNamespace
+
+    from openfollow import net_utils as net_utils_mod
+
+    monkeypatch.setattr(
+        net_utils_mod.psutil,
+        "net_if_addrs",
+        lambda: {"eth0": [SimpleNamespace(family=_socket.AF_INET, address="192.168.178.59")]},
+    )
+    _server, base = live_server
+
+    status, body = _get(base, "/network/interfaces/by_name?blank=%3Cscript%3E&current=")
+    assert status == 200
+    assert "Auto-detect" in body
+    assert "<script>" not in body
+
+
 # ---------------------------------------------------------------------------
 # JSON API – shape and content
 # ---------------------------------------------------------------------------

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -702,6 +702,66 @@ def test_interface_assignment_renders_rows_with_resolved_addresses(
     assert "10.0.0.9" in body
 
 
+def test_interface_assignment_shows_a_down_interface_as_an_error(
+    live_server,
+    monkeypatch,
+) -> None:
+    """A configured interface with no address must not render as some other
+    interface's address – the plane will not send there."""
+    import socket as _socket
+    from types import SimpleNamespace
+
+    from openfollow import net_utils as net_utils_mod
+
+    monkeypatch.setattr(
+        net_utils_mod.psutil,
+        "net_if_addrs",
+        lambda: {"eth0": [SimpleNamespace(family=_socket.AF_INET, address="192.168.178.59")]},
+    )
+    server, base = live_server
+    cfg = load_config(server.config_path)
+    cfg.psn_source_iface = "eth0"
+    cfg.otp_output.source_iface = "eth_gone"
+    save_config(cfg, server.config_path)
+
+    status, body = _get(base, "/section/interface_assignment")
+    assert status == 200
+    # Scope to the OTP row: the station-following rows legitimately carry the
+    # station address, and it must not leak into OTP's cell.
+    otp_row = body[body.index("OTP output") :].split("</tr>", 1)[0]
+    assert "eth_gone is down" in otp_row
+    assert "192.168.178.59" not in otp_row
+
+
+def test_interface_assignment_scan_rerenders_the_panel(live_server) -> None:
+    """Scan re-renders instead of refreshing the pickers in place: an in-place
+    refresh re-marked the SAVED value as selected and silently discarded an
+    unsaved choice."""
+    _server, base = live_server
+    _status, body = _get(base, "/section/interface_assignment")
+    assert 'hx-get="/section/interface_assignment"' in body
+    assert 'hx-target="#interface-assignment-section"' in body
+    # The pickers load once and are not re-fetched by Scan.
+    assert "click from:#refresh-iface-assignment" not in body
+
+
+def test_interface_assignment_pickers_have_accessible_names(live_server) -> None:
+    """A <th scope="row"> names cells, not a nested control."""
+    _server, base = live_server
+    _status, body = _get(base, "/section/interface_assignment")
+    assert 'aria-label="Station default interface"' in body
+    assert 'aria-label="OTP output interface"' in body
+
+
+def test_protocol_sections_link_switches_to_the_general_tab(live_server) -> None:
+    """A bare href="#id" does nothing when the target sits in a display:none
+    tab, so the pointer had no effect at all."""
+    _server, base = live_server
+    for path in ("/section/psn", "/section/otp_output"):
+        _status, body = _get(base, path)
+        assert "goToSection('general', 'interface-assignment')" in body
+
+
 def test_interface_assignment_save_round_trips_to_disk(
     live_server,
     monkeypatch,

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -624,6 +624,107 @@ def test_network_interfaces_by_name_empty_current_does_not_fall_back_to_psn(
     assert "selected" not in body
 
 
+def test_interface_assignment_renders_rows_with_resolved_addresses(
+    live_server,
+    monkeypatch,
+) -> None:
+    """The panel shows where each plane will actually bind, including rows
+    left on "follow station" – an empty cell would hide the indirection."""
+    import socket as _socket
+    from types import SimpleNamespace
+
+    from openfollow import net_utils as net_utils_mod
+
+    monkeypatch.setattr(
+        net_utils_mod.psutil,
+        "net_if_addrs",
+        lambda: {
+            "eth0": [SimpleNamespace(family=_socket.AF_INET, address="192.168.178.59")],
+            "eth1": [SimpleNamespace(family=_socket.AF_INET, address="10.0.0.9")],
+        },
+    )
+    server, base = live_server
+    cfg = load_config(server.config_path)
+    cfg.psn_source_iface = "eth0"
+    cfg.otp_output.source_iface = "eth1"
+    save_config(cfg, server.config_path)
+
+    status, body = _get(base, "/section/interface_assignment")
+    assert status == 200
+    assert "Station default" in body
+    assert "OTP output" in body
+    # PSN follows the station pin and has no picker of its own.
+    assert "PSN in / out" in body
+    assert 'name="psn_source_iface"' in body
+    assert 'name="otp_output.source_iface"' in body
+    # Both resolved addresses are on screen: the station's and the OTP pin's.
+    assert "192.168.178.59" in body
+    assert "10.0.0.9" in body
+
+
+def test_interface_assignment_save_round_trips_to_disk(
+    live_server,
+    monkeypatch,
+) -> None:
+    """One POST writes pins that live on different owning dataclasses."""
+    import socket as _socket
+    from types import SimpleNamespace
+
+    from openfollow import net_utils as net_utils_mod
+
+    monkeypatch.setattr(
+        net_utils_mod.psutil,
+        "net_if_addrs",
+        lambda: {
+            "eth0": [SimpleNamespace(family=_socket.AF_INET, address="192.168.178.59")],
+            "eth1": [SimpleNamespace(family=_socket.AF_INET, address="10.0.0.9")],
+        },
+    )
+    server, base = live_server
+
+    status, body = _post_form(
+        base,
+        "/section/interface_assignment",
+        {"psn_source_iface": "eth0", "otp_output.source_iface": "eth1"},
+    )
+    assert status == 200
+    assert "saved" in body
+
+    saved = load_config(server.config_path)
+    assert saved.psn_source_iface == "eth0"
+    assert saved.otp_output.source_iface == "eth1"
+
+
+def test_interface_assignment_save_can_clear_a_pin(
+    live_server,
+    monkeypatch,
+) -> None:
+    """Selecting "follow station interface" must undo a pin – otherwise a
+    plane can be moved onto its own NIC but never moved back."""
+    import socket as _socket
+    from types import SimpleNamespace
+
+    from openfollow import net_utils as net_utils_mod
+
+    monkeypatch.setattr(
+        net_utils_mod.psutil,
+        "net_if_addrs",
+        lambda: {"eth0": [SimpleNamespace(family=_socket.AF_INET, address="192.168.178.59")]},
+    )
+    server, base = live_server
+    cfg = load_config(server.config_path)
+    cfg.otp_output.source_iface = "eth1"
+    save_config(cfg, server.config_path)
+
+    status, _body = _post_form(
+        base,
+        "/section/interface_assignment",
+        {"psn_source_iface": "eth0", "otp_output.source_iface": ""},
+    )
+    assert status == 200
+    assert load_config(server.config_path).otp_output.source_iface == ""
+
+
 def test_network_interfaces_by_name_blank_station_relabels_empty_option(
     live_server,
     monkeypatch,

--- a/tests/test_web_server_unit.py
+++ b/tests/test_web_server_unit.py
@@ -1246,3 +1246,27 @@ class TestGetNetworkInterfaces:
         )
         srv.get_network_interfaces().append({"name": "bogus"})
         assert [r["name"] for r in srv.get_network_interfaces()] == ["eth0"]
+
+    def test_caller_cannot_mutate_a_cached_row(self, tmp_path, monkeypatch) -> None:
+        """Copying only the list leaves every caller holding the cached dicts,
+        so a helper decorating a row corrupts the next render."""
+        srv = _make_quiet_server(
+            tmp_path,
+            monkeypatch,
+            network_interfaces_provider=lambda: [{"name": "eth0"}],
+        )
+        srv.get_network_interfaces()[0]["name"] = "corrupted"
+        assert [r["name"] for r in srv.get_network_interfaces()] == ["eth0"]
+
+    def test_the_provider_cannot_mutate_the_cache_afterwards(self, tmp_path, monkeypatch) -> None:
+        """The services provider rebuilds its rows each call, but a future one
+        reusing dicts must not reach into what is already cached."""
+        rows = [{"name": "eth0"}]
+        srv = _make_quiet_server(
+            tmp_path,
+            monkeypatch,
+            network_interfaces_provider=lambda: rows,
+        )
+        srv.get_network_interfaces()
+        rows[0]["name"] = "corrupted"
+        assert [r["name"] for r in srv.get_network_interfaces()] == ["eth0"]

--- a/tests/test_web_server_unit.py
+++ b/tests/test_web_server_unit.py
@@ -1177,3 +1177,72 @@ def test_get_local_peer_info_throttles_ip_refresh(tmp_path, monkeypatch) -> None
     srv._local_ip_refresh_ts -= 1000.0
     srv.get_local_peer_info()
     assert calls["n"] == 2
+
+
+class TestGetNetworkInterfaces:
+    """The Network Settings interface list costs one backend call per adapter,
+    so it is TTL-cached; ``Scan`` bypasses the cache."""
+
+    def test_no_provider_returns_empty(self, tmp_path, monkeypatch) -> None:
+        """Stations wiring only the single-interface provider must degrade to
+        an empty list, not raise – the card falls back to synthesising rows."""
+        srv = _make_quiet_server(tmp_path, monkeypatch)
+        assert srv.get_network_interfaces() == []
+
+    def test_second_call_inside_ttl_reuses_the_snapshot(self, tmp_path, monkeypatch) -> None:
+        calls: list[int] = []
+
+        def _provider() -> list[dict]:
+            calls.append(1)
+            return [{"name": "eth0", "address": "10.0.0.5"}]
+
+        srv = _make_quiet_server(tmp_path, monkeypatch, network_interfaces_provider=_provider)
+        assert srv.get_network_interfaces()[0]["name"] == "eth0"
+        assert srv.get_network_interfaces()[0]["name"] == "eth0"
+        assert len(calls) == 1
+
+    def test_force_bypasses_the_cache(self, tmp_path, monkeypatch) -> None:
+        """Scan has to show a just-plugged adapter without waiting out the TTL."""
+        calls: list[int] = []
+
+        def _provider() -> list[dict]:
+            calls.append(1)
+            return [{"name": "eth0"}]
+
+        srv = _make_quiet_server(tmp_path, monkeypatch, network_interfaces_provider=_provider)
+        srv.get_network_interfaces()
+        srv.get_network_interfaces(force=True)
+        assert len(calls) == 2
+
+    def test_provider_failure_serves_the_last_good_snapshot(self, tmp_path, monkeypatch) -> None:
+        """A transient backend failure must not blank the interface list -
+        stale rows are far more useful than an empty card."""
+        state = {"fail": False}
+
+        def _provider() -> list[dict]:
+            if state["fail"]:
+                raise RuntimeError("nmcli exploded")
+            return [{"name": "eth0", "address": "10.0.0.5"}]
+
+        srv = _make_quiet_server(tmp_path, monkeypatch, network_interfaces_provider=_provider)
+        assert srv.get_network_interfaces()[0]["address"] == "10.0.0.5"
+        state["fail"] = True
+        assert srv.get_network_interfaces(force=True)[0]["address"] == "10.0.0.5"
+
+    def test_provider_failure_with_no_snapshot_yet_returns_empty(self, tmp_path, monkeypatch) -> None:
+        def _provider() -> list[dict]:
+            raise RuntimeError("nmcli exploded")
+
+        srv = _make_quiet_server(tmp_path, monkeypatch, network_interfaces_provider=_provider)
+        assert srv.get_network_interfaces() == []
+
+    def test_caller_cannot_mutate_the_cache(self, tmp_path, monkeypatch) -> None:
+        """Rows are handed out as a copy, so a template helper decorating them
+        can't corrupt what the next render reads."""
+        srv = _make_quiet_server(
+            tmp_path,
+            monkeypatch,
+            network_interfaces_provider=lambda: [{"name": "eth0"}],
+        )
+        srv.get_network_interfaces().append({"name": "bogus"})
+        assert [r["name"] for r in srv.get_network_interfaces()] == ["eth0"]


### PR DESCRIPTION
First of the stacked PRs for #50. It builds the editing surface and the
resolution rule the rest of the feature hangs off, using the two interface pins
that already exist.

## The rule

Every network function stays on the interface it was configured for.

`resolve_plane_source_ip(pin, station_iface)` inherits for an **unset** value
only: a blank pin follows the station default, a blank station default
auto-detects. Once an interface *is* configured it is the only one that plane
may use - if it currently has no address the plane binds **nothing**, says so,
and waits.

It deliberately does **not** fall through to another interface. On a show, an
output that has stopped is something an operator can see and diagnose; one that
quietly reappeared on the office LAN because a lighting VLAN dropped is not,
and it puts stage data on a network nobody chose.

The *address* is free to change. A reconnect that yields a different DHCP lease
on the same interface is normal and is followed. Only the interface is fixed.

### "" and None are different

Every downstream socket reads an empty source address as *auto-detect*:
`OtpServer` skips `iface_ip` and follows the OS routing table, `PsnServer` runs
`resolve_iface_ip("")` and picks the primary. So "no address" cannot be
signalled with `""`.

`station_source_ip_or_none()` and `_resolved_plane_source_ip()` return `None`
for a configured-but-down interface, and `init_psn` / `init_otp` / the OTP
live-restart all treat that as **do not start**. `""` still means nothing was
configured and auto-detect found nothing.

## Why editing is central but storage is not

Each pin stays on the sub-config that owns its protocol - the
`otp_output.source_iface` precedent - so the existing per-section save,
hot-reload and device-local machinery applies unchanged and the panel needs no
dispatch of its own.

Editing is centralised in one **Interface Assignment** panel on the General tab,
because "which network does each function use" was un-answerable without
visiting six cards. The protocol sections lose their inline pickers and point at
the panel instead.

PSN in/out and Discovery/marker sync render **read-only**: they carry this
station's identity - the address other stations and consoles see it at - so
splitting them from the station default would mean the box advertised one
address and answered on another.

The Address column resolves live, and shows `<iface> is down` rather than some
other interface's address. A row promising a working address for a plane that
is stopped would be a lie.

Changing only the Station default row now repoints the planes that follow it:
they are gated on their own dataclass differing, which it isn't in that case, so
the panel used to advertise a new address for an output still sending from the
old interface.

## Why Network Settings was restructured

Its `Interface` dropdown showed one adapter at a time, so a multi-NIC or
tagged-VLAN station had nowhere to see its own layout, and "which interface am I
editing?" was ambiguous. It now lists every non-loopback interface with address,
method and up-state, and `Configure` expands that interface's form beneath its
own row.

`get_state` shells out to `nmcli` per interface, so the list is TTL-cached with
`Scan` forcing a refresh. Rows are handed out as copies - of the list *and* each
dict - so a template helper decorating one can't corrupt the next render.

The `This session` badge marks the interface the browser actually arrived over.
It is the only badge: one for the pinned web-UI interface was designed and
dropped, because it would be absent in the default all-interfaces configuration,
exactly when an accidental change is most likely.

## Deliberate behaviour change

A station that pins `psn_source_iface` and leaves `otp_output.source_iface`
blank previously sent OTP out the OS-primary interface. It now follows the
station pin. Needs a release-note line; stations that pin nothing are
unaffected.

## Out of scope

- **Multi-bind** (N interfaces per receiver). One pin per plane.
- **Independent pins for PSN, discovery and catalog sync** - they follow the
  station, shown read-only.
- **Runtime repointing** when an interface changes address or goes away - that
  is #67, stacked on this.
- Every remaining row (web UI, OSC in, RTTrPM, OSC destinations, video input),
  each of which lands with its own config field in a later PR.

## Verification

`make ci-remote` green on the Pi (aarch64 / Python 3.13): lint, mypy, bandit,
1006 tests, 100.00% coverage, build.

**Not hardware-validated.** Needs a Pi to confirm a pinned plane stops rather
than moving when its interface goes dark, and that the panel and HUD agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
