### PR TITLE
feat(net): follow each plane's interface and stop when it goes dark

### DIFF
--- a/openfollow/app.py
+++ b/openfollow/app.py
@@ -469,6 +469,10 @@ class OpenFollowApp:
     def _animate(self) -> None:
         runtime_animate(self)
 
+    def _observe_network_planes(self) -> None:
+        """Keep each network plane on its configured interface (polled)."""
+        self._runtime_services.observe_network_planes()
+
     def _run_housekeeping(self) -> bool:
         return runtime_housekeeping(self)
 

--- a/openfollow/marker_catalog/sync.py
+++ b/openfollow/marker_catalog/sync.py
@@ -344,7 +344,7 @@ class MarkerCatalogSync:
         A no-op when the address is unchanged. That is *not* enough on its own:
         an interface that drops and returns with the same lease has had its
         memberships torn down by the kernel while the address string stayed
-        put, so the observer calls :meth:`reopen` for that case.
+        put, so the station-follower path calls :meth:`reopen` on recovery.
         """
         if iface_ip == self._iface_ip:
             return

--- a/openfollow/marker_catalog/sync.py
+++ b/openfollow/marker_catalog/sync.py
@@ -56,6 +56,13 @@ _SEND_ERROR_BACKOFF = HEARTBEAT_INTERVAL
 
 # Reject packets larger than 60KB to prevent receive buffer exhaustion.
 _MAX_RX_PACKET = 60 * 1024
+
+# Receive-socket open retries. An interface switch makes the address briefly
+# unavailable, so a single failure must not disable sync input for the session;
+# a permanently taken port must not spin forever either.
+_RX_OPEN_MAX_RETRIES = 5
+_RX_OPEN_RETRY_S = 1.0
+
 # Stay under a typical MTU so a beacon is never IP-fragmented on multicast.
 _MAX_TX_PACKET = 1400
 # ``json.dumps`` writes ", " between array items.
@@ -291,6 +298,9 @@ class MarkerCatalogSync:
         self._iface_ip = iface_ip
 
         self._stop_event = threading.Event()
+        # Set by ``update_iface_ip`` to make both loops drop and rebuild their
+        # sockets, so sync follows the station onto its new address.
+        self._reopen = threading.Event()
         self._send_thread: threading.Thread | None = None
         self._recv_thread: threading.Thread | None = None
 
@@ -312,6 +322,22 @@ class MarkerCatalogSync:
         self._envelope_log_ts = float("-inf")
 
     # -- Public API ----------------------------------------------------------
+
+    def update_iface_ip(self, iface_ip: str) -> None:
+        """Repoint both sockets after the station's address changed.
+
+        The TX socket pins ``IP_MULTICAST_IF`` and the RX socket joins
+        ``IP_ADD_MEMBERSHIP`` on the address they were opened with, and neither
+        notices when that address goes away – an idle recv times out rather
+        than raising, so nothing triggers a rebuild. Without this, sync stops
+        converging after an interface switch until the app restarts.
+
+        A no-op when the address is unchanged.
+        """
+        if iface_ip == self._iface_ip:
+            return
+        self._iface_ip = iface_ip
+        self._reopen.set()
 
     def start(self) -> None:
         if self._send_thread is not None:
@@ -433,6 +459,9 @@ class MarkerCatalogSync:
         sock: socket.socket | None = None
         next_heartbeat = time.monotonic()
         while not self._stop_event.is_set():
+            if self._reopen.is_set() and sock is not None:
+                sock.close()
+                sock = None
             if sock is None:
                 try:
                     sock = self._open_tx_socket()
@@ -598,7 +627,13 @@ class MarkerCatalogSync:
 
     # -- Receive path ---------------------------------------------------------
 
-    def _recv_loop(self) -> None:
+    def _open_rx_socket(self) -> socket.socket | None:
+        """Bind the catalog port and join the group on the current interface.
+
+        Returns ``None`` when the port can't be bound or the group can't be
+        joined at all; the caller retries so a transient failure during an
+        interface switch doesn't kill sync for the session.
+        """
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
@@ -610,7 +645,7 @@ class MarkerCatalogSync:
         except OSError as exc:
             logger.error("MarkerCatalogSync: bind failed: %s", exc)
             sock.close()
-            return
+            return None
 
         iface_addr = socket.inet_aton(self._iface_ip) if self._iface_ip else socket.inet_aton("0.0.0.0")
         mreq = socket.inet_aton(CATALOG_MCAST_GROUP) + iface_addr
@@ -628,19 +663,45 @@ class MarkerCatalogSync:
             except OSError as exc2:
                 logger.error("MarkerCatalogSync: fallback join failed: %s", exc2)
                 sock.close()
-                return
+                return None
         sock.settimeout(1.0)
-        try:
-            while not self._stop_event.is_set():
-                try:
-                    data, _addr = sock.recvfrom(_MAX_RX_PACKET)
-                except TimeoutError:
-                    continue
-                except OSError:
-                    continue
-                self._handle_packet(data)
-        finally:
-            sock.close()
+        return sock
+
+    def _recv_loop(self) -> None:
+        # Outer loop so a repoint rebuilds the socket: the group membership is
+        # bound to the address it was joined with, and an idle recv times out
+        # rather than raising, so nothing else would ever notice the change.
+        #
+        # A failed open is retried rather than fatal - during an interface
+        # switch the address is briefly gone - but only for a bounded run, so a
+        # permanently unavailable port logs and gives up instead of spinning
+        # for the life of the process.
+        failures = 0
+        while not self._stop_event.is_set():
+            sock = self._open_rx_socket()
+            if sock is None:
+                failures += 1
+                if failures >= _RX_OPEN_MAX_RETRIES:
+                    logger.error(
+                        "MarkerCatalogSync: receive socket unavailable after %d attempts; sync input disabled.",
+                        failures,
+                    )
+                    return
+                self._stop_event.wait(_RX_OPEN_RETRY_S)
+                continue
+            failures = 0
+            self._reopen.clear()
+            try:
+                while not self._stop_event.is_set() and not self._reopen.is_set():
+                    try:
+                        data, _addr = sock.recvfrom(_MAX_RX_PACKET)
+                    except TimeoutError:
+                        continue
+                    except OSError:
+                        continue
+                    self._handle_packet(data)
+            finally:
+                sock.close()
 
     def _handle_packet(self, data: bytes) -> None:
         decoded = _parse_beacon(data)

--- a/openfollow/marker_catalog/sync.py
+++ b/openfollow/marker_catalog/sync.py
@@ -54,13 +54,18 @@ _PEER_CAP_LOG_INTERVAL = 30.0
 # Back-off prevents CPU spin on persistent send failures.
 _SEND_ERROR_BACKOFF = HEARTBEAT_INTERVAL
 
+# Longest the send loop sleeps in one go, so a repoint is acted on within this
+# rather than at the next heartbeat.
+_REPOINT_CHECK_INTERVAL_S = 0.5
+
 # Reject packets larger than 60KB to prevent receive buffer exhaustion.
 _MAX_RX_PACKET = 60 * 1024
 
-# Receive-socket open retries. An interface switch makes the address briefly
-# unavailable, so a single failure must not disable sync input for the session;
-# a permanently taken port must not spin forever either.
-_RX_OPEN_MAX_RETRIES = 5
+# Receive-socket open retries. The budget has to outlast a DHCP re-lease
+# (5-15s is normal), because that is exactly the window the retry exists to
+# cover - a shorter one gives up in the case it was added for. A port that is
+# permanently taken still stops rather than spinning for the whole show.
+_RX_OPEN_MAX_RETRIES = 30
 _RX_OPEN_RETRY_S = 1.0
 
 # Stay under a typical MTU so a beacon is never IP-fragmented on multicast.
@@ -298,9 +303,13 @@ class MarkerCatalogSync:
         self._iface_ip = iface_ip
 
         self._stop_event = threading.Event()
-        # Set by ``update_iface_ip`` to make both loops drop and rebuild their
-        # sockets, so sync follows the station onto its new address.
-        self._reopen = threading.Event()
+        # One event per loop. A shared event is a trap: whichever loop wakes
+        # first clears it and the other never sees the repoint - the RX loop
+        # wakes within its 1s socket timeout while TX is parked for a whole
+        # heartbeat, so TX would keep IP_MULTICAST_IF on the dead address
+        # forever. ``web/discovery.py`` has the same shape for the same reason.
+        self._tx_reopen = threading.Event()
+        self._rx_reopen = threading.Event()
         self._send_thread: threading.Thread | None = None
         self._recv_thread: threading.Thread | None = None
 
@@ -332,12 +341,25 @@ class MarkerCatalogSync:
         than raising, so nothing triggers a rebuild. Without this, sync stops
         converging after an interface switch until the app restarts.
 
-        A no-op when the address is unchanged.
+        A no-op when the address is unchanged. That is *not* enough on its own:
+        an interface that drops and returns with the same lease has had its
+        memberships torn down by the kernel while the address string stayed
+        put, so the observer calls :meth:`reopen` for that case.
         """
         if iface_ip == self._iface_ip:
             return
         self._iface_ip = iface_ip
-        self._reopen.set()
+        self.reopen()
+
+    def reopen(self) -> None:
+        """Force both sockets to rebuild on their next loop iteration.
+
+        For a link that flapped: removing an address drops the multicast
+        membership and the egress route, and getting the identical address back
+        does not restore either.
+        """
+        self._tx_reopen.set()
+        self._rx_reopen.set()
 
     def start(self) -> None:
         if self._send_thread is not None:
@@ -459,10 +481,14 @@ class MarkerCatalogSync:
         sock: socket.socket | None = None
         next_heartbeat = time.monotonic()
         while not self._stop_event.is_set():
-            if self._reopen.is_set() and sock is not None:
+            if self._tx_reopen.is_set() and sock is not None:
                 sock.close()
                 sock = None
             if sock is None:
+                # Cleared BEFORE the open reads _iface_ip: clearing afterwards
+                # discards a repoint that landed in between, and nothing
+                # re-arms it.
+                self._tx_reopen.clear()
                 try:
                     sock = self._open_tx_socket()
                 except Exception:
@@ -506,7 +532,12 @@ class MarkerCatalogSync:
             with self._pending_lock:
                 if self._delta_due_at is not None:
                     wait_until = min(wait_until, self._delta_due_at)
-            wait = max(0.0, wait_until - time.monotonic())
+            # Capped so a repoint is picked up promptly. Parked on the full
+            # heartbeat, this loop would keep IP_MULTICAST_IF on the dead
+            # address for up to HEARTBEAT_INTERVAL after the address moved.
+            # The extra wakeups are a no-op - the heartbeat is scheduled by
+            # ``next_heartbeat``, not by how often the loop turns.
+            wait = min(max(0.0, wait_until - time.monotonic()), _REPOINT_CHECK_INTERVAL_S)
             self._stop_event.wait(wait)
 
         if sock is not None:
@@ -678,21 +709,30 @@ class MarkerCatalogSync:
         # for the life of the process.
         failures = 0
         while not self._stop_event.is_set():
+            # Cleared before the open, for the same reason as TX.
+            self._rx_reopen.clear()
             sock = self._open_rx_socket()
             if sock is None:
                 failures += 1
                 if failures >= _RX_OPEN_MAX_RETRIES:
+                    # Park instead of returning: the thread is never restarted
+                    # (``start()`` short-circuits while it exists), so exiting
+                    # here would disable sync input for the process with no way
+                    # back. A later repoint wakes it.
                     logger.error(
-                        "MarkerCatalogSync: receive socket unavailable after %d attempts; sync input disabled.",
+                        "MarkerCatalogSync: receive socket unavailable after %d attempts; "
+                        "sync input paused until the interface changes.",
                         failures,
                     )
-                    return
+                    while not self._stop_event.is_set() and not self._rx_reopen.is_set():
+                        self._stop_event.wait(_RX_OPEN_RETRY_S)
+                    failures = 0
+                    continue
                 self._stop_event.wait(_RX_OPEN_RETRY_S)
                 continue
             failures = 0
-            self._reopen.clear()
             try:
-                while not self._stop_event.is_set() and not self._reopen.is_set():
+                while not self._stop_event.is_set() and not self._rx_reopen.is_set():
                     try:
                         data, _addr = sock.recvfrom(_MAX_RX_PACKET)
                     except TimeoutError:

--- a/openfollow/net_utils.py
+++ b/openfollow/net_utils.py
@@ -35,7 +35,12 @@ def get_primary_local_ipv4(default: str = "N/A") -> str:
     except OSError:
         pass
 
-    for ip in get_local_ipv4_addresses():
+    # Sorted, not set-iteration order: on an offline show LAN the probe above
+    # always fails, so this branch decides the station's address. Unordered
+    # iteration makes that pick flip when an unrelated address appears (a VPN,
+    # docker0, a second lease), which reads downstream as a genuine IP change
+    # and repoints the data planes onto a network nobody chose.
+    for ip in sorted(get_local_ipv4_addresses()):
         if not ip.startswith("127."):
             return ip
 

--- a/openfollow/net_utils.py
+++ b/openfollow/net_utils.py
@@ -35,16 +35,35 @@ def get_primary_local_ipv4(default: str = "N/A") -> str:
     except OSError:
         pass
 
-    # Sorted, not set-iteration order: on an offline show LAN the probe above
+    # Ordered, not set-iteration order: on an offline show LAN the probe above
     # always fails, so this branch decides the station's address. Unordered
     # iteration makes that pick flip when an unrelated address appears (a VPN,
     # docker0, a second lease), which reads downstream as a genuine IP change
     # and repoints the data planes onto a network nobody chose.
-    for ip in sorted(get_local_ipv4_addresses()):
+    #
+    # Link-local sorts last rather than first: a station that took a 169.254
+    # address while DHCP was failing keeps advertising it after a real lease
+    # arrives, because "169." precedes "192." lexicographically. That address
+    # is the station's identity - what peers and consoles reach it at - so a
+    # real lease has to win.
+    for ip in sorted(get_local_ipv4_addresses(), key=_address_preference):
         if not ip.startswith("127."):
             return ip
 
     return default
+
+
+def _address_preference(ip: str) -> tuple[int, tuple[int, ...]]:
+    """Sort key preferring a routable address, then ordering numerically.
+
+    Numeric rather than lexicographic so ``10.0.0.9`` precedes ``10.0.0.10``;
+    the point is a stable pick, and digit-string order is stable but arbitrary.
+    """
+    try:
+        octets = tuple(int(part) for part in ip.split("."))
+    except ValueError:  # pragma: no cover - psutil only yields dotted quads
+        octets = ()
+    return (1 if ip.startswith("169.254.") else 0, octets)
 
 
 def get_local_ipv4_addresses() -> set[str]:

--- a/openfollow/otp/server.py
+++ b/openfollow/otp/server.py
@@ -615,6 +615,12 @@ class OtpServer:
         """True unless the test-only unicast/loopback branch is active."""
         return self._mcast_ip_override != ""
 
+    def bound_source_ip(self) -> str | None:
+        """Address this server is sending from, or ``None`` when stopped."""
+        if self._stop_event.is_set() or self._transform_thread is None:
+            return None
+        return self._source_ip
+
     def stop(self) -> None:
         """Signal threads to stop, wait for them, then close the socket."""
         self._stop_event.set()

--- a/openfollow/psn/receiver.py
+++ b/openfollow/psn/receiver.py
@@ -28,6 +28,24 @@ class _RobustReceiver(pypsn.Receiver):  # type: ignore[misc]
     callback error crashes the thread.  This subclass fixes both issues.
     """
 
+    # Bound so a caller on the GTK thread can't stall the render loop. pypsn's
+    # own ``stop()`` does a plain ``self.join()`` with no timeout while ``run``
+    # is blocked in ``recvfrom``; closing the fd does not reliably wake a
+    # thread already parked there, so the join waits out the socket timeout.
+    _JOIN_TIMEOUT_S = 3.0
+
+    def stop(self) -> None:
+        """Signal the loop to end and join it, but never block indefinitely."""
+        self.running = False
+        if self.socket is not None:
+            try:
+                self.socket.close()
+            except OSError:
+                pass
+        self.join(timeout=self._JOIN_TIMEOUT_S)
+        if self.is_alive():
+            logger.warning("PSN receiver thread did not stop within %.0fs", self._JOIN_TIMEOUT_S)
+
     def run(self) -> None:
         if self.socket is None:
             return
@@ -115,6 +133,12 @@ class PsnReceiver:
         if self._receiver is not None:
             self._receiver.stop()
             self._receiver = None
+
+    def bound_source_ip(self) -> str | None:
+        """Address this receiver is joined on, or ``None`` when stopped."""
+        if self._receiver is None:
+            return None
+        return self._source_ip
 
     def rebind(self, source_ip: str) -> None:
         """Recreate socket bound to new interface; raises on failure."""

--- a/openfollow/psn/server.py
+++ b/openfollow/psn/server.py
@@ -132,6 +132,18 @@ class PsnServer:
         self._data_thread.start()
         self._info_thread.start()
 
+    def bound_source_ip(self) -> str | None:
+        """Address this server is sending from, or ``None`` when stopped.
+
+        Lets the network observer tell "already bound correctly" from "needs a
+        rebind" without tearing the socket down to find out - a rebind kills
+        the background retry thread that recovers a boot where the multicast
+        route came up late.
+        """
+        if self._stop_event.is_set() or self._data_thread is None:
+            return None
+        return self._source_ip
+
     def stop(self) -> None:
         """Signal threads to stop, wait for them, then close the socket."""
         self._stop_event.set()

--- a/openfollow/runtime/app_orchestration.py
+++ b/openfollow/runtime/app_orchestration.py
@@ -87,6 +87,7 @@ def housekeeping(app: OpenFollowApp) -> bool:
         app._check_pi_network_worker,
         app._check_button_detection_request,
         app._check_marker_speeds_persist,
+        app._observe_network_planes,
     ):
         try:
             check()

--- a/openfollow/runtime/network_observer.py
+++ b/openfollow/runtime/network_observer.py
@@ -12,6 +12,24 @@ Nothing else notices these transitions on its own: the sockets pin
 ``IP_MULTICAST_IF`` / ``IP_ADD_MEMBERSHIP`` at open time, and an idle receive
 times out rather than raising, so a plane bound to an address that has gone
 away keeps looking healthy while sending nowhere.
+
+Three properties are load-bearing and easy to lose in a refactor:
+
+*Decisions compare against what is actually bound*, not against the previous
+poll's resolution. A plane the runtime already bound correctly is left alone
+rather than torn down and rebuilt, and a plane something else rebound behind
+the observer's back is noticed rather than assumed still suspended.
+
+*Suspension is debounced; resumption is not.* Applying an address or renewing a
+lease runs ``nmcli con down`` then ``con up``, so the interface is legitimately
+addressless for a second or more. Reacting to the first poll would mean the
+Network page's own buttons drop stage output.
+
+*A down→up transition rebuilds even when the address is unchanged.* Removing an
+address drops the interface's multicast memberships and routes; getting the
+same DHCP lease back does not restore them, and comparing address strings
+cannot see that. Outages shorter than one poll interval are invisible to
+polling and are not claimed to be handled.
 """
 
 from __future__ import annotations
@@ -25,9 +43,25 @@ from openfollow.net_utils import ResolveStatus
 logger = logging.getLogger(__name__)
 
 # How often the interface table is re-read. Enumerating adapters costs a psutil
-# call, and the housekeeping tick runs at 100 ms, so this throttles it to
-# roughly the rate an operator would notice a cable moving.
+# call and the housekeeping tick runs at 100 ms, so this throttles it to roughly
+# the rate an operator would notice a cable moving.
 POLL_INTERVAL_S = 1.0
+
+# Consecutive polls an interface must look addressless before its plane is
+# stopped. ``nmcli con down``/``con up`` behind Apply and Renew DHCP lease
+# leaves a gap of ~1 s for a static apply and up to ~5 s for a DHCP handshake,
+# so a single missing sample is not evidence of an outage.
+DOWN_POLLS_BEFORE_SUSPEND = 8
+
+# Backoff after a failed apply/suspend, so a plane whose backend keeps raising
+# doesn't retry once a second for the length of a show. Each failure doubles
+# the wait, up to the cap.
+_RETRY_BACKOFF_S = 2.0
+_RETRY_BACKOFF_MAX_S = 60.0
+
+
+def _always_enabled() -> bool:
+    return True
 
 
 @dataclass(frozen=True)
@@ -38,80 +72,160 @@ class Plane:
     # Returns (bind address, status, configured interface). The address is
     # empty when the configured interface currently has none.
     resolve: Callable[[], tuple[str, ResolveStatus, str]]
+    # The address this plane is bound to right now, or None when it is not
+    # running. Compared against the resolution to decide whether anything needs
+    # doing, so the observer never rebuilds a binding that is already correct.
+    current: Callable[[], str | None]
     # Bind to the given address. Only called with a non-empty address.
     apply: Callable[[str], None]
     # Bind nothing. Called when the configured interface has no address, so no
     # traffic leaves on an interface the operator did not choose.
     suspend: Callable[[], None]
+    # False when the operator has this output switched off. A disabled plane is
+    # never touched and never alerts – it is not broken, it is off.
+    enabled: Callable[[], bool] = _always_enabled
 
 
 @dataclass
-class _Binding:
-    iface: str
-    address: str
-    down: bool
+class _PlaneState:
+    down_polls: int = 0
+    suspended: bool = False
+    # Set once the interface has been seen addressless, so the plane rebuilds
+    # on the way back even when the address is byte-identical.
+    saw_outage: bool = False
+    failure: str = ""
+    retry_at: float = 0.0
+    backoff: float = _RETRY_BACKOFF_S
 
 
 @dataclass
 class NetworkPlaneObserver:
-    """Polls each plane's configured interface and repoints or stops it.
-
-    Idempotent: a plane is only touched when its resolved ``(interface,
-    address)`` differs from what was last applied, so a steady station does no
-    work beyond the resolve.
-    """
+    """Polls each plane's configured interface and repoints or stops it."""
 
     planes: list[Plane]
     clock: Callable[[], float]
-    _bindings: dict[str, _Binding] = field(default_factory=dict)
+    _states: dict[str, _PlaneState] = field(default_factory=dict)
     _next_poll: float = 0.0
 
-    def poll(self, *, force: bool = False) -> None:
-        """Re-resolve every plane and apply any change. Never raises."""
+    def poll(self, *, force: bool = False) -> bool:
+        """Re-resolve every plane and apply any change. Never raises.
+
+        Returns whether the throttle let this call through, so a caller with
+        its own equally expensive follow-up work can share the same interval.
+        """
         now = self.clock()
         if not force and now < self._next_poll:
-            return
+            return False
         self._next_poll = now + POLL_INTERVAL_S
         for plane in self.planes:
             try:
-                self._poll_one(plane)
-            except Exception:
-                # One plane's backend misbehaving must not stop the others from
-                # being followed - a stalled OTP rebind cannot be allowed to
-                # leave PSN on a dead address.
-                logger.exception("Network observer: %s failed", plane.label)
+                self._poll_one(plane, now)
+            except Exception as exc:  # noqa: BLE001
+                # One plane's backend misbehaving must not stop the others
+                # being followed – a stalled OTP rebind cannot be allowed to
+                # leave PSN on a dead address. Recorded so it surfaces to the
+                # operator instead of only appearing as a repeating traceback.
+                self._record_failure(plane, now, exc)
+        return True
 
-    def _poll_one(self, plane: Plane) -> None:
-        address, status, iface = plane.resolve()
-        down = status == "down"
-        previous = self._bindings.get(plane.label)
-        if previous is not None and previous.iface == iface and previous.address == address and previous.down == down:
+    def _state(self, label: str) -> _PlaneState:
+        return self._states.setdefault(label, _PlaneState())
+
+    def _record_failure(self, plane: Plane, now: float, exc: Exception) -> None:
+        state = self._state(plane.label)
+        state.failure = str(exc) or exc.__class__.__name__
+        state.retry_at = now + state.backoff
+        state.backoff = min(state.backoff * 2, _RETRY_BACKOFF_MAX_S)
+        logger.exception("Network observer: %s failed", plane.label)
+
+    @staticmethod
+    def _clear_failure(state: _PlaneState) -> None:
+        state.failure = ""
+        state.retry_at = 0.0
+        state.backoff = _RETRY_BACKOFF_S
+
+    def _poll_one(self, plane: Plane, now: float) -> None:
+        if not plane.enabled():
+            # Reset rather than carry a stale down-count or alert into the next
+            # time the operator switches this output on.
+            self._states[plane.label] = _PlaneState()
+            return
+        state = self._state(plane.label)
+        if now < state.retry_at:
             return
 
-        if down:
-            plane.suspend()
-            logger.error(
-                "%s: configured interface %s has no address; output stopped until it returns "
-                "(it will not be sent on another interface).",
+        address, status, iface = plane.resolve()
+        # "none" is nothing configured and nothing to auto-detect: the station
+        # has no address at all. Binding "" would hand the plane INADDR_ANY,
+        # which is the wrong network by definition.
+        if status in ("down", "none"):
+            self._handle_down(plane, state, iface)
+            return
+
+        state.down_polls = 0
+        # Compare against the live binding, not the previous resolution: the
+        # runtime may already have bound this correctly at startup, and
+        # something else may have rebound it since.
+        if plane.current() == address and not state.saw_outage:
+            state.suspended = False
+            self._clear_failure(state)
+            return
+
+        plane.apply(address)
+        if state.suspended or state.saw_outage:
+            logger.info(
+                "%s: interface %s is back at %s; output resumed.",
                 plane.label,
-                iface,
+                iface or "auto-detect",
+                address,
             )
-        else:
-            plane.apply(address)
-            if previous is not None and previous.down:
-                logger.info("%s: interface %s is back at %s; output resumed.", plane.label, iface, address or "auto")
-            elif previous is not None:
-                logger.info("%s: now bound to %s on %s.", plane.label, address or "auto", iface or "auto-detect")
-        self._bindings[plane.label] = _Binding(iface=iface, address=address, down=down)
+        state.suspended = False
+        state.saw_outage = False
+        self._clear_failure(state)
+
+    def _handle_down(self, plane: Plane, state: _PlaneState, iface: str) -> None:
+        state.down_polls += 1
+        state.saw_outage = True
+        if state.down_polls < DOWN_POLLS_BEFORE_SUSPEND:
+            return
+        # Re-check the live binding rather than trusting the recorded flag: a
+        # config save elsewhere restarts the output on a wildcard bind, which
+        # would otherwise run misrouted while this still says "suspended".
+        if state.suspended and plane.current() is None:
+            return
+        plane.suspend()
+        state.suspended = True
+        self._clear_failure(state)
+        logger.error(
+            "%s: configured interface %s has no address; output stopped until it returns "
+            "(it will not be sent on another interface).",
+            plane.label,
+            iface or "auto-detect",
+        )
 
     def alerts(self) -> list[str]:
-        """Operator-facing lines for every plane that is currently stopped.
+        """Operator-facing lines for every plane that is not currently sending.
 
         Rendered on the HUD, which is the only surface an operator has when the
-        interface carrying the web UI is the one that went away.
+        interface carrying the web UI is the one that went away. Emitted in
+        plane order so the rows don't reshuffle between frames.
         """
-        return [
-            f"{label}: {binding.iface or 'interface'} is down"
-            for label, binding in sorted(self._bindings.items())
-            if binding.down
-        ]
+        out: list[str] = []
+        for plane in self.planes:
+            state = self._states.get(plane.label)
+            if state is None:
+                continue
+            if state.suspended:
+                out.append(f"{plane.label}: {self._iface_of(plane)} is down")
+            elif state.failure:
+                # A plane whose rebind keeps failing is just as dead as a
+                # suspended one, and used to surface nowhere at all.
+                out.append(f"{plane.label}: {state.failure}")
+        return out
+
+    @staticmethod
+    def _iface_of(plane: Plane) -> str:
+        try:
+            return plane.resolve()[2] or "interface"
+        except Exception:  # noqa: BLE001
+            return "interface"

--- a/openfollow/runtime/network_observer.py
+++ b/openfollow/runtime/network_observer.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""Keeps every network plane on the interface it was configured for.
+
+A plane pins an **interface**, never an address. The address on that interface
+is free to change – a reconnect that yields a new DHCP lease is normal and must
+be followed – but the plane must never move to a different interface. When the
+configured interface has no address the plane binds nothing, says so, and waits
+for it to come back.
+
+Nothing else notices these transitions on its own: the sockets pin
+``IP_MULTICAST_IF`` / ``IP_ADD_MEMBERSHIP`` at open time, and an idle receive
+times out rather than raising, so a plane bound to an address that has gone
+away keeps looking healthy while sending nowhere.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from openfollow.net_utils import ResolveStatus
+
+logger = logging.getLogger(__name__)
+
+# How often the interface table is re-read. Enumerating adapters costs a psutil
+# call, and the housekeeping tick runs at 100 ms, so this throttles it to
+# roughly the rate an operator would notice a cable moving.
+POLL_INTERVAL_S = 1.0
+
+
+@dataclass(frozen=True)
+class Plane:
+    """One network function and how to point it at an interface."""
+
+    label: str
+    # Returns (bind address, status, configured interface). The address is
+    # empty when the configured interface currently has none.
+    resolve: Callable[[], tuple[str, ResolveStatus, str]]
+    # Bind to the given address. Only called with a non-empty address.
+    apply: Callable[[str], None]
+    # Bind nothing. Called when the configured interface has no address, so no
+    # traffic leaves on an interface the operator did not choose.
+    suspend: Callable[[], None]
+
+
+@dataclass
+class _Binding:
+    iface: str
+    address: str
+    down: bool
+
+
+@dataclass
+class NetworkPlaneObserver:
+    """Polls each plane's configured interface and repoints or stops it.
+
+    Idempotent: a plane is only touched when its resolved ``(interface,
+    address)`` differs from what was last applied, so a steady station does no
+    work beyond the resolve.
+    """
+
+    planes: list[Plane]
+    clock: Callable[[], float]
+    _bindings: dict[str, _Binding] = field(default_factory=dict)
+    _next_poll: float = 0.0
+
+    def poll(self, *, force: bool = False) -> None:
+        """Re-resolve every plane and apply any change. Never raises."""
+        now = self.clock()
+        if not force and now < self._next_poll:
+            return
+        self._next_poll = now + POLL_INTERVAL_S
+        for plane in self.planes:
+            try:
+                self._poll_one(plane)
+            except Exception:
+                # One plane's backend misbehaving must not stop the others from
+                # being followed - a stalled OTP rebind cannot be allowed to
+                # leave PSN on a dead address.
+                logger.exception("Network observer: %s failed", plane.label)
+
+    def _poll_one(self, plane: Plane) -> None:
+        address, status, iface = plane.resolve()
+        down = status == "down"
+        previous = self._bindings.get(plane.label)
+        if previous is not None and previous.iface == iface and previous.address == address and previous.down == down:
+            return
+
+        if down:
+            plane.suspend()
+            logger.error(
+                "%s: configured interface %s has no address; output stopped until it returns "
+                "(it will not be sent on another interface).",
+                plane.label,
+                iface,
+            )
+        else:
+            plane.apply(address)
+            if previous is not None and previous.down:
+                logger.info("%s: interface %s is back at %s; output resumed.", plane.label, iface, address or "auto")
+            elif previous is not None:
+                logger.info("%s: now bound to %s on %s.", plane.label, address or "auto", iface or "auto-detect")
+        self._bindings[plane.label] = _Binding(iface=iface, address=address, down=down)
+
+    def alerts(self) -> list[str]:
+        """Operator-facing lines for every plane that is currently stopped.
+
+        Rendered on the HUD, which is the only surface an operator has when the
+        interface carrying the web UI is the one that went away.
+        """
+        return [
+            f"{label}: {binding.iface or 'interface'} is down"
+            for label, binding in sorted(self._bindings.items())
+            if binding.down
+        ]

--- a/openfollow/runtime/network_observer.py
+++ b/openfollow/runtime/network_observer.py
@@ -96,6 +96,9 @@ class _PlaneState:
     failure: str = ""
     retry_at: float = 0.0
     backoff: float = _RETRY_BACKOFF_S
+    # Interface name from the last resolve, so ``alerts()`` can name it without
+    # re-resolving. ``alerts()`` runs on the render path.
+    iface: str = ""
 
 
 @dataclass
@@ -155,6 +158,7 @@ class NetworkPlaneObserver:
             return
 
         address, status, iface = plane.resolve()
+        state.iface = iface
         # "none" is nothing configured and nothing to auto-detect: the station
         # has no address at all. Binding "" would hand the plane INADDR_ANY,
         # which is the wrong network by definition.
@@ -209,6 +213,11 @@ class NetworkPlaneObserver:
         Rendered on the HUD, which is the only surface an operator has when the
         interface carrying the web UI is the one that went away. Emitted in
         plane order so the rows don't reshuffle between frames.
+
+        Reads the interface name cached by the last poll rather than resolving
+        it: this runs once per rendered frame (60-120 Hz), and resolving walks
+        every interface via psutil - so an outage would put that enumeration on
+        the render path for as long as it lasted.
         """
         out: list[str] = []
         for plane in self.planes:
@@ -216,16 +225,9 @@ class NetworkPlaneObserver:
             if state is None:
                 continue
             if state.suspended:
-                out.append(f"{plane.label}: {self._iface_of(plane)} is down")
+                out.append(f"{plane.label}: {state.iface or 'interface'} is down")
             elif state.failure:
                 # A plane whose rebind keeps failing is just as dead as a
                 # suspended one, and used to surface nowhere at all.
                 out.append(f"{plane.label}: {state.failure}")
         return out
-
-    @staticmethod
-    def _iface_of(plane: Plane) -> str:
-        try:
-            return plane.resolve()[2] or "interface"
-        except Exception:  # noqa: BLE001
-            return "interface"

--- a/openfollow/runtime/overlay_draw_hud.py
+++ b/openfollow/runtime/overlay_draw_hud.py
@@ -931,6 +931,10 @@ def build_info_panel_rows(state: OverlayState, *, source_max_len: int = 38) -> l
         ("Video Source:", format_source_text(state.video_source_type, state.source_label, max_len=source_max_len))
     )
     rows.append(("Station:", state.station_name or "OpenFollow"))
+    # Labelled once; the rest are bare so a multi-plane outage doesn't repeat
+    # the word down the panel.
+    for i, alert in enumerate(state.network_alerts):
+        rows.append(("Network:" if i == 0 else "", alert))
     return rows
 
 

--- a/openfollow/runtime/overlay_state.py
+++ b/openfollow/runtime/overlay_state.py
@@ -189,6 +189,10 @@ class OverlayState:
     # answered. Drives the qualifier that stops an operator reading a
     # 169.254 address as a working lease.
     ip_is_fallback: bool = False
+    # One line per network plane stopped because its configured interface has
+    # no address. The HUD is the only surface left when the interface that
+    # carries the web UI is the one that went away.
+    network_alerts: list[str] = field(default_factory=list)
     show_hud_help: bool = True
     # System stats (CPU, RAM, temperature)
     cpu_percent: float = 0.0
@@ -326,6 +330,7 @@ class OverlayState:
         self.ip_text = ""
         self.hostname_text = ""
         self.ip_is_fallback = False
+        self.network_alerts = []
         self.show_hud_help = True
         self.cpu_percent = 0.0
         self.ram_percent = 0.0

--- a/openfollow/runtime/services_marker_visuals.py
+++ b/openfollow/runtime/services_marker_visuals.py
@@ -382,6 +382,7 @@ def build_marker_visual_state(
     system_stats: Any,
     person_detector: Any,
     cam_params_buffer: npt.NDArray[Any],
+    network_alerts: list[str] | None = None,
 ) -> OverlayState:
     """Build a complete OverlayState snapshot for atomic renderer swap."""
     controlled_set = set(app._controlled_ids)
@@ -442,6 +443,8 @@ def build_marker_visual_state(
     # Carries the port for the same reason the IP row does: on a fallback bind
     # the UI is not on 80, and a name pointing at a dead port is worse than no
     # name at all.
+    state.network_alerts = list(network_alerts or ())
+
     hostname = _local_hostname()
     state.hostname_text = hostname + _port_suffix(web_port) if hostname else ""
 

--- a/openfollow/runtime/services_marker_visuals.py
+++ b/openfollow/runtime/services_marker_visuals.py
@@ -440,11 +440,11 @@ def build_marker_visual_state(
             state.ip_text = ip
         state.ip_is_fallback = is_link_local(ip)
 
+    state.network_alerts = list(network_alerts or ())
+
     # Carries the port for the same reason the IP row does: on a fallback bind
     # the UI is not on 80, and a name pointing at a dead port is worse than no
     # name at all.
-    state.network_alerts = list(network_alerts or ())
-
     hostname = _local_hostname()
     state.hostname_text = hostname + _port_suffix(web_port) if hostname else ""
 

--- a/openfollow/services.py
+++ b/openfollow/services.py
@@ -27,10 +27,12 @@ from openfollow.configuration import (
     HotkeyTrigger,
 )
 from openfollow.input import InputManager
+from openfollow.net_utils import ResolveStatus
 from openfollow.otp import OtpServer
 from openfollow.psn import PsnReceiver, PsnServer
 from openfollow.psn.server import _UNCHANGED, _Unchanged
 from openfollow.rttrpm import RttrpmServer
+from openfollow.runtime.network_observer import NetworkPlaneObserver, Plane
 from openfollow.runtime.overlay_state import OverlayState
 from openfollow.runtime.services_detection_pin import _NOMINAL_FRAME_DT
 from openfollow.runtime.services_detection_pin import (
@@ -626,6 +628,10 @@ class AppRuntimeServices:
         # app launch.
         from openfollow.network.detect import select_adapter as _select_network_adapter
 
+        # Built lazily on the first housekeeping poll so construction stays
+        # free of interface enumeration.
+        self._network_observer: NetworkPlaneObserver | None = None
+
         backend_choice = self._network_backend_choice(app)
         self._network_adapter = _select_network_adapter(
             backend_choice,
@@ -892,6 +898,90 @@ class AppRuntimeServices:
             )
             return None
         return resolved
+
+    def _build_network_planes(self) -> list[Plane]:
+        """Every plane the observer follows, in report order.
+
+        Later PRs add a row each (web UI, OSC in, RTTrPM, OSC destinations,
+        video input); each is one entry here and needs no observer changes.
+        """
+        from openfollow.net_utils import plane_source_iface, resolve_plane_source_ip
+
+        def _resolver(
+            pin_getter: Callable[[], str],
+            *,
+            is_station: bool,
+        ) -> Callable[[], tuple[str, ResolveStatus, str]]:
+            def _resolve() -> tuple[str, ResolveStatus, str]:
+                pin = pin_getter()
+                station = "" if is_station else self._app._config.psn_source_iface
+                address, status = resolve_plane_source_ip(pin, station)
+                return address, status, plane_source_iface(pin, station)
+
+            return _resolve
+
+        def _apply_psn(address: str) -> None:
+            self.apply_psn_source_ip_change(address)
+
+        def _suspend_psn() -> None:
+            # Both directions: leaving the receiver joined on a dead address
+            # would keep viewer markers showing stale positions.
+            for service in (self._app._server, self._app._psn_receiver):
+                if service is not None:
+                    service.stop()
+
+        def _apply_otp(_address: str) -> None:
+            # The orchestrator re-resolves the pin itself, so it always binds
+            # the address this poll just observed.
+            self.apply_otp_output_change(self._app._config.otp_output)
+
+        def _suspend_otp() -> None:
+            if self._app._otp_server is not None:
+                self._app._otp_server.stop()
+
+        return [
+            Plane(
+                label="PSN",
+                resolve=_resolver(lambda: self._app._config.psn_source_iface, is_station=True),
+                apply=_apply_psn,
+                suspend=_suspend_psn,
+            ),
+            Plane(
+                label="OTP output",
+                resolve=_resolver(lambda: self._app._config.otp_output.source_iface, is_station=False),
+                apply=_apply_otp,
+                suspend=_suspend_otp,
+            ),
+        ]
+
+    def observe_network_planes(self) -> None:
+        """Follow every plane's configured interface. Called from housekeeping.
+
+        Also repoints the station-followers that have no plane of their own -
+        the web self-row, the discovery beacon and marker-catalog sync. Those
+        were previously repointed from a web request path, so they only healed
+        while somebody had a browser tab open.
+        """
+        observer = self._network_observer
+        if observer is None:
+            observer = NetworkPlaneObserver(planes=self._build_network_planes(), clock=time.monotonic)
+            self._network_observer = observer
+        observer.poll()
+        self._follow_station_ip()
+
+    def _follow_station_ip(self) -> None:
+        """Repoint the services that track the station address rather than pin one."""
+        server = self._app._web_server
+        if server is not None:
+            server.refresh_local_ip()
+        sync = getattr(self._app, "_marker_catalog_sync", None)
+        if sync is not None:
+            sync.update_iface_ip(self._resolved_source_ip())
+
+    def network_alerts(self) -> list[str]:
+        """Planes currently stopped because their interface has no address."""
+        observer = self._network_observer
+        return observer.alerts() if observer is not None else []
 
     def init_online_sync(self) -> None:
         """Start the background online-sync worker.
@@ -2423,6 +2513,7 @@ class AppRuntimeServices:
             system_stats=self._system_stats,
             person_detector=self._person_detector,
             cam_params_buffer=self._cam_params_buffer,
+            network_alerts=self.network_alerts(),
         )
 
         # Atomic swap: release old state back to pool

--- a/openfollow/services.py
+++ b/openfollow/services.py
@@ -923,17 +923,34 @@ class AppRuntimeServices:
         def _apply_psn(address: str) -> None:
             self.apply_psn_source_ip_change(address)
 
+        def _current_psn() -> str | None:
+            server = self._app._server
+            return server.bound_source_ip() if server is not None else None
+
         def _suspend_psn() -> None:
-            # Both directions: leaving the receiver joined on a dead address
-            # would keep viewer markers showing stale positions.
+            # Both directions, and both attempted even if the first raises:
+            # leaving the receiver joined on a dead address would keep viewer
+            # markers showing stale positions, which is the thing this exists
+            # to prevent.
+            errors: list[Exception] = []
             for service in (self._app._server, self._app._psn_receiver):
-                if service is not None:
+                if service is None:
+                    continue
+                try:
                     service.stop()
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(exc)
+            if errors:
+                raise errors[0]
 
         def _apply_otp(_address: str) -> None:
             # The orchestrator re-resolves the pin itself, so it always binds
             # the address this poll just observed.
             self.apply_otp_output_change(self._app._config.otp_output)
+
+        def _current_otp() -> str | None:
+            server = self._app._otp_server
+            return server.bound_source_ip() if server is not None else None
 
         def _suspend_otp() -> None:
             if self._app._otp_server is not None:
@@ -943,14 +960,19 @@ class AppRuntimeServices:
             Plane(
                 label="PSN",
                 resolve=_resolver(lambda: self._app._config.psn_source_iface, is_station=True),
+                current=_current_psn,
                 apply=_apply_psn,
                 suspend=_suspend_psn,
             ),
             Plane(
                 label="OTP output",
                 resolve=_resolver(lambda: self._app._config.otp_output.source_iface, is_station=False),
+                current=_current_otp,
                 apply=_apply_otp,
                 suspend=_suspend_otp,
+                # A switched-off output is not broken; alerting on it would put
+                # a second fault on the HUD for a protocol nobody enabled.
+                enabled=lambda: self._app._config.otp_output.enabled,
             ),
         ]
 
@@ -966,17 +988,32 @@ class AppRuntimeServices:
         if observer is None:
             observer = NetworkPlaneObserver(planes=self._build_network_planes(), clock=time.monotonic)
             self._network_observer = observer
-        observer.poll()
-        self._follow_station_ip()
+        # Inside the same throttle: resolving the station address enumerates
+        # every adapter, and housekeeping runs at 100 ms.
+        if observer.poll():
+            self._follow_station_ip()
 
     def _follow_station_ip(self) -> None:
-        """Repoint the services that track the station address rather than pin one."""
+        """Repoint the services that track the station address rather than pin one.
+
+        Resolved fail-closed, like every other plane: the station interface
+        being down must not move catalog sync or the discovery beacon onto
+        whatever else happens to be up. Doing so would put this station's
+        identity - its name, marker names and colours, its selection - on a
+        network the operator never chose, at the exact moment the observer is
+        stopping PSN for that same reason.
+        """
+        from openfollow.net_utils import resolve_plane_source_ip
+
+        address, status = resolve_plane_source_ip("", self._app._config.psn_source_iface)
+        if status in ("down", "none"):
+            return
         server = self._app._web_server
         if server is not None:
             server.refresh_local_ip()
         sync = getattr(self._app, "_marker_catalog_sync", None)
         if sync is not None:
-            sync.update_iface_ip(self._resolved_source_ip())
+            sync.update_iface_ip(address)
 
     def network_alerts(self) -> list[str]:
         """Planes currently stopped because their interface has no address."""

--- a/openfollow/services.py
+++ b/openfollow/services.py
@@ -631,6 +631,9 @@ class AppRuntimeServices:
         # Built lazily on the first housekeeping poll so construction stays
         # free of interface enumeration.
         self._network_observer: NetworkPlaneObserver | None = None
+        # Whether the station interface has been seen without an address since
+        # the followers were last repointed.
+        self._station_saw_outage = False
 
         backend_choice = self._network_backend_choice(app)
         self._network_adapter = _select_network_adapter(
@@ -1007,13 +1010,28 @@ class AppRuntimeServices:
 
         address, status = resolve_plane_source_ip("", self._app._config.psn_source_iface)
         if status in ("down", "none"):
+            self._station_saw_outage = True
             return
+
+        # The observer forces its own planes to rebuild after an outage even at
+        # an unchanged address; these followers need the same treatment, and
+        # both of their entry points short-circuit on an unchanged IP. Without
+        # this a replug that returns the same DHCP lease leaves catalog sync
+        # and the beacon joined to memberships the kernel already dropped -
+        # still looking healthy, converging with nobody.
+        recovered = self._station_saw_outage
+        self._station_saw_outage = False
+
         server = self._app._web_server
         if server is not None:
             server.refresh_local_ip()
+            if recovered:
+                server.reopen_beacons()
         sync = getattr(self._app, "_marker_catalog_sync", None)
         if sync is not None:
             sync.update_iface_ip(address)
+            if recovered:
+                sync.reopen()
 
     def network_alerts(self) -> list[str]:
         """Planes currently stopped because their interface has no address."""

--- a/openfollow/web/discovery.py
+++ b/openfollow/web/discovery.py
@@ -154,6 +154,15 @@ class BeaconSender:
         if iface_ip == self._iface_ip:
             return
         self._iface_ip = iface_ip
+        self.reopen()
+
+    def reopen(self) -> None:
+        """Force the send socket to rebuild on the next loop iteration.
+
+        For a link that flapped: removing an address drops the egress route,
+        and getting the identical address back does not restore it - so an
+        unchanged-IP guard alone would leave the beacon sending nowhere.
+        """
         self._reopen.set()
 
     def _drain_reopen(self, sock: socket.socket | None) -> socket.socket | None:
@@ -366,6 +375,16 @@ class BeaconReceiver:
         # as local immediately; otherwise our own looped-back beacon passes the
         # filter and we self-list as a peer until the next TTL refresh.
         self._local_ips_ts = 0.0
+        self.reopen()
+
+    def reopen(self) -> None:
+        """Force the receive socket to rebuild on the next loop iteration.
+
+        For a link that flapped: the kernel drops the group membership when the
+        address is removed, and getting the identical address back does not
+        restore it - so an unchanged-IP guard alone would leave the receiver
+        joined to nothing while still looking healthy.
+        """
         self._reopen.set()
 
     def start(self) -> None:

--- a/openfollow/web/help/general-interface-assignment.md
+++ b/openfollow/web/help/general-interface-assignment.md
@@ -18,7 +18,9 @@ A function stays on the interface you gave it, always. If that interface has no 
 
 That is deliberate. During a show, output that has stopped is something you can see and diagnose; output that quietly reappeared on the office LAN is not. It also means nothing this station sends can end up on a network you didn't choose.
 
-Nothing about your configuration changes while the interface is away. Save the panel again once it is back to start the function on it.
+The function resumes on its own as soon as the interface has an address again – no restart, no re-save. The station checks about once a second, so a cable going back in recovers within a moment. Nothing about your configuration changes while the interface is away.
+
+While a function is stopped, the on-screen display lists it under **Network**, next to the IP address. That matters when the interface that went away is the one carrying this web page: the screen on the device is the only place left to look.
 
 The **address** is allowed to change. If the interface is on DHCP and comes back with a different address than before, that is normal and the function follows it. Only the interface itself is fixed.
 

--- a/openfollow/web/server.py
+++ b/openfollow/web/server.py
@@ -522,6 +522,17 @@ class ConfigWebServer:
         """
         self._refresh_local_ip()
 
+    def reopen_beacons(self) -> None:
+        """Rebuild both beacon sockets regardless of whether the IP changed.
+
+        Called on recovery from an interface outage: the kernel drops the
+        group membership and the egress route when an address is removed, and
+        the same address coming back does not restore either - so the
+        unchanged-IP guard in ``update_iface_ip`` is not enough on its own.
+        """
+        self._beacon_sender.reopen()
+        self._beacon_receiver.reopen()
+
     def get_local_peer_info(self) -> PeerInfo:
         """Get info about this server as a PeerInfo object."""
         self._refresh_local_ip()

--- a/openfollow/web/server.py
+++ b/openfollow/web/server.py
@@ -511,6 +511,17 @@ class ConfigWebServer:
             self._beacon_receiver.update_iface_ip(candidate)
         logger.info("Local IP changed to %s; beacon interface repointed.", candidate)
 
+    def refresh_local_ip(self) -> None:
+        """Public entry point for the runtime network observer.
+
+        The refresh used to happen only on a request path, so a station whose
+        address changed healed its self-row and beacon interface only while
+        somebody had a browser tab open. The observer calls this on a timer
+        instead; the internal throttle still applies, so the request paths
+        calling it too costs nothing.
+        """
+        self._refresh_local_ip()
+
     def get_local_peer_info(self) -> PeerInfo:
         """Get info about this server as a PeerInfo object."""
         self._refresh_local_ip()

--- a/tests/test_app_lifecycle.py
+++ b/tests/test_app_lifecycle.py
@@ -641,6 +641,19 @@ class TestDelegators:
         # All helpers take ``app`` as first arg.
         assert hits[0][0] is app
 
+    def test_observe_network_planes_delegates_to_services(
+        self,
+        patched_ctor,
+        monkeypatch: pytest.MonkeyPatch,  # noqa: ANN001
+    ) -> None:
+        """Housekeeping drives this ~10x/s; it must reach the observer that
+        keeps each plane on its configured interface."""
+        app = OpenFollowApp(config_path=patched_ctor.cfg_path)
+        hits: list[int] = []
+        app._runtime_services.observe_network_planes = lambda: hits.append(1)
+        app._observe_network_planes()
+        assert hits == [1]
+
     @pytest.mark.parametrize(
         ("method_name", "helper_name", "payload"),
         [

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -128,6 +128,7 @@ def _make_fake_app(
         _check_pi_network_worker=_recorder("check_pi_network_worker"),
         _check_button_detection_request=_recorder("check_button_detection_request"),
         _check_marker_speeds_persist=_recorder("check_marker_speeds_persist"),
+        _observe_network_planes=_recorder("observe_network_planes"),
         _check_video_disconnect_banner=_recorder("check_video_disconnect_banner"),
         _process_input=_recorder("process_input"),
         _refresh_iface_list=_recorder("refresh_iface_list"),
@@ -263,6 +264,7 @@ class TestHousekeeping:
             "check_pi_network_worker",
             "check_button_detection_request",
             "check_marker_speeds_persist",
+            "observe_network_planes",
         ]
 
     def test_swallows_check_exception_and_keeps_timer(self) -> None:
@@ -283,6 +285,7 @@ class TestHousekeeping:
             "check_pi_network_worker",
             "check_button_detection_request",
             "check_marker_speeds_persist",
+            "observe_network_planes",
         ]
 
 

--- a/tests/test_marker_sync.py
+++ b/tests/test_marker_sync.py
@@ -1228,17 +1228,60 @@ class TestRecvLoopOneIteration:
             selection_provider=lambda: ([], []),
         )
 
-    def test_bind_failure_retries_then_gives_up(self, monkeypatch) -> None:
-        """An interface switch makes the address briefly unavailable, so one
-        failure must not disable sync input for the session - but a
-        permanently taken port must not spin for the life of the process."""
-        monkeypatch.setattr(marker_sync, "_RX_OPEN_RETRY_S", 0.0)
+    def test_bind_failure_retries_across_a_dhcp_release(self, monkeypatch) -> None:
+        """The retry budget has to outlast a DHCP re-lease (5-15s), because
+        that is the window it exists to cover. Giving up sooner fails in
+        exactly the case it was added for."""
+        assert marker_sync._RX_OPEN_MAX_RETRIES * marker_sync._RX_OPEN_RETRY_S >= 15.0
+
+    def test_bind_failure_parks_instead_of_killing_the_thread(self, monkeypatch) -> None:
+        """The receive thread is never restarted - ``start()`` short-circuits
+        while it exists - so returning at the cap would disable sync input for
+        the process with no way back.
+
+        Driven on a daemon thread with an external terminator: the park calls
+        nothing, so a terminator that depends on the loop's own internals can
+        never fire.
+        """
+        monkeypatch.setattr(marker_sync, "_RX_OPEN_RETRY_S", 0.001)
+        monkeypatch.setattr(marker_sync, "_RX_OPEN_MAX_RETRIES", 2)
         sync = self._sync()
         bad_sock = MagicMock()
         bad_sock.bind.side_effect = OSError("port busy")
+
         with patch.object(_socket, "socket", return_value=bad_sock):
-            sync._recv_loop()
-        assert bad_sock.close.call_count == marker_sync._RX_OPEN_MAX_RETRIES
+            worker = threading.Thread(target=sync._recv_loop, daemon=True)
+            worker.start()
+            time.sleep(0.2)
+            assert worker.is_alive(), "gave up and exited instead of parking"
+            sync._stop_event.set()
+            worker.join(timeout=5.0)
+        assert not worker.is_alive(), "park did not honour the stop event"
+
+    def test_a_repoint_revives_a_parked_receive_loop(self, monkeypatch) -> None:
+        """Parking is only safe if something can wake it - otherwise it is the
+        same dead end as returning, just quieter."""
+        monkeypatch.setattr(marker_sync, "_RX_OPEN_RETRY_S", 0.001)
+        monkeypatch.setattr(marker_sync, "_RX_OPEN_MAX_RETRIES", 2)
+        sync = self._sync()
+        opens = [0]
+        bad_sock = MagicMock()
+        bad_sock.bind.side_effect = OSError("port busy")
+
+        def _factory(*_a, **_kw):
+            opens[0] += 1
+            return bad_sock
+
+        with patch.object(_socket, "socket", _factory):
+            worker = threading.Thread(target=sync._recv_loop, daemon=True)
+            worker.start()
+            time.sleep(0.2)
+            parked_at = opens[0]
+            sync.reopen()
+            time.sleep(0.2)
+            assert opens[0] > parked_at, "repoint did not wake the parked loop"
+            sync._stop_event.set()
+            worker.join(timeout=5.0)
 
     def test_reuseport_attribute_error_swallowed(self) -> None:
         """SO_REUSEPORT is absent on some platforms; its absence must not stop
@@ -1656,17 +1699,68 @@ class TestUpdateIfaceIp:
             iface_ip=iface_ip,
         )
 
-    def test_new_address_arms_a_rebuild(self) -> None:
+    def test_new_address_arms_both_loops(self) -> None:
         sync = self._sync()
         sync.update_iface_ip("10.0.0.9")
         assert sync._iface_ip == "10.0.0.9"
-        assert sync._reopen.is_set()
+        assert sync._tx_reopen.is_set()
+        assert sync._rx_reopen.is_set()
 
     def test_unchanged_address_is_a_no_op(self) -> None:
         """A steady station must not rebuild its sockets on every poll."""
         sync = self._sync()
         sync.update_iface_ip("192.168.1.5")
-        assert sync._reopen.is_set() is False
+        assert not sync._tx_reopen.is_set()
+        assert not sync._rx_reopen.is_set()
+
+    def test_reopen_forces_a_rebuild_at_the_same_address(self) -> None:
+        """A link that dropped and came back with the same lease has had its
+        memberships torn down by the kernel; the address string cannot show
+        that, so the caller has to be able to force it."""
+        sync = self._sync()
+        sync.reopen()
+        assert sync._tx_reopen.is_set()
+        assert sync._rx_reopen.is_set()
+
+    def test_the_loops_do_not_consume_each_others_event(self) -> None:
+        """One shared event is a trap: RX wakes within its 1s socket timeout
+        while TX is parked for a whole heartbeat, so RX would clear the flag
+        and TX would keep IP_MULTICAST_IF on the dead address forever."""
+        sync = self._sync()
+        sync.reopen()
+        # Model the RX loop reaching its clear first.
+        sync._rx_reopen.clear()
+        assert sync._tx_reopen.is_set(), "RX consumed the TX repoint"
+
+    def test_tx_socket_is_rebuilt_on_a_repoint(self) -> None:
+        """The behaviour the whole fix exists for. Driven on a daemon thread so
+        a regression fails the assertion instead of hanging the suite."""
+        sync = self._sync()
+        opened: list[MagicMock] = []
+
+        def _open():
+            sock = MagicMock()
+            opened.append(sock)
+            return sock
+
+        sync._open_tx_socket = _open  # type: ignore[method-assign]
+        worker = threading.Thread(target=sync._send_loop, daemon=True)
+        worker.start()
+        try:
+            deadline = time.monotonic() + 3.0
+            while not opened and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert opened, "send loop never opened a socket"
+            before = len(opened)
+            sync.reopen()
+            deadline = time.monotonic() + 3.0
+            while len(opened) == before and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert len(opened) > before, "TX socket was not rebuilt after the repoint"
+            assert opened[before - 1].close.called
+        finally:
+            sync._stop_event.set()
+            worker.join(timeout=5.0)
 
     def test_rx_socket_joins_on_the_new_address(self) -> None:
         sync = self._sync()
@@ -1682,21 +1776,3 @@ class TestUpdateIfaceIp:
         with patch.object(_socket, "socket", return_value=sock):
             assert sync._open_rx_socket() is sock
         assert memberships[0].endswith(_socket.inet_aton("10.0.0.9"))
-
-    def test_send_loop_drops_its_socket_on_repoint(self) -> None:
-        """The TX socket pins IP_MULTICAST_IF, so it must be reopened rather
-        than reused after the address moves."""
-        sync = self._sync()
-        opened: list[MagicMock] = []
-
-        def _open():
-            sock = MagicMock()
-            opened.append(sock)
-            if len(opened) == 2:
-                sync._stop_event.set()
-            return sock
-
-        sync._open_tx_socket = _open  # type: ignore[method-assign]
-        sync._reopen.set()
-        sync._send_loop()
-        assert len(opened) >= 1

--- a/tests/test_marker_sync.py
+++ b/tests/test_marker_sync.py
@@ -1228,29 +1228,31 @@ class TestRecvLoopOneIteration:
             selection_provider=lambda: ([], []),
         )
 
-    def test_bind_failure_returns_immediately(self) -> None:
+    def test_bind_failure_retries_then_gives_up(self, monkeypatch) -> None:
+        """An interface switch makes the address briefly unavailable, so one
+        failure must not disable sync input for the session - but a
+        permanently taken port must not spin for the life of the process."""
+        monkeypatch.setattr(marker_sync, "_RX_OPEN_RETRY_S", 0.0)
         sync = self._sync()
         bad_sock = MagicMock()
         bad_sock.bind.side_effect = OSError("port busy")
         with patch.object(_socket, "socket", return_value=bad_sock):
             sync._recv_loop()
-        bad_sock.close.assert_called_once()
+        assert bad_sock.close.call_count == marker_sync._RX_OPEN_MAX_RETRIES
 
     def test_reuseport_attribute_error_swallowed(self) -> None:
+        """SO_REUSEPORT is absent on some platforms; its absence must not stop
+        the socket being opened."""
         sync = self._sync()
         sock = MagicMock()
-        # Make setsockopt fail with AttributeError on the SO_REUSEPORT call only.
 
         def setsockopt(level, opt, val):
             if opt == _socket.SO_REUSEPORT:
                 raise AttributeError("not available")
 
         sock.setsockopt.side_effect = setsockopt
-        # bind succeeds (default MagicMock); set stop so recv loop exits.
-        sync._stop_event.set()
         with patch.object(_socket, "socket", return_value=sock):
-            sync._recv_loop()
-        sock.close.assert_called_once()
+            assert sync._open_rx_socket() is sock
 
     def test_fallback_join_on_iface_failure(self) -> None:
         """When IP_ADD_MEMBERSHIP fails on the bound iface (e.g. iface
@@ -1273,7 +1275,7 @@ class TestRecvLoopOneIteration:
 
         sock.setsockopt.side_effect = setsockopt
         with patch.object(_socket, "socket", return_value=sock):
-            sync._recv_loop()
+            assert sync._open_rx_socket() is None
         # Two IP_ADD_MEMBERSHIP attempts (iface, then 0.0.0.0 fallback).
         assert len(membership_calls) == 2
         sock.close.assert_called_once()
@@ -1634,3 +1636,67 @@ def test_entry_from_dict_caps_huge_version() -> None:
     back = _entry_from_dict({"id": 1, "name": "A", "color": "#ffffff", "version": 10**30})
     assert back is not None
     assert back.version == 2**63 - 1
+
+
+class TestUpdateIfaceIp:
+    """Sync has to follow the station onto a new address.
+
+    Both sockets pin the interface at open time - TX via IP_MULTICAST_IF, RX
+    via IP_ADD_MEMBERSHIP - and an idle recv times out rather than raising, so
+    without an explicit repoint sync silently stops converging after an
+    interface switch.
+    """
+
+    def _sync(self, iface_ip: str = "192.168.1.5") -> MarkerCatalogSync:
+        return MarkerCatalogSync(
+            MarkerCatalog(),
+            station_id="station-A",
+            station_name_provider=lambda: "X",
+            selection_provider=lambda: ([], []),
+            iface_ip=iface_ip,
+        )
+
+    def test_new_address_arms_a_rebuild(self) -> None:
+        sync = self._sync()
+        sync.update_iface_ip("10.0.0.9")
+        assert sync._iface_ip == "10.0.0.9"
+        assert sync._reopen.is_set()
+
+    def test_unchanged_address_is_a_no_op(self) -> None:
+        """A steady station must not rebuild its sockets on every poll."""
+        sync = self._sync()
+        sync.update_iface_ip("192.168.1.5")
+        assert sync._reopen.is_set() is False
+
+    def test_rx_socket_joins_on_the_new_address(self) -> None:
+        sync = self._sync()
+        sync.update_iface_ip("10.0.0.9")
+        sock = MagicMock()
+        memberships: list[bytes] = []
+
+        def setsockopt(level, opt, val):
+            if opt == _socket.IP_ADD_MEMBERSHIP:
+                memberships.append(val)
+
+        sock.setsockopt.side_effect = setsockopt
+        with patch.object(_socket, "socket", return_value=sock):
+            assert sync._open_rx_socket() is sock
+        assert memberships[0].endswith(_socket.inet_aton("10.0.0.9"))
+
+    def test_send_loop_drops_its_socket_on_repoint(self) -> None:
+        """The TX socket pins IP_MULTICAST_IF, so it must be reopened rather
+        than reused after the address moves."""
+        sync = self._sync()
+        opened: list[MagicMock] = []
+
+        def _open():
+            sock = MagicMock()
+            opened.append(sock)
+            if len(opened) == 2:
+                sync._stop_event.set()
+            return sock
+
+        sync._open_tx_socket = _open  # type: ignore[method-assign]
+        sync._reopen.set()
+        sync._send_loop()
+        assert len(opened) >= 1

--- a/tests/test_net_utils.py
+++ b/tests/test_net_utils.py
@@ -729,3 +729,54 @@ class TestWaitForSourceIp:
             )
             == "127.0.0.1"
         )
+
+
+class TestPrimaryAddressPrefersARealLease:
+    """A link-local address must never outrank a routable one.
+
+    The offline probe always fails on a show LAN, so this branch picks the
+    station's identity - the address peers and consoles reach it at. Ordering
+    the raw strings puts ``169.254.x`` ahead of ``192.168.x`` (``"16"`` sorts
+    before ``"19"``), so a station that self-assigned while DHCP was failing
+    kept advertising that address after a real lease arrived.
+    """
+
+    @staticmethod
+    def _offline(monkeypatch, addresses: set[str]) -> None:
+        class FakeSocket:
+            def __init__(self, *a, **kw) -> None:
+                pass
+
+            def connect(self, addr) -> None:
+                raise OSError("No route")
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a) -> None:
+                pass
+
+        monkeypatch.setattr(net_utils_module.socket, "socket", FakeSocket)
+        monkeypatch.setattr(net_utils_module, "get_local_ipv4_addresses", lambda: addresses)
+
+    def test_real_lease_beats_link_local(self, monkeypatch) -> None:
+        self._offline(monkeypatch, {"169.254.8.31", "192.168.178.66"})
+        assert get_primary_local_ipv4() == "192.168.178.66"
+
+    def test_link_local_still_used_when_it_is_all_there_is(self, monkeypatch) -> None:
+        """The DHCP-failure fallback is a working address on its own segment,
+        so it is a legitimate last resort - just never a preferred one."""
+        self._offline(monkeypatch, {"169.254.8.31"})
+        assert get_primary_local_ipv4() == "169.254.8.31"
+
+    def test_pick_is_numeric_not_lexicographic(self, monkeypatch) -> None:
+        self._offline(monkeypatch, {"10.0.0.10", "10.0.0.9"})
+        assert get_primary_local_ipv4() == "10.0.0.9"
+
+    def test_pick_is_stable_across_calls(self, monkeypatch) -> None:
+        """The reason ordering exists at all: an unordered pick flips when an
+        unrelated address appears, which reads downstream as a real IP change."""
+        self._offline(monkeypatch, {"192.168.1.50", "172.16.0.4", "10.1.2.3"})
+        first = get_primary_local_ipv4()
+        self._offline(monkeypatch, {"172.16.0.4", "10.1.2.3", "192.168.1.50"})
+        assert get_primary_local_ipv4() == first

--- a/tests/test_network_observer.py
+++ b/tests/test_network_observer.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""Tests for NetworkPlaneObserver: a plane follows its configured interface,
+stops when that interface has no address, and never moves to another one."""
+
+from __future__ import annotations
+
+import pytest
+
+from openfollow.runtime.network_observer import (
+    POLL_INTERVAL_S,
+    NetworkPlaneObserver,
+    Plane,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _Recorder:
+    """Stand-in for one plane's bind surface."""
+
+    def __init__(self, address: str = "192.168.1.5", status: str = "iface", iface: str = "eth0") -> None:
+        self.address = address
+        self.status = status
+        self.iface = iface
+        self.applied: list[str] = []
+        self.suspends = 0
+
+    def resolve(self) -> tuple[str, str, str]:
+        return self.address, self.status, self.iface
+
+    def apply(self, address: str) -> None:
+        self.applied.append(address)
+
+    def suspend(self) -> None:
+        self.suspends += 1
+
+    def go_down(self) -> None:
+        self.address, self.status = "", "down"
+
+    def come_back(self, address: str) -> None:
+        self.address, self.status = address, "iface"
+
+    def plane(self, label: str = "PSN") -> Plane:
+        return Plane(label=label, resolve=self.resolve, apply=self.apply, suspend=self.suspend)
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float = POLL_INTERVAL_S) -> None:
+        self.now += seconds
+
+
+def _observer(*recorders: _Recorder, clock: _Clock | None = None) -> tuple[NetworkPlaneObserver, _Clock]:
+    clk = clock or _Clock()
+    planes = [r.plane(f"plane{i}") for i, r in enumerate(recorders)]
+    return NetworkPlaneObserver(planes=planes, clock=clk), clk
+
+
+class TestFollowingAnInterface:
+    def test_first_poll_binds(self) -> None:
+        rec = _Recorder()
+        obs, _clk = _observer(rec)
+        obs.poll()
+        assert rec.applied == ["192.168.1.5"]
+
+    def test_unchanged_state_does_not_rebind(self) -> None:
+        """A steady station must not churn its sockets once a second."""
+        rec = _Recorder()
+        obs, clk = _observer(rec)
+        for _ in range(4):
+            obs.poll()
+            clk.advance()
+        assert rec.applied == ["192.168.1.5"]
+
+    def test_new_lease_on_the_same_interface_is_followed(self) -> None:
+        """Reconnecting a cable and getting a different DHCP address is normal.
+        Only the interface is fixed, so the plane must rebind to the new one."""
+        rec = _Recorder()
+        obs, clk = _observer(rec)
+        obs.poll()
+        rec.come_back("192.168.1.77")
+        clk.advance()
+        obs.poll()
+        assert rec.applied == ["192.168.1.5", "192.168.1.77"]
+        assert rec.suspends == 0
+
+
+class TestFailingClosed:
+    def test_down_interface_suspends_instead_of_rebinding(self) -> None:
+        """The load-bearing rule: no traffic on an interface the operator did
+        not choose. A stopped output is diagnosable; a misrouted one is not."""
+        rec = _Recorder()
+        obs, clk = _observer(rec)
+        obs.poll()
+        rec.go_down()
+        clk.advance()
+        obs.poll()
+        assert rec.suspends == 1
+        assert rec.applied == ["192.168.1.5"]
+
+    def test_suspend_happens_once_while_it_stays_down(self) -> None:
+        rec = _Recorder()
+        obs, clk = _observer(rec)
+        rec.go_down()
+        for _ in range(4):
+            obs.poll()
+            clk.advance()
+        assert rec.suspends == 1
+
+    def test_interface_returning_resumes_automatically(self) -> None:
+        """No restart, no re-save - the operator plugs the cable back in."""
+        rec = _Recorder()
+        obs, clk = _observer(rec)
+        rec.go_down()
+        obs.poll()
+        clk.advance()
+        rec.come_back("10.0.0.9")
+        obs.poll()
+        assert rec.applied == ["10.0.0.9"]
+
+    def test_alerts_name_the_plane_and_interface(self) -> None:
+        rec = _Recorder(iface="eth0.10")
+        obs, _clk = _observer(rec)
+        rec.go_down()
+        obs.poll()
+        assert obs.alerts() == ["plane0: eth0.10 is down"]
+
+    def test_alerts_clear_when_the_interface_returns(self) -> None:
+        rec = _Recorder()
+        obs, clk = _observer(rec)
+        rec.go_down()
+        obs.poll()
+        clk.advance()
+        rec.come_back("192.168.1.5")
+        obs.poll()
+        assert obs.alerts() == []
+
+
+class TestIsolationAndThrottling:
+    def test_one_failing_plane_does_not_stop_the_others(self) -> None:
+        """A stalled OTP rebind cannot be allowed to leave PSN on a dead
+        address."""
+        broken = _Recorder()
+        healthy = _Recorder(address="10.0.0.9", iface="eth1")
+
+        def _boom(_address: str) -> None:
+            raise OSError("bind failed")
+
+        obs = NetworkPlaneObserver(
+            planes=[
+                Plane(label="broken", resolve=broken.resolve, apply=_boom, suspend=broken.suspend),
+                healthy.plane("healthy"),
+            ],
+            clock=_Clock(),
+        )
+        obs.poll()
+        assert healthy.applied == ["10.0.0.9"]
+
+    def test_poll_is_throttled(self) -> None:
+        """Interface enumeration costs a psutil call and housekeeping runs at
+        100ms, so the observer must not resolve on every tick."""
+        rec = _Recorder()
+        obs, clk = _observer(rec)
+        obs.poll()
+        rec.come_back("10.0.0.9")
+        obs.poll()  # same instant - throttled
+        assert rec.applied == ["192.168.1.5"]
+        clk.advance()
+        obs.poll()
+        assert rec.applied == ["192.168.1.5", "10.0.0.9"]
+
+    def test_force_bypasses_the_throttle(self) -> None:
+        rec = _Recorder()
+        obs, _clk = _observer(rec)
+        obs.poll()
+        rec.come_back("10.0.0.9")
+        obs.poll(force=True)
+        assert rec.applied == ["192.168.1.5", "10.0.0.9"]

--- a/tests/test_network_observer.py
+++ b/tests/test_network_observer.py
@@ -348,6 +348,13 @@ class TestAlertsAndThrottling:
         failing["now"] = True
         assert obs.alerts() == ["plane0: interface is down"]
 
+    def test_a_plane_never_polled_contributes_no_alert(self) -> None:
+        """A plane added but not yet reached - a disabled one, or the first
+        tick - must not render a phantom row."""
+        rec = _Recorder()
+        obs, _clk = _observer(rec)
+        assert obs.alerts() == []
+
     def test_poll_is_throttled(self) -> None:
         rec = _Recorder()
         obs, clk = _observer(rec)

--- a/tests/test_network_observer.py
+++ b/tests/test_network_observer.py
@@ -1,13 +1,20 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 OpenFollow Project
-"""Tests for NetworkPlaneObserver: a plane follows its configured interface,
-stops when that interface has no address, and never moves to another one."""
+"""Tests for NetworkPlaneObserver.
+
+A plane follows its configured interface, stops when that interface has no
+address, and never moves to another one. Three properties get their own
+sections because each was a real defect: decisions compare against what is
+actually bound, suspension is debounced, and a down-to-up transition rebuilds
+even when the address is unchanged.
+"""
 
 from __future__ import annotations
 
 import pytest
 
 from openfollow.runtime.network_observer import (
+    DOWN_POLLS_BEFORE_SUSPEND,
     POLL_INTERVAL_S,
     NetworkPlaneObserver,
     Plane,
@@ -17,23 +24,36 @@ pytestmark = pytest.mark.unit
 
 
 class _Recorder:
-    """Stand-in for one plane's bind surface."""
+    """Stand-in for one plane's bind surface, tracking what is 'bound'."""
 
     def __init__(self, address: str = "192.168.1.5", status: str = "iface", iface: str = "eth0") -> None:
         self.address = address
         self.status = status
         self.iface = iface
+        self.bound: str | None = None
         self.applied: list[str] = []
         self.suspends = 0
+        self.is_enabled = True
+        self.apply_error: Exception | None = None
 
     def resolve(self) -> tuple[str, str, str]:
         return self.address, self.status, self.iface
 
+    def current(self) -> str | None:
+        return self.bound
+
     def apply(self, address: str) -> None:
+        if self.apply_error is not None:
+            raise self.apply_error
         self.applied.append(address)
+        self.bound = address
 
     def suspend(self) -> None:
         self.suspends += 1
+        self.bound = None
+
+    def enabled(self) -> bool:
+        return self.is_enabled
 
     def go_down(self) -> None:
         self.address, self.status = "", "down"
@@ -42,7 +62,14 @@ class _Recorder:
         self.address, self.status = address, "iface"
 
     def plane(self, label: str = "PSN") -> Plane:
-        return Plane(label=label, resolve=self.resolve, apply=self.apply, suspend=self.suspend)
+        return Plane(
+            label=label,
+            resolve=self.resolve,
+            current=self.current,
+            apply=self.apply,
+            suspend=self.suspend,
+            enabled=self.enabled,
+        )
 
 
 class _Clock:
@@ -56,129 +83,281 @@ class _Clock:
         self.now += seconds
 
 
-def _observer(*recorders: _Recorder, clock: _Clock | None = None) -> tuple[NetworkPlaneObserver, _Clock]:
-    clk = clock or _Clock()
+def _observer(*recorders: _Recorder) -> tuple[NetworkPlaneObserver, _Clock]:
+    clk = _Clock()
     planes = [r.plane(f"plane{i}") for i, r in enumerate(recorders)]
     return NetworkPlaneObserver(planes=planes, clock=clk), clk
 
 
-class TestFollowingAnInterface:
-    def test_first_poll_binds(self) -> None:
+def _poll_n(obs: NetworkPlaneObserver, clk: _Clock, n: int) -> None:
+    for _ in range(n):
+        obs.poll()
+        clk.advance()
+
+
+class TestComparesAgainstWhatIsBound:
+    """Keying idempotence on the previous resolution instead of the live
+    binding meant the first poll tore down and rebuilt a plane the runtime had
+    already bound correctly - which on PSN kills the retry thread that recovers
+    a boot where the multicast route came up late."""
+
+    def test_a_correctly_bound_plane_is_left_alone(self) -> None:
+        rec = _Recorder()
+        rec.bound = "192.168.1.5"  # services bound this at startup
+        obs, _clk = _observer(rec)
+        obs.poll()
+        assert rec.applied == []
+
+    def test_an_unbound_plane_is_bound(self) -> None:
         rec = _Recorder()
         obs, _clk = _observer(rec)
         obs.poll()
         assert rec.applied == ["192.168.1.5"]
 
-    def test_unchanged_state_does_not_rebind(self) -> None:
-        """A steady station must not churn its sockets once a second."""
+    def test_an_external_rebind_of_a_suspended_plane_is_noticed(self) -> None:
+        """Saving an unrelated setting restarts the output on a wildcard bind.
+        Keyed on the resolution, the observer would see an identical tuple and
+        never re-suspend, leaving it misrouted while the HUD says 'is down'."""
         rec = _Recorder()
         obs, clk = _observer(rec)
-        for _ in range(4):
-            obs.poll()
-            clk.advance()
-        assert rec.applied == ["192.168.1.5"]
+        rec.go_down()
+        _poll_n(obs, clk, DOWN_POLLS_BEFORE_SUSPEND)
+        assert rec.suspends == 1
 
-    def test_new_lease_on_the_same_interface_is_followed(self) -> None:
-        """Reconnecting a cable and getting a different DHCP address is normal.
-        Only the interface is fixed, so the plane must rebind to the new one."""
+        rec.bound = ""  # something else restarted it behind our back
+        _poll_n(obs, clk, 1)
+        assert rec.suspends == 2
+
+    def test_a_steady_station_does_no_work(self) -> None:
         rec = _Recorder()
+        rec.bound = "192.168.1.5"
         obs, clk = _observer(rec)
-        obs.poll()
-        rec.come_back("192.168.1.77")
-        clk.advance()
-        obs.poll()
-        assert rec.applied == ["192.168.1.5", "192.168.1.77"]
+        _poll_n(obs, clk, 5)
+        assert rec.applied == []
         assert rec.suspends == 0
 
 
-class TestFailingClosed:
-    def test_down_interface_suspends_instead_of_rebinding(self) -> None:
-        """The load-bearing rule: no traffic on an interface the operator did
-        not choose. A stopped output is diagnosable; a misrouted one is not."""
+class TestDebouncedSuspension:
+    """Apply and Renew DHCP lease both run nmcli con down then con up, so the
+    interface is legitimately addressless for a second or more. Suspending on
+    the first sample means the Network page's own buttons drop stage output."""
+
+    def test_a_brief_outage_does_not_suspend(self) -> None:
         rec = _Recorder()
+        rec.bound = "192.168.1.5"
         obs, clk = _observer(rec)
-        obs.poll()
         rec.go_down()
-        clk.advance()
-        obs.poll()
+        _poll_n(obs, clk, DOWN_POLLS_BEFORE_SUSPEND - 1)
+        assert rec.suspends == 0
+
+    def test_a_sustained_outage_suspends(self) -> None:
+        rec = _Recorder()
+        rec.bound = "192.168.1.5"
+        obs, clk = _observer(rec)
+        rec.go_down()
+        _poll_n(obs, clk, DOWN_POLLS_BEFORE_SUSPEND)
         assert rec.suspends == 1
+
+    def test_recovery_within_the_window_never_stops_output(self) -> None:
+        """The renew-lease case end to end: gone for a few polls, back before
+        the debounce expires, output never interrupted."""
+        rec = _Recorder()
+        rec.bound = "192.168.1.5"
+        obs, clk = _observer(rec)
+        rec.go_down()
+        _poll_n(obs, clk, DOWN_POLLS_BEFORE_SUSPEND - 1)
+        rec.come_back("192.168.1.5")
+        _poll_n(obs, clk, 1)
+        assert rec.suspends == 0
+
+    def test_suspend_fires_once_while_it_stays_down(self) -> None:
+        rec = _Recorder()
+        rec.bound = "192.168.1.5"
+        obs, clk = _observer(rec)
+        rec.go_down()
+        _poll_n(obs, clk, DOWN_POLLS_BEFORE_SUSPEND + 5)
+        assert rec.suspends == 1
+
+
+class TestRebuildAfterAnOutage:
+    """Removing an address drops the interface's multicast memberships and
+    routes. Getting the same DHCP lease back does not restore them, and
+    comparing address strings cannot see that."""
+
+    def test_same_lease_after_an_outage_still_rebuilds(self) -> None:
+        rec = _Recorder()
+        rec.bound = "192.168.1.5"
+        obs, clk = _observer(rec)
+        rec.go_down()
+        _poll_n(obs, clk, 2)
+        rec.come_back("192.168.1.5")  # identical address
+        _poll_n(obs, clk, 1)
         assert rec.applied == ["192.168.1.5"]
 
-    def test_suspend_happens_once_while_it_stays_down(self) -> None:
+    def test_new_lease_after_an_outage_rebuilds(self) -> None:
         rec = _Recorder()
+        rec.bound = "192.168.1.5"
         obs, clk = _observer(rec)
         rec.go_down()
-        for _ in range(4):
-            obs.poll()
-            clk.advance()
-        assert rec.suspends == 1
+        _poll_n(obs, clk, 2)
+        rec.come_back("192.168.1.77")
+        _poll_n(obs, clk, 1)
+        assert rec.applied == ["192.168.1.77"]
 
-    def test_interface_returning_resumes_automatically(self) -> None:
-        """No restart, no re-save - the operator plugs the cable back in."""
+    def test_resuming_from_suspended_rebuilds_and_clears_the_alert(self) -> None:
         rec = _Recorder()
+        rec.bound = "192.168.1.5"
         obs, clk = _observer(rec)
         rec.go_down()
-        obs.poll()
-        clk.advance()
-        rec.come_back("10.0.0.9")
-        obs.poll()
-        assert rec.applied == ["10.0.0.9"]
-
-    def test_alerts_name_the_plane_and_interface(self) -> None:
-        rec = _Recorder(iface="eth0.10")
-        obs, _clk = _observer(rec)
-        rec.go_down()
-        obs.poll()
-        assert obs.alerts() == ["plane0: eth0.10 is down"]
-
-    def test_alerts_clear_when_the_interface_returns(self) -> None:
-        rec = _Recorder()
-        obs, clk = _observer(rec)
-        rec.go_down()
-        obs.poll()
-        clk.advance()
+        _poll_n(obs, clk, DOWN_POLLS_BEFORE_SUSPEND)
         rec.come_back("192.168.1.5")
-        obs.poll()
+        _poll_n(obs, clk, 1)
+        assert rec.applied == ["192.168.1.5"]
         assert obs.alerts() == []
 
 
-class TestIsolationAndThrottling:
+class TestNoAddressAtAll:
+    def test_status_none_is_treated_as_down(self) -> None:
+        """Nothing configured and nothing detected means the station has no
+        address. Binding "" would hand the plane INADDR_ANY, i.e. whatever
+        interface the kernel picks."""
+        rec = _Recorder(address="", status="none", iface="")
+        obs, clk = _observer(rec)
+        _poll_n(obs, clk, DOWN_POLLS_BEFORE_SUSPEND)
+        assert rec.applied == []
+        assert rec.suspends == 1
+
+
+class TestDisabledPlanes:
+    def test_a_switched_off_output_is_never_touched_or_alerted(self) -> None:
+        """A disabled output is not broken, it is off. Alerting on it puts a
+        second fault on the HUD for a protocol nobody enabled."""
+        rec = _Recorder()
+        rec.is_enabled = False
+        rec.go_down()
+        obs, clk = _observer(rec)
+        _poll_n(obs, clk, DOWN_POLLS_BEFORE_SUSPEND + 2)
+        assert rec.suspends == 0
+        assert rec.applied == []
+        assert obs.alerts() == []
+
+    def test_disabling_clears_a_standing_alert(self) -> None:
+        rec = _Recorder()
+        obs, clk = _observer(rec)
+        rec.go_down()
+        _poll_n(obs, clk, DOWN_POLLS_BEFORE_SUSPEND)
+        assert obs.alerts()
+        rec.is_enabled = False
+        _poll_n(obs, clk, 1)
+        assert obs.alerts() == []
+
+
+class TestFailureHandling:
+    def test_a_failing_plane_backs_off_instead_of_retrying_every_poll(self) -> None:
+        """Each PSN retry is four stop/start cycles with thread joins on the
+        GTK thread; once a second for the length of a show is not acceptable."""
+        rec = _Recorder()
+        attempts = [0]
+        original = rec.apply
+
+        def _counting(address: str) -> None:
+            attempts[0] += 1
+            original(address)
+
+        rec.apply = _counting  # type: ignore[method-assign]
+        rec.apply_error = OSError("bind failed")
+        obs, clk = _observer(rec)
+        _poll_n(obs, clk, 6)
+        assert attempts[0] < 6, "retried on every poll instead of backing off"
+
+    def test_a_failing_plane_raises_an_alert(self) -> None:
+        """It is exactly as dead as a suspended one, and used to surface
+        nowhere at all."""
+        rec = _Recorder()
+        rec.apply_error = OSError("bind failed")
+        obs, _clk = _observer(rec)
+        obs.poll()
+        assert obs.alerts() == ["plane0: bind failed"]
+
+    def test_a_recovered_plane_clears_its_alert(self) -> None:
+        rec = _Recorder()
+        rec.apply_error = OSError("bind failed")
+        obs, clk = _observer(rec)
+        obs.poll()
+        rec.apply_error = None
+        clk.advance(120.0)  # past the backoff window
+        obs.poll()
+        assert obs.alerts() == []
+        assert rec.applied == ["192.168.1.5"]
+
     def test_one_failing_plane_does_not_stop_the_others(self) -> None:
-        """A stalled OTP rebind cannot be allowed to leave PSN on a dead
-        address."""
         broken = _Recorder()
+        broken.apply_error = OSError("bind failed")
         healthy = _Recorder(address="10.0.0.9", iface="eth1")
-
-        def _boom(_address: str) -> None:
-            raise OSError("bind failed")
-
-        obs = NetworkPlaneObserver(
-            planes=[
-                Plane(label="broken", resolve=broken.resolve, apply=_boom, suspend=broken.suspend),
-                healthy.plane("healthy"),
-            ],
-            clock=_Clock(),
-        )
+        obs, _clk = _observer(broken, healthy)
         obs.poll()
         assert healthy.applied == ["10.0.0.9"]
 
+
+class TestAlertsAndThrottling:
+    def test_alerts_name_the_plane_and_interface(self) -> None:
+        rec = _Recorder(iface="eth0.10")
+        obs, clk = _observer(rec)
+        rec.go_down()
+        _poll_n(obs, clk, DOWN_POLLS_BEFORE_SUSPEND)
+        assert obs.alerts() == ["plane0: eth0.10 is down"]
+
+    def test_alerts_follow_plane_order(self) -> None:
+        """Sorted output would reshuffle the rows between frames."""
+        first = _Recorder(iface="zzz0")
+        second = _Recorder(iface="aaa0")
+        obs, clk = _observer(first, second)
+        first.go_down()
+        second.go_down()
+        _poll_n(obs, clk, DOWN_POLLS_BEFORE_SUSPEND)
+        assert obs.alerts() == ["plane0: zzz0 is down", "plane1: aaa0 is down"]
+
+    def test_alert_falls_back_when_the_interface_cannot_be_named(self) -> None:
+        rec = _Recorder(iface="")
+        obs, clk = _observer(rec)
+        rec.go_down()
+        _poll_n(obs, clk, DOWN_POLLS_BEFORE_SUSPEND)
+        assert obs.alerts() == ["plane0: interface is down"]
+
+    def test_alert_survives_a_resolver_that_raises(self) -> None:
+        """Rendering the HUD must not depend on nmcli still answering."""
+        rec = _Recorder()
+        failing = {"now": False}
+
+        def _resolve() -> tuple[str, str, str]:
+            if failing["now"]:
+                raise OSError("nmcli gone")
+            return rec.resolve()
+
+        plane = Plane(
+            label="plane0",
+            resolve=_resolve,
+            current=rec.current,
+            apply=rec.apply,
+            suspend=rec.suspend,
+        )
+        clk = _Clock()
+        obs = NetworkPlaneObserver(planes=[plane], clock=clk)
+        rec.go_down()
+        _poll_n(obs, clk, DOWN_POLLS_BEFORE_SUSPEND)
+        failing["now"] = True
+        assert obs.alerts() == ["plane0: interface is down"]
+
     def test_poll_is_throttled(self) -> None:
-        """Interface enumeration costs a psutil call and housekeeping runs at
-        100ms, so the observer must not resolve on every tick."""
         rec = _Recorder()
         obs, clk = _observer(rec)
-        obs.poll()
-        rec.come_back("10.0.0.9")
-        obs.poll()  # same instant - throttled
-        assert rec.applied == ["192.168.1.5"]
+        assert obs.poll() is True
+        assert obs.poll() is False
         clk.advance()
-        obs.poll()
-        assert rec.applied == ["192.168.1.5", "10.0.0.9"]
+        assert obs.poll() is True
 
     def test_force_bypasses_the_throttle(self) -> None:
         rec = _Recorder()
         obs, _clk = _observer(rec)
         obs.poll()
-        rec.come_back("10.0.0.9")
-        obs.poll(force=True)
-        assert rec.applied == ["192.168.1.5", "10.0.0.9"]
+        assert obs.poll(force=True) is True

--- a/tests/test_network_observer.py
+++ b/tests/test_network_observer.py
@@ -35,8 +35,10 @@ class _Recorder:
         self.suspends = 0
         self.is_enabled = True
         self.apply_error: Exception | None = None
+        self.resolves = 0
 
     def resolve(self) -> tuple[str, str, str]:
+        self.resolves += 1
         return self.address, self.status, self.iface
 
     def current(self) -> str | None:
@@ -325,7 +327,12 @@ class TestAlertsAndThrottling:
         assert obs.alerts() == ["plane0: interface is down"]
 
     def test_alert_survives_a_resolver_that_raises(self) -> None:
-        """Rendering the HUD must not depend on nmcli still answering."""
+        """Rendering the HUD must not depend on nmcli still answering.
+
+        ``alerts()`` reads the interface name cached by the last poll, so a
+        backend that has since died cannot reach the render path at all - and
+        the operator still gets the interface named rather than a placeholder.
+        """
         rec = _Recorder()
         failing = {"now": False}
 
@@ -346,7 +353,7 @@ class TestAlertsAndThrottling:
         rec.go_down()
         _poll_n(obs, clk, DOWN_POLLS_BEFORE_SUSPEND)
         failing["now"] = True
-        assert obs.alerts() == ["plane0: interface is down"]
+        assert obs.alerts() == ["plane0: eth0 is down"]
 
     def test_a_plane_never_polled_contributes_no_alert(self) -> None:
         """A plane added but not yet reached - a disabled one, or the first
@@ -368,3 +375,35 @@ class TestAlertsAndThrottling:
         obs, _clk = _observer(rec)
         obs.poll()
         assert obs.poll(force=True) is True
+
+
+class TestAlertsStayOffTheRenderPath:
+    """``alerts()`` feeds the HUD, so it runs once per rendered frame.
+
+    Resolving there walked every interface via psutil for as long as an outage
+    lasted - at 60-120 Hz, on the frame loop, exactly while the station is
+    already in trouble.
+    """
+
+    def test_alerts_never_resolve(self) -> None:
+        rec = _Recorder()
+        rec.bound = "192.168.1.5"
+        obs, clk = _observer(rec)
+        rec.go_down()
+        _poll_n(obs, clk, DOWN_POLLS_BEFORE_SUSPEND)
+        assert obs.alerts(), "expected a suspended plane to raise an alert"
+
+        before = rec.resolves
+        for _ in range(120):
+            obs.alerts()
+        assert rec.resolves == before
+
+    def test_the_alert_still_names_the_interface(self) -> None:
+        """Caching must not cost the operator the one detail that makes the
+        line actionable."""
+        rec = _Recorder(iface="eth0.10")
+        rec.bound = "192.168.1.5"
+        obs, clk = _observer(rec)
+        rec.go_down()
+        _poll_n(obs, clk, DOWN_POLLS_BEFORE_SUSPEND)
+        assert any("eth0.10" in line for line in obs.alerts())

--- a/tests/test_otp.py
+++ b/tests/test_otp.py
@@ -1328,3 +1328,28 @@ class TestOtpHandleSendErrorEdges:
             srv._stop_event.set()
             if srv._socket_thread is not None:
                 srv._socket_thread.join(timeout=2.0)
+
+
+class TestOtpBoundSourceIp:
+    """Lets the observer tell a correctly bound output from one needing a
+    rebind, without stopping it to find out."""
+
+    def _server(self):
+        from openfollow.otp.server import OtpServer
+
+        return OtpServer(system_name="X", system_number=1, port=5568, source_ip="10.0.0.9")
+
+    def test_reports_none_before_start(self) -> None:
+        assert self._server().bound_source_ip() is None
+
+    def test_reports_the_address_while_running(self) -> None:
+        srv = self._server()
+        srv._stop_event.clear()
+        srv._transform_thread = object()
+        assert srv.bound_source_ip() == "10.0.0.9"
+
+    def test_reports_none_once_stopped(self) -> None:
+        srv = self._server()
+        srv._transform_thread = object()
+        srv._stop_event.set()
+        assert srv.bound_source_ip() is None

--- a/tests/test_overlay_draw_hud.py
+++ b/tests/test_overlay_draw_hud.py
@@ -1021,6 +1021,27 @@ class TestBottomLeftInfoPanel:
         assert spans[1][0] > spans[0][0]
         assert spans[1][1] < spans[0][1]
 
+    def test_down_plane_alerts_render_on_the_panel(self) -> None:
+        """When the interface carrying the web UI is the one that went away,
+        the HUD is the only surface the operator has left."""
+        state = _base_state(ip_text="192.168.1.2")
+        state.network_alerts = ["PSN: eth0.10 is down", "OTP output: eth0.20 is down"]
+        cr = FakeCairo()
+        draw_bottom_left_info_panel(FakeRenderer(state=state), cr, state, 1920, 1080)
+        texts = cr.show_text_strings()
+        assert "Network:" in texts
+        assert "PSN: eth0.10 is down" in texts
+        assert "OTP output: eth0.20 is down" in texts
+        # Labelled once, so a multi-plane outage doesn't repeat the word.
+        assert texts.count("Network:") == 1
+
+    def test_no_network_row_when_every_plane_is_up(self) -> None:
+        state = _base_state(ip_text="192.168.1.2")
+        state.network_alerts = []
+        cr = FakeCairo()
+        draw_bottom_left_info_panel(FakeRenderer(state=state), cr, state, 1920, 1080)
+        assert "Network:" not in cr.show_text_strings()
+
     def test_empty_ip_falls_back_to_unavailable(self) -> None:
         state = _base_state(ip_text="")
         cr = FakeCairo()

--- a/tests/test_psn_receiver.py
+++ b/tests/test_psn_receiver.py
@@ -169,3 +169,69 @@ def test_receiver_eviction_sweep_is_throttled(monkeypatch) -> None:
     receiver._on_packet(_FakeDataPacket([_PacketTracker(1, _Vec(0.0, 0.0, 0.0), _Vec(0.0, 0.0, 0.0))]))
     receiver._on_packet(_FakeDataPacket([_PacketTracker(1, _Vec(0.0, 0.0, 0.0), _Vec(0.0, 0.0, 0.0))]))
     assert 99 in receiver._last_seen  # throttled – not yet swept
+
+
+class TestBoundedStop:
+    """pypsn's own stop() does a plain join() with no timeout while run() is
+    blocked in recvfrom. Closing the fd does not reliably wake a thread already
+    parked there, so the join waits out the socket timeout - and this is now
+    called from housekeeping on the GTK thread, where it stalls the render
+    loop and marker motion."""
+
+    def _receiver(self, *, alive: bool, sock=None):
+        from openfollow.psn.receiver import _RobustReceiver
+
+        rx = _RobustReceiver.__new__(_RobustReceiver)
+        rx.running = True
+        rx.socket = sock
+        rx.joins = []
+        rx.join = lambda timeout=None: rx.joins.append(timeout)  # type: ignore[method-assign]
+        rx.is_alive = lambda: alive  # type: ignore[method-assign]
+        return rx
+
+    def test_join_is_bounded(self) -> None:
+        from openfollow.psn.receiver import _RobustReceiver
+
+        rx = self._receiver(alive=False)
+        rx.stop()
+        assert rx.running is False
+        assert rx.joins == [_RobustReceiver._JOIN_TIMEOUT_S]
+
+    def test_socket_is_closed_and_a_close_error_is_swallowed(self) -> None:
+        class _Sock:
+            def __init__(self) -> None:
+                self.closed = 0
+
+            def close(self) -> None:
+                self.closed += 1
+                raise OSError("already gone")
+
+        sock = _Sock()
+        rx = self._receiver(alive=False, sock=sock)
+        rx.stop()
+        assert sock.closed == 1
+
+    def test_a_thread_that_will_not_die_is_logged_not_awaited(self, caplog) -> None:
+        rx = self._receiver(alive=True)
+        with caplog.at_level("WARNING"):
+            rx.stop()
+        assert any("did not stop" in r.message for r in caplog.records)
+
+
+class TestBoundSourceIp:
+    """Drives the observer's 'already bound correctly, leave it alone'
+    decision, which is what keeps the first poll from tearing down a healthy
+    startup binding."""
+
+    def test_reports_none_when_stopped(self) -> None:
+        from openfollow.psn.receiver import PsnReceiver
+
+        rx = PsnReceiver(source_ip="192.168.1.5")
+        assert rx.bound_source_ip() is None
+
+    def test_reports_the_address_when_running(self) -> None:
+        from openfollow.psn.receiver import PsnReceiver
+
+        rx = PsnReceiver(source_ip="192.168.1.5")
+        rx._receiver = object()
+        assert rx.bound_source_ip() == "192.168.1.5"

--- a/tests/test_psn_server.py
+++ b/tests/test_psn_server.py
@@ -323,3 +323,26 @@ def test_handle_send_error_noop_when_stopping() -> None:
 
     assert server._socket is sentinel_socket  # untouched
     assert server._socket_thread is None  # no recovery thread spawned
+
+
+class TestBoundSourceIp:
+    """Drives the observer's 'already bound correctly, leave it alone'
+    decision. Without it the first poll calls rebind(), which kills the
+    background retry thread that recovers a boot where the multicast route
+    came up late - turning a self-healing boot into a permanent outage."""
+
+    def test_reports_none_before_start(self) -> None:
+        srv = PsnServer(source_ip="192.168.1.5", mcast_ip="236.10.10.10")
+        assert srv.bound_source_ip() is None
+
+    def test_reports_the_address_while_running(self) -> None:
+        srv = PsnServer(source_ip="192.168.1.5", mcast_ip="236.10.10.10")
+        srv._stop_event.clear()
+        srv._data_thread = object()  # type: ignore[assignment]
+        assert srv.bound_source_ip() == "192.168.1.5"
+
+    def test_reports_none_once_stopped(self) -> None:
+        srv = PsnServer(source_ip="192.168.1.5", mcast_ip="236.10.10.10")
+        srv._data_thread = object()  # type: ignore[assignment]
+        srv._stop_event.set()
+        assert srv.bound_source_ip() is None

--- a/tests/test_services_marker_visuals_remaining.py
+++ b/tests/test_services_marker_visuals_remaining.py
@@ -214,6 +214,7 @@ def _build(
     *,
     system_stats: Any = None,
     person_detector: Any = None,
+    network_alerts: list[str] | None = None,
 ) -> OverlayState:
     # Controller badge is stamped from InputManager.get_controller_info.
     return build_marker_visual_state(
@@ -222,6 +223,7 @@ def _build(
         system_stats=system_stats,
         person_detector=person_detector,
         cam_params_buffer=np.zeros(7, dtype=np.float64),
+        network_alerts=network_alerts,
     )
 
 
@@ -353,6 +355,30 @@ class TestSystemStatsFlow:
         collector = SimpleNamespace(update=lambda: stats)
         state = _build(app, pool, system_stats=collector)
         assert state.ip_is_fallback is expected
+
+
+class TestNetworkAlerts:
+    """The observer-to-HUD seam. Nothing asserted this end to end, so blanking
+    the field left the whole suite green while the one surface an operator has
+    during an outage silently went empty."""
+
+    def test_alerts_reach_the_overlay_state(self, pool: OverlayStatePool) -> None:
+        app = _build_app()
+        state = _build(app, pool, network_alerts=["PSN: eth0.10 is down"])
+        assert state.network_alerts == ["PSN: eth0.10 is down"]
+
+    def test_no_alerts_leaves_the_field_empty(self, pool: OverlayStatePool) -> None:
+        app = _build_app()
+        assert _build(app, pool).network_alerts == []
+
+    def test_the_state_owns_its_copy(self, pool: OverlayStatePool) -> None:
+        """The observer rebuilds its list each poll; the overlay must not hold
+        a reference that mutates under the renderer mid-frame."""
+        app = _build_app()
+        alerts = ["PSN: eth0 is down"]
+        state = _build(app, pool, network_alerts=alerts)
+        alerts.append("OTP output: eth1 is down")
+        assert state.network_alerts == ["PSN: eth0 is down"]
 
 
 class TestHostnameRow:

--- a/tests/test_services_startup.py
+++ b/tests/test_services_startup.py
@@ -1076,3 +1076,81 @@ def test_plane_current_reports_the_live_binding(monkeypatch) -> None:
     planes = {p.label: p for p in services._build_network_planes()}
     assert planes["PSN"].current() == "192.168.1.5"
     assert planes["OTP output"].current() is None
+
+
+class _FollowerSync:
+    def __init__(self) -> None:
+        self.ips: list[str] = []
+        self.reopens = 0
+
+    def update_iface_ip(self, ip: str) -> None:
+        self.ips.append(ip)
+
+    def reopen(self) -> None:
+        self.reopens += 1
+
+
+class _FollowerServer:
+    def __init__(self) -> None:
+        self.refreshes = 0
+        self.reopens = 0
+
+    def refresh_local_ip(self) -> None:
+        self.refreshes += 1
+
+    def reopen_beacons(self) -> None:
+        self.reopens += 1
+
+
+def _wire_followers(services):
+    sync, server = _FollowerSync(), _FollowerServer()
+    services._app._marker_catalog_sync = sync
+    services._app._web_server = server
+    return sync, server
+
+
+def test_station_followers_rebuild_after_a_same_lease_flap(monkeypatch) -> None:
+    """The observer forces its own planes to rebuild after an outage even at an
+    unchanged address; the followers short-circuit on an unchanged IP, so a
+    replug returning the same lease left catalog sync and the beacon joined to
+    memberships the kernel had already dropped - converging with nobody while
+    looking healthy."""
+    services = _build_services_with_psutil_backend(monkeypatch)
+    services._app._config.psn_source_iface = "eth0"
+    sync, server = _wire_followers(services)
+
+    _fake_ifaces(monkeypatch, {"eth0": "192.168.1.5"})
+    services._follow_station_ip()
+    assert (sync.reopens, server.reopens) == (0, 0)
+
+    _fake_ifaces(monkeypatch, {})  # cable out
+    services._follow_station_ip()
+
+    _fake_ifaces(monkeypatch, {"eth0": "192.168.1.5"})  # same lease back
+    services._follow_station_ip()
+    assert sync.reopens == 1
+    assert server.reopens == 1
+
+
+def test_a_steady_station_never_forces_a_rebuild(monkeypatch) -> None:
+    """Rebuilding sockets once a second would be worse than the bug."""
+    services = _build_services_with_psutil_backend(monkeypatch)
+    services._app._config.psn_source_iface = "eth0"
+    sync, server = _wire_followers(services)
+    _fake_ifaces(monkeypatch, {"eth0": "192.168.1.5"})
+    for _ in range(5):
+        services._follow_station_ip()
+    assert (sync.reopens, server.reopens) == (0, 0)
+
+
+def test_the_outage_flag_clears_after_one_recovery(monkeypatch) -> None:
+    services = _build_services_with_psutil_backend(monkeypatch)
+    services._app._config.psn_source_iface = "eth0"
+    sync, server = _wire_followers(services)
+    _fake_ifaces(monkeypatch, {})
+    services._follow_station_ip()
+    _fake_ifaces(monkeypatch, {"eth0": "192.168.1.5"})
+    services._follow_station_ip()
+    services._follow_station_ip()
+    assert sync.reopens == 1
+    assert server.reopens == 1

--- a/tests/test_services_startup.py
+++ b/tests/test_services_startup.py
@@ -915,3 +915,68 @@ def test_follow_station_ip_tolerates_missing_services(monkeypatch) -> None:
 def test_alerts_are_empty_before_the_first_poll(monkeypatch) -> None:
     services = _build_services_with_psutil_backend(monkeypatch)
     assert services.network_alerts() == []
+
+
+def test_applying_psn_routes_through_the_rebind_orchestrator(monkeypatch) -> None:
+    services = _build_services_with_psutil_backend(monkeypatch)
+    applied: list[str] = []
+    services.apply_psn_source_ip_change = applied.append  # type: ignore[method-assign]
+    psn = next(p for p in services._build_network_planes() if p.label == "PSN")
+    psn.apply("10.0.0.9")
+    assert applied == ["10.0.0.9"]
+
+
+def test_suspending_psn_tolerates_a_service_that_never_started(monkeypatch) -> None:
+    services = _build_services_with_psutil_backend(monkeypatch)
+    services._app._server = None
+    services._app._psn_receiver = None
+    next(p for p in services._build_network_planes() if p.label == "PSN").suspend()
+
+
+def test_applying_otp_re_resolves_through_its_orchestrator(monkeypatch) -> None:
+    """The orchestrator resolves the pin itself, so it binds the address this
+    poll observed rather than one the observer passed along."""
+    services = _build_services_with_psutil_backend(monkeypatch)
+    applied: list[object] = []
+    services.apply_otp_output_change = applied.append  # type: ignore[method-assign]
+    otp = next(p for p in services._build_network_planes() if p.label == "OTP output")
+    otp.apply("10.0.0.9")
+    assert applied == [services._app._config.otp_output]
+
+
+def test_suspending_otp_stops_the_server(monkeypatch) -> None:
+    services = _build_services_with_psutil_backend(monkeypatch)
+
+    class _Server:
+        def __init__(self) -> None:
+            self.stopped = 0
+
+        def stop(self) -> None:
+            self.stopped += 1
+
+    server = _Server()
+    services._app._otp_server = server
+    otp = next(p for p in services._build_network_planes() if p.label == "OTP output")
+    otp.suspend()
+    assert server.stopped == 1
+    services._app._otp_server = None
+    otp.suspend()  # no server to stop
+
+
+def test_observe_builds_the_observer_once_and_follows_the_station(monkeypatch) -> None:
+    """Housekeeping calls this ~10x/s; rebuilding the plane list each time
+    would re-enumerate interfaces on every tick."""
+    services = _build_services_with_psutil_backend(monkeypatch)
+    _fake_ifaces(monkeypatch, {"eth0": "192.168.1.5"})
+    services._app._config.psn_source_iface = "eth0"
+    services.apply_psn_source_ip_change = lambda _ip: None  # type: ignore[method-assign]
+    services.apply_otp_output_change = lambda _cfg: None  # type: ignore[method-assign]
+
+    followed: list[int] = []
+    services._follow_station_ip = lambda: followed.append(1)  # type: ignore[method-assign]
+
+    services.observe_network_planes()
+    first = services._network_observer
+    services.observe_network_planes()
+    assert services._network_observer is first
+    assert len(followed) == 2

--- a/tests/test_services_startup.py
+++ b/tests/test_services_startup.py
@@ -963,20 +963,116 @@ def test_suspending_otp_stops_the_server(monkeypatch) -> None:
     otp.suspend()  # no server to stop
 
 
-def test_observe_builds_the_observer_once_and_follows_the_station(monkeypatch) -> None:
+def test_observe_builds_the_observer_once(monkeypatch) -> None:
     """Housekeeping calls this ~10x/s; rebuilding the plane list each time
     would re-enumerate interfaces on every tick."""
     services = _build_services_with_psutil_backend(monkeypatch)
     _fake_ifaces(monkeypatch, {"eth0": "192.168.1.5"})
     services._app._config.psn_source_iface = "eth0"
     services.apply_psn_source_ip_change = lambda _ip: None  # type: ignore[method-assign]
-    services.apply_otp_output_change = lambda _cfg: None  # type: ignore[method-assign]
-
-    followed: list[int] = []
-    services._follow_station_ip = lambda: followed.append(1)  # type: ignore[method-assign]
+    services._follow_station_ip = lambda: None  # type: ignore[method-assign]
 
     services.observe_network_planes()
     first = services._network_observer
     services.observe_network_planes()
     assert services._network_observer is first
-    assert len(followed) == 2
+
+
+def test_station_followers_share_the_observer_throttle(monkeypatch) -> None:
+    """Resolving the station address enumerates every adapter, and
+    housekeeping runs at 100ms - paying that ten times a second on the render
+    thread is exactly what the observer's own throttle exists to avoid."""
+    services = _build_services_with_psutil_backend(monkeypatch)
+    _fake_ifaces(monkeypatch, {"eth0": "192.168.1.5"})
+    services._app._config.psn_source_iface = "eth0"
+    services.apply_psn_source_ip_change = lambda _ip: None  # type: ignore[method-assign]
+
+    followed: list[int] = []
+    services._follow_station_ip = lambda: followed.append(1)  # type: ignore[method-assign]
+
+    services.observe_network_planes()
+    services.observe_network_planes()  # same instant - throttled
+    assert len(followed) == 1
+
+
+def test_station_followers_do_not_move_to_another_interface(monkeypatch) -> None:
+    """The station interface being down must not put this station's identity -
+    its name, marker names and colours - on whatever else happens to be up, at
+    the exact moment the observer is stopping PSN for that same reason."""
+    services = _build_services_with_psutil_backend(monkeypatch)
+    _fake_ifaces(monkeypatch, {"eth1": "10.0.0.9"})
+    services._app._config.psn_source_iface = "eth0_gone"
+
+    class _Sync:
+        def __init__(self) -> None:
+            self.ips: list[str] = []
+
+        def update_iface_ip(self, ip: str) -> None:
+            self.ips.append(ip)
+
+    class _Server:
+        def __init__(self) -> None:
+            self.refreshes = 0
+
+        def refresh_local_ip(self) -> None:
+            self.refreshes += 1
+
+    sync, server = _Sync(), _Server()
+    services._app._marker_catalog_sync = sync
+    services._app._web_server = server
+    services._follow_station_ip()
+    assert sync.ips == []
+    assert server.refreshes == 0
+
+
+def test_suspending_psn_stops_the_receiver_even_if_the_server_raises(monkeypatch) -> None:
+    """Aborting on the first failure left the receiver joined on the dead
+    address - the exact outcome the suspend exists to prevent - and swallowed
+    the HUD alert with it."""
+    services = _build_services_with_psutil_backend(monkeypatch)
+
+    class _Boom:
+        def stop(self) -> None:
+            raise OSError("stop failed")
+
+    class _Stoppable:
+        def __init__(self) -> None:
+            self.stopped = 0
+
+        def stop(self) -> None:
+            self.stopped += 1
+
+    receiver = _Stoppable()
+    services._app._server = _Boom()
+    services._app._psn_receiver = receiver
+    psn = next(p for p in services._build_network_planes() if p.label == "PSN")
+    with pytest.raises(OSError, match="stop failed"):
+        psn.suspend()
+    assert receiver.stopped == 1
+
+
+def test_a_disabled_otp_output_is_not_a_plane_to_alert_on(monkeypatch) -> None:
+    """The shipped default has OTP off; a false 'is down' row would put a
+    second fault on the HUD for a protocol nobody enabled."""
+    services = _build_services_with_psutil_backend(monkeypatch)
+    otp = next(p for p in services._build_network_planes() if p.label == "OTP output")
+    services._app._config.otp_output.enabled = False
+    assert otp.enabled() is False
+    services._app._config.otp_output.enabled = True
+    assert otp.enabled() is True
+
+
+def test_plane_current_reports_the_live_binding(monkeypatch) -> None:
+    """Drives the 'already bound correctly, leave it alone' decision, which is
+    what keeps the first poll from tearing down a healthy startup binding."""
+    services = _build_services_with_psutil_backend(monkeypatch)
+
+    class _Server:
+        def bound_source_ip(self) -> str | None:
+            return "192.168.1.5"
+
+    services._app._server = _Server()
+    services._app._otp_server = None
+    planes = {p.label: p for p in services._build_network_planes()}
+    assert planes["PSN"].current() == "192.168.1.5"
+    assert planes["OTP output"].current() is None

--- a/tests/test_services_startup.py
+++ b/tests/test_services_startup.py
@@ -810,3 +810,108 @@ def test_network_interfaces_provider_degrades_one_failing_row(monkeypatch) -> No
     rows = {r["name"]: r for r in services._network_interfaces_provider()}
     assert rows["eth0"]["address"] == ""
     assert rows["eth1"]["address"] == "10.0.0.9"
+
+
+# --------------------------------------------------------------------------- #
+# Network plane observer wiring
+# --------------------------------------------------------------------------- #
+
+
+def _fake_ifaces(monkeypatch, spec: dict[str, str]) -> None:
+    import socket as _socket
+    from types import SimpleNamespace
+
+    import openfollow.net_utils as net_utils_module
+
+    monkeypatch.setattr(
+        net_utils_module.psutil,
+        "net_if_addrs",
+        lambda: {name: [SimpleNamespace(family=_socket.AF_INET, address=addr)] for name, addr in spec.items()},
+    )
+
+
+def test_planes_resolve_their_own_and_the_station_interface(monkeypatch) -> None:
+    """PSN is the station itself; OTP inherits it only when its own pin is blank."""
+    services = _build_services_with_psutil_backend(monkeypatch)
+    _fake_ifaces(monkeypatch, {"eth0": "192.168.1.5", "eth1": "10.0.0.9"})
+    services._app._config.psn_source_iface = "eth0"
+    services._app._config.otp_output.source_iface = "eth1"
+
+    resolved = {p.label: p.resolve() for p in services._build_network_planes()}
+    assert resolved["PSN"] == ("192.168.1.5", "iface", "eth0")
+    assert resolved["OTP output"] == ("10.0.0.9", "iface", "eth1")
+
+    services._app._config.otp_output.source_iface = ""
+    resolved = {p.label: p.resolve() for p in services._build_network_planes()}
+    assert resolved["OTP output"] == ("192.168.1.5", "station", "eth0")
+
+
+def test_a_down_plane_reports_down_not_another_interface(monkeypatch) -> None:
+    services = _build_services_with_psutil_backend(monkeypatch)
+    _fake_ifaces(monkeypatch, {"eth0": "192.168.1.5"})
+    services._app._config.psn_source_iface = "eth0"
+    services._app._config.otp_output.source_iface = "eth_gone"
+
+    resolved = {p.label: p.resolve() for p in services._build_network_planes()}
+    assert resolved["OTP output"] == ("", "down", "eth_gone")
+
+
+def test_suspending_psn_stops_both_directions(monkeypatch) -> None:
+    """Leaving the receiver joined on a dead address would keep viewer markers
+    showing stale positions."""
+    services = _build_services_with_psutil_backend(monkeypatch)
+
+    class _Stoppable:
+        def __init__(self) -> None:
+            self.stopped = 0
+
+        def stop(self) -> None:
+            self.stopped += 1
+
+    server, receiver = _Stoppable(), _Stoppable()
+    services._app._server = server
+    services._app._psn_receiver = receiver
+    psn = next(p for p in services._build_network_planes() if p.label == "PSN")
+    psn.suspend()
+    assert (server.stopped, receiver.stopped) == (1, 1)
+
+
+def test_station_followers_are_repointed_without_a_web_request(monkeypatch) -> None:
+    """These used to heal only from a request path, so a station whose address
+    changed stayed stale unless somebody had a browser tab open."""
+    services = _build_services_with_psutil_backend(monkeypatch)
+    _fake_ifaces(monkeypatch, {"eth0": "192.168.1.5"})
+    services._app._config.psn_source_iface = "eth0"
+
+    class _Server:
+        def __init__(self) -> None:
+            self.refreshes = 0
+
+        def refresh_local_ip(self) -> None:
+            self.refreshes += 1
+
+    class _Sync:
+        def __init__(self) -> None:
+            self.ips: list[str] = []
+
+        def update_iface_ip(self, ip: str) -> None:
+            self.ips.append(ip)
+
+    server, sync = _Server(), _Sync()
+    services._app._web_server = server
+    services._app._marker_catalog_sync = sync
+    services._follow_station_ip()
+    assert server.refreshes == 1
+    assert sync.ips == ["192.168.1.5"]
+
+
+def test_follow_station_ip_tolerates_missing_services(monkeypatch) -> None:
+    services = _build_services_with_psutil_backend(monkeypatch)
+    services._app._web_server = None
+    services._app._marker_catalog_sync = None
+    services._follow_station_ip()
+
+
+def test_alerts_are_empty_before_the_first_poll(monkeypatch) -> None:
+    services = _build_services_with_psutil_backend(monkeypatch)
+    assert services.network_alerts() == []

--- a/tests/test_web_discovery.py
+++ b/tests/test_web_discovery.py
@@ -1345,3 +1345,26 @@ def test_beacon_receiver_recv_loop_dispatches_then_exits_on_stop() -> None:
 
     receiver._recv_loop(_OneThenStop())
     assert receiver.packets_received == 1
+
+
+class TestPublicReopen:
+    """A link that flapped needs both sockets rebuilt even at an unchanged
+    address: the kernel drops the group membership and the egress route when
+    the address is removed, and the same address returning does not restore
+    either - so the unchanged-IP guard in update_iface_ip is not enough."""
+
+    def test_sender_reopen_arms_a_rebuild(self) -> None:
+        from openfollow.web.discovery import BeaconSender
+
+        sender = BeaconSender(name="Node", web_port=80, version="0.1.0", iface_ip="")
+        assert not sender._reopen.is_set()
+        sender.reopen()
+        assert sender._reopen.is_set()
+
+    def test_receiver_reopen_arms_a_rebuild(self) -> None:
+        from openfollow.web.discovery import BeaconReceiver
+
+        receiver = BeaconReceiver()
+        assert not receiver._reopen.is_set()
+        receiver.reopen()
+        assert receiver._reopen.is_set()

--- a/tests/test_web_server_unit.py
+++ b/tests/test_web_server_unit.py
@@ -1328,3 +1328,15 @@ def test_refresh_local_ip_is_publicly_callable(tmp_path, monkeypatch) -> None:
     srv._local_ip_provider = lambda: "10.0.0.77"
     srv.refresh_local_ip()
     assert srv.local_ip == "10.0.0.77"
+
+
+def test_reopen_beacons_rebuilds_both_sockets(tmp_path, monkeypatch) -> None:
+    """Recovery from an interface outage: the unchanged-IP guard in
+    update_iface_ip is not enough, because the kernel already dropped the
+    membership and the route while the address string stayed put."""
+    srv = _make_quiet_server(tmp_path, monkeypatch)
+    srv._beacon_sender._reopen.clear()
+    srv._beacon_receiver._reopen.clear()
+    srv.reopen_beacons()
+    assert srv._beacon_sender._reopen.is_set()
+    assert srv._beacon_receiver._reopen.is_set()

--- a/tests/test_web_server_unit.py
+++ b/tests/test_web_server_unit.py
@@ -1314,3 +1314,17 @@ def test_pinned_bind_gets_a_loopback_listener(tmp_path, monkeypatch) -> None:
     assert srv._needs_loopback_listener() is True
     for host in ("127.0.0.1", "::1", "0.0.0.0", ""):
         assert _make_quiet_server(tmp_path, monkeypatch, host=host)._needs_loopback_listener() is False
+
+
+def test_refresh_local_ip_is_publicly_callable(tmp_path, monkeypatch) -> None:
+    """The runtime observer drives the refresh on a timer. It used to happen
+    only on a request path, so a station whose address changed healed its
+    self-row and beacon interface only while a browser tab was open."""
+    monkeypatch.setattr(
+        "openfollow.web.server.get_local_ipv4_addresses",
+        lambda: {"10.0.0.55"},
+    )
+    srv = _make_quiet_server(tmp_path, monkeypatch, local_ip="10.0.0.55")
+    srv._local_ip_provider = lambda: "10.0.0.77"
+    srv.refresh_local_ip()
+    assert srv.local_ip == "10.0.0.77"


### PR DESCRIPTION
Third of the stacked PRs for #50. **Stacked on #66** – review that first; the
diff here is only this PR's commits. Absorbs #26.

## What was missing

#65 and #66 gave a plane a *configured interface*. Nothing watched it
afterwards, so a plane bound at startup stayed bound to whatever it resolved
then. Two concrete failures fall out of that.

**A cable unplugged and plugged back in.** On DHCP the interface often returns
with a different address. `PsnServer` freezes the literal IP at construction and
`resolve_iface_ip` returns a non-empty argument verbatim (`net_utils.py:151`),
so its recovery thread re-binds that same dead address every two seconds,
forever. The show-data plane never comes back, while the web UI and the beacon
look perfectly healthy.

**An interface switch.** `MarkerCatalogSync` had no repoint at all. The TX
socket pins `IP_MULTICAST_IF` and the RX socket joins `IP_ADD_MEMBERSHIP` at
open time; an idle receive times out rather than raising, so nothing ever
notices the address it was opened with has gone. Cross-station catalog sync
silently stops converging until a restart.

## The rule this implements

**The interface is fixed; the address is not.**

A new DHCP lease on the configured interface is normal and is followed
automatically. Moving to a *different* interface never happens – if the
configured one has no address the plane binds **nothing**, says so, and waits.

That is deliberate and it is the whole point. On a show, an output that has
stopped is something an operator can see and diagnose. An output that quietly
reappeared on the office LAN because a lighting VLAN dropped is not – and it
puts stage data on a network nobody chose.

Note this is *not* the same as failing on an unset value: a blank pin still
inherits the station default and a blank station default still auto-detects,
because those are configured choices. Only "configured but currently has no
address" is an error state.

## Shape

`NetworkPlaneObserver` polls from housekeeping and acts only on a change, so a
steady station does no work beyond the resolve. Each plane supplies three
things – `resolve()`, `apply(address)`, `suspend()` – which is why the later
rows cost one entry each:

| Plane | Added by |
|---|---|
| PSN in / out | this PR |
| OTP output | this PR |
| Web UI, OSC input, RTTrPM, each OSC destination, video input | PRs 4–7, one `Plane` entry each, no observer change |

One plane's backend misbehaving cannot stop the others being followed – a
stalled OTP rebind must not leave PSN on a dead address.

**Station-followers** – the web self-row, the discovery beacon and
marker-catalog sync – pin nothing of their own and are repointed on the same
tick. They previously healed from `ConfigWebServer.get_local_peer_info()`, a
*web request path*, so a station whose address changed stayed stale unless
somebody happened to have a browser tab open. `refresh_local_ip()` is now
public and driven on a timer; the existing throttle means the request paths
calling it too costs nothing.

**Surfacing.** A stopped plane appears on the HUD under `Network:`. That is not
decoration: when the interface that went away is the one carrying the web UI,
the screen on the device is the only place left to look.

## `MarkerCatalogSync` receive loop

Restructured so a repoint rebuilds the socket. A failed open now retries a
bounded number of times instead of returning immediately – during an interface
switch the address is briefly gone, and one failure should not disable sync
input for the session – but it still gives up rather than spinning for the life
of the process on a port that is permanently taken. Three existing tests
asserted the old give-up-immediately contract and were rewritten; two of them
were really testing `_open_rx_socket`, so they now target it directly.

## Verification

`make ci-remote` green on the Pi (aarch64 / Python 3.13): lint, mypy, bandit,
1017 tests, 100.00% coverage, build.

**Not hardware-validated.** The checks that need a Pi and a real cable are still
owed: unplug and replug on a DHCP LAN and confirm PSN resumes on the new lease;
pin a plane to a VLAN, drop that VLAN, and confirm the plane stops rather than
appearing on another interface; confirm the HUD `Network:` row appears and
clears; confirm catalog sync reconverges after an interface switch.

## Out of scope

- **RTTrPM and OSC-destination source binding** don't exist yet (PR 6), so they
  aren't planes here.
- **Video input** (PR 7) is plugin-owned and swaps through `swap_video`.
- Anything that would change configuration on its own. The observer only ever
  rebinds sockets to what the operator already configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
