### PR TITLE
fix(network): make network apply errors say what to do, and add a pending state

### DIFF
--- a/openfollow/network/adapter.py
+++ b/openfollow/network/adapter.py
@@ -89,6 +89,15 @@ class ApplyResult:
     message: str = ""
     partial_failures: tuple[str, ...] = field(default_factory=tuple)
 
+    pending: bool = False
+    """The settings were saved but the interface never came up.
+
+    Distinct from ``partial_failures``, which means "activated, with caveats".
+    Callers must not treat a pending apply as reachable: there is no address
+    serving anything yet, so redirecting a browser at it lands on nothing.
+    Every backend that can persist settings without activating them has to set
+    this - the web layer keys the redirect and the banner on it."""
+
 
 class NetworkAdapter(ABC):
     """Abstract adapter for reading/writing host network config."""

--- a/openfollow/network/dhcpcd_adapter.py
+++ b/openfollow/network/dhcpcd_adapter.py
@@ -363,15 +363,15 @@ class DhcpcdAdapter(NetworkAdapter):
                 return ApplyResult(
                     ok=False,
                     message=(
-                        f"Could not write {self.conf_path}: {exc}. Check the file is present and not mounted read-only."
+                        f"Could not write {self.conf_path}; check it exists and is not mounted read-only ({exc})."
                     ),
                 )
         except Exception as exc:  # noqa: BLE001
             return ApplyResult(
                 ok=False,
                 message=(
-                    f"Could not update {self.conf_path}: {exc}. Nothing was changed; "
-                    f"the interface keeps its current settings."
+                    f"Could not update {self.conf_path}; nothing was changed and {iface} keeps its "
+                    f"current settings ({exc})."
                 ),
             )
 
@@ -415,8 +415,8 @@ class DhcpcdAdapter(NetworkAdapter):
                 return ApplyResult(
                     ok=False,
                     message=(
-                        f"dhcpcd -n failed ({rebind.detail}); systemctl reload dhcpcd also failed: {detail}. "
-                        f"Restored the prior config; the device may need a manual retry."
+                        f"Could not apply the new config so the previous one was restored; {iface} may "
+                        f"need a manual retry (dhcpcd -n: {rebind.detail}; reload: {detail})."
                     ),
                 )
             partial.append(f"dhcpcd -n: {rebind.detail} (fell back to systemctl reload)")
@@ -432,7 +432,7 @@ class DhcpcdAdapter(NetworkAdapter):
             return ApplyResult(
                 ok=True,
                 pending=True,
-                message=f"Saved. {iface} has no link yet.",
+                message=f"Saved; the settings take effect when {iface} has a link.",
                 partial_failures=tuple(partial),
             )
         return ApplyResult(ok=True, message="Applied.", partial_failures=tuple(partial))

--- a/openfollow/network/dhcpcd_adapter.py
+++ b/openfollow/network/dhcpcd_adapter.py
@@ -53,10 +53,7 @@ class _BrokerCallResult:
 # Shown when the privilege broker is absent, which on a real device means the
 # sudoers rules were never installed. "Broker not configured." named an
 # internal object and left the operator with nothing to try.
-_NO_BROKER_MESSAGE = (
-    "This build cannot change network settings - the privileged helper is not configured. "
-    "Configure the interface from the on-screen Settings menu instead."
-)
+_NO_BROKER_MESSAGE = "Cannot change network settings - the privileged helper is not configured."
 
 _BLOCK_START = "# >>> openfollow managed: {iface} >>>"
 _BLOCK_END = "# <<< openfollow managed: {iface} <<<"
@@ -427,7 +424,30 @@ class DhcpcdAdapter(NetworkAdapter):
         warning = self._verify_static_applied(iface, config)
         if warning:
             partial.append(warning)
+        if not self._has_carrier(iface):
+            # ``dhcpcd -n`` returns 0 on a carrier-less interface - it only
+            # signals the daemon - so without this the apply reads as clean and
+            # the web layer redirects the browser to an address nothing is
+            # serving yet.
+            return ApplyResult(
+                ok=True,
+                pending=True,
+                message=f"Saved. {iface} has no link yet.",
+                partial_failures=tuple(partial),
+            )
         return ApplyResult(ok=True, message="Applied.", partial_failures=tuple(partial))
+
+    def _has_carrier(self, iface: str) -> bool:
+        """False only when the kernel explicitly reports the link is down.
+
+        An unreadable state counts as having carrier, so an apply we can't
+        explain is never downgraded to a reassuring "saved, pending".
+        """
+        try:
+            state = Path(f"/sys/class/net/{iface}/operstate").read_text(encoding="utf-8").strip()
+        except OSError:
+            return True
+        return state != "down"
 
     def _restore_conf(self, text: str) -> None:
         """Best-effort restore of the prior conf after a failed bounce.

--- a/openfollow/network/dhcpcd_adapter.py
+++ b/openfollow/network/dhcpcd_adapter.py
@@ -50,6 +50,14 @@ class _BrokerCallResult:
     detail: str
 
 
+# Shown when the privilege broker is absent, which on a real device means the
+# sudoers rules were never installed. "Broker not configured." named an
+# internal object and left the operator with nothing to try.
+_NO_BROKER_MESSAGE = (
+    "This build cannot change network settings - the privileged helper is not configured. "
+    "Configure the interface from the on-screen Settings menu instead."
+)
+
 _BLOCK_START = "# >>> openfollow managed: {iface} >>>"
 _BLOCK_END = "# <<< openfollow managed: {iface} <<<"
 _DHCPCD_TIMEOUT = 8
@@ -337,7 +345,10 @@ class DhcpcdAdapter(NetworkAdapter):
         # ``parse_ipv4`` (via validate_apply) rejects embedded newlines, which
         # blocks injecting extra directives into the conf.
         if not _IFACE_RE.fullmatch(iface):
-            return ApplyResult(ok=False, message=f"Invalid interface name: {iface!r}")
+            return ApplyResult(
+                ok=False,
+                message=f"{iface!r} is not a valid interface name, so nothing was changed.",
+            )
         errors = validate_apply(config.method, config.address, config.prefix, config.router, list(config.dns))
         if errors:
             return ApplyResult(ok=False, message="; ".join(errors))
@@ -352,9 +363,20 @@ class DhcpcdAdapter(NetworkAdapter):
             except PrivilegeError as exc:
                 return ApplyResult(ok=False, message=str(exc))
             except OSError as exc:
-                return ApplyResult(ok=False, message=f"Cannot write {self.conf_path}: {exc}")
+                return ApplyResult(
+                    ok=False,
+                    message=(
+                        f"Could not write {self.conf_path}: {exc}. Check the file is present and not mounted read-only."
+                    ),
+                )
         except Exception as exc:  # noqa: BLE001
-            return ApplyResult(ok=False, message=f"Failed to update dhcpcd.conf: {exc}")
+            return ApplyResult(
+                ok=False,
+                message=(
+                    f"Could not update {self.conf_path}: {exc}. Nothing was changed; "
+                    f"the interface keeps its current settings."
+                ),
+            )
 
         partial: list[str] = []
         release = self._broker_run(
@@ -375,7 +397,7 @@ class DhcpcdAdapter(NetworkAdapter):
         # prior conf so the next reload/reboot doesn't silently come up on it.
         if rebind is None:
             self._restore_conf(current)
-            return ApplyResult(ok=False, message="Broker not configured.")
+            return ApplyResult(ok=False, message=_NO_BROKER_MESSAGE)
         if not rebind.ok:
             reload_ = self._broker_run(
                 NETWORK_DHCPCD_RELOAD,
@@ -456,9 +478,12 @@ class DhcpcdAdapter(NetworkAdapter):
             reason=f"Renew DHCP lease on {iface}",
         )
         if result is None:
-            return ApplyResult(ok=False, message="Broker not configured.")
+            return ApplyResult(ok=False, message=_NO_BROKER_MESSAGE)
         if not result.ok:
-            return ApplyResult(ok=False, message=result.detail)
+            return ApplyResult(
+                ok=False,
+                message=f"Could not renew the lease on {iface}. {result.detail}".strip(),
+            )
         return ApplyResult(ok=True, message="Lease renewed.")
 
     def _broker_run(

--- a/openfollow/network/nm_adapter.py
+++ b/openfollow/network/nm_adapter.py
@@ -36,6 +36,11 @@ _NMCLI_TIMEOUT = 8
 # that merely names the same device.
 _ADDRESSABLE_CONNECTION_TYPES = frozenset({"802-3-ethernet", "802-11-wireless", "vlan"})
 
+# How long the inactive-profile map is reused. Long enough to cover one page
+# render (which resolves every interface), short enough that a profile created
+# or renamed from a shell shows up promptly.
+_INACTIVE_MAP_TTL_S = 2.0
+
 
 def _unescape_terse(value: str) -> str:
     """Reverse nmcli ``-t`` (terse) escaping in a field value: a literal
@@ -64,6 +69,7 @@ class NetworkManagerAdapter(NetworkAdapter):
 
     def __init__(self, *, broker: PrivilegeBroker | None = None) -> None:
         self._broker = broker
+        self._inactive_map_cache: tuple[float, dict[str, str]] | None = None
 
     def _run(self, argv: Sequence[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
         """Execute read-only nmcli call."""
@@ -156,36 +162,57 @@ class NetworkManagerAdapter(NetworkAdapter):
         return self._inactive_connection_for(iface)
 
     def _inactive_connection_for(self, iface: str) -> str | None:
-        """Find a deactivated profile by its configured interface name.
+        """Find a deactivated profile by its configured interface name."""
+        return self._inactive_profile_map().get(iface)
+
+    def _inactive_profile_map(self) -> dict[str, str]:
+        """interface name -> best inactive profile, built in one pass.
+
+        Briefly cached because the cost is multiplicative otherwise: reading a
+        profile's ``connection.interface-name`` needs its own ``nmcli`` call,
+        and ``_connection_for`` runs once per interface via ``get_state``. On a
+        station with several down interfaces and a handful of saved profiles
+        that is dozens of subprocess spawns for one page render, each with an
+        8 s timeout, on a web request thread.
 
         Ranked so the choice is stable when a device has several profiles:
-        autoconnect first (that is the one NetworkManager would bring up),
-        then the higher autoconnect-priority, then name order as a tiebreak.
-        Without a deterministic order the operator's edit could land on a
-        different profile each time they pressed Apply.
+        autoconnect first (that is the one NetworkManager would bring up), then
+        the higher autoconnect-priority, then name order. Without a
+        deterministic order the operator's edit could land on a different
+        profile each time they pressed Apply.
         """
+        now = time.monotonic()
+        cached = self._inactive_map_cache
+        if cached is not None and now - cached[0] < _INACTIVE_MAP_TTL_S:
+            return cached[1]
+
         try:
             res = self._run(["nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"])
         except (RuntimeError, FileNotFoundError, subprocess.SubprocessError):
-            return None
+            return {}
 
-        candidates: list[tuple[int, int, str]] = []
+        ranked: dict[str, tuple[int, int, str]] = {}
         for line in res.stdout.splitlines():
             name, _, kind = line.partition(":")
             if not name or kind not in _ADDRESSABLE_CONNECTION_TYPES:
                 continue
             details = self._connection_details(name)
-            if details.get("connection.interface-name") != iface:
+            bound_iface = details.get("connection.interface-name", "")
+            if not bound_iface:
                 continue
             autoconnect = 0 if details.get("connection.autoconnect", "").lower() == "yes" else 1
             try:
                 priority = -int(details.get("connection.autoconnect-priority", "0") or 0)
             except ValueError:
                 priority = 0
-            candidates.append((autoconnect, priority, name))
-        if not candidates:
-            return None
-        return min(candidates)[2]
+            candidate = (autoconnect, priority, name)
+            best = ranked.get(bound_iface)
+            if best is None or candidate < best:
+                ranked[bound_iface] = candidate
+
+        out = {bound_iface: candidate[2] for bound_iface, candidate in ranked.items()}
+        self._inactive_map_cache = (now, out)
+        return out
 
     def _connection_details(self, name: str) -> dict[str, str]:
         """First value of each requested field for one profile, or ``{}``."""
@@ -517,13 +544,16 @@ class NetworkManagerAdapter(NetworkAdapter):
             # the settings are persisted and take effect on next plug-in, so
             # reporting a hard failure would be wrong.
             if not self._has_carrier(iface):
+                # Reported through partial_failures, not just the message: the
+                # web layer redirects the browser to the new address on a clean
+                # apply, and there is nothing listening there until the cable
+                # goes in. partial_failures is the existing channel that keeps
+                # the operator on the page with the note visible.
+                pending = f"{iface} has no link, so the settings take effect when the cable is connected."
                 return ApplyResult(
                     ok=True,
-                    message=(
-                        f"Saved to profile '{name}'. {iface} has no link, so the settings "
-                        f"take effect when the cable is connected."
-                    ),
-                    partial_failures=tuple(partial),
+                    message=f"Saved to profile '{name}'. {pending}",
+                    partial_failures=(*partial, pending),
                 )
             return ApplyResult(
                 ok=False,

--- a/openfollow/network/nm_adapter.py
+++ b/openfollow/network/nm_adapter.py
@@ -31,15 +31,10 @@ logger = logging.getLogger(__name__)
 
 _NMCLI_TIMEOUT = 8
 
-# Connection types that carry an IPv4 address the Network page can edit. Used
-# to keep the by-interface-name lookup from matching a bridge/bond/tun profile
-# that merely names the same device.
-_ADDRESSABLE_CONNECTION_TYPES = frozenset({"802-3-ethernet", "802-11-wireless", "vlan"})
-
-# How long the inactive-profile map is reused. Long enough to cover one page
-# render (which resolves every interface), short enough that a profile created
-# or renamed from a shell shows up promptly.
-_INACTIVE_MAP_TTL_S = 2.0
+# Shown when the privilege broker is absent, which on a real device means the
+# sudoers rules were never installed. Kept short: the on-screen banner is one
+# truncated line.
+_NO_BROKER_MESSAGE = "Cannot change network settings - the privileged helper is not configured."
 
 
 def _unescape_terse(value: str) -> str:
@@ -69,7 +64,6 @@ class NetworkManagerAdapter(NetworkAdapter):
 
     def __init__(self, *, broker: PrivilegeBroker | None = None) -> None:
         self._broker = broker
-        self._inactive_map_cache: tuple[float, dict[str, str]] | None = None
 
     def _run(self, argv: Sequence[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
         """Execute read-only nmcli call."""
@@ -92,7 +86,7 @@ class NetworkManagerAdapter(NetworkAdapter):
     ) -> tuple[bool, str]:
         """Invoke capability via broker, return (ok, detail)."""
         if self._broker is None:
-            return (False, "Broker not configured.")
+            return (False, _NO_BROKER_MESSAGE)
         try:
             proc = self._broker.run(
                 capability,
@@ -134,14 +128,6 @@ class NetworkManagerAdapter(NetworkAdapter):
         return out
 
     def _connection_for(self, iface: str) -> str | None:
-        """Return the profile that owns *iface*, active or not.
-
-        The ``DEVICE`` column is only populated for connections nmcli
-        considers **active**, so matching on it finds nothing once the carrier
-        drops and NetworkManager deactivates the profile. That is exactly the
-        pre-stage-a-static-address-before-the-show case, so the last resort
-        matches ``connection.interface-name`` instead.
-        """
         try:
             res = self._run(["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"])
         except (RuntimeError, FileNotFoundError, subprocess.SubprocessError):
@@ -159,89 +145,20 @@ class NetworkManagerAdapter(NetworkAdapter):
             name, _, dev = line.partition(":")
             if dev == iface:
                 return name
-        return self._inactive_connection_for(iface)
+        return None
 
-    def _inactive_connection_for(self, iface: str) -> str | None:
-        """Find a deactivated profile by its configured interface name."""
-        return self._inactive_profile_map().get(iface)
+    def _device_state(self, iface: str) -> str | None:
+        """nmcli's STATE word for *iface*, ``""`` if absent, ``None`` if unreadable.
 
-    def _inactive_profile_map(self) -> dict[str, str]:
-        """interface name -> best inactive profile, built in one pass.
-
-        Briefly cached because the cost is multiplicative otherwise: reading a
-        profile's ``connection.interface-name`` needs its own ``nmcli`` call,
-        and ``_connection_for`` runs once per interface via ``get_state``. On a
-        station with several down interfaces and a handful of saved profiles
-        that is dozens of subprocess spawns for one page render, each with an
-        8 s timeout, on a web request thread.
-
-        Ranked so the choice is stable when a device has several profiles:
-        autoconnect first (that is the one NetworkManager would bring up), then
-        the higher autoconnect-priority, then name order. Without a
-        deterministic order the operator's edit could land on a different
-        profile each time they pressed Apply.
-        """
-        now = time.monotonic()
-        cached = self._inactive_map_cache
-        if cached is not None and now - cached[0] < _INACTIVE_MAP_TTL_S:
-            return cached[1]
-
-        try:
-            res = self._run(["nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"])
-        except (RuntimeError, FileNotFoundError, subprocess.SubprocessError):
-            return {}
-
-        ranked: dict[str, tuple[int, int, str]] = {}
-        for line in res.stdout.splitlines():
-            name, _, kind = line.partition(":")
-            if not name or kind not in _ADDRESSABLE_CONNECTION_TYPES:
-                continue
-            details = self._connection_details(name)
-            bound_iface = details.get("connection.interface-name", "")
-            if not bound_iface:
-                continue
-            autoconnect = 0 if details.get("connection.autoconnect", "").lower() == "yes" else 1
-            try:
-                priority = -int(details.get("connection.autoconnect-priority", "0") or 0)
-            except ValueError:
-                priority = 0
-            candidate = (autoconnect, priority, name)
-            best = ranked.get(bound_iface)
-            if best is None or candidate < best:
-                ranked[bound_iface] = candidate
-
-        out = {bound_iface: candidate[2] for bound_iface, candidate in ranked.items()}
-        self._inactive_map_cache = (now, out)
-        return out
-
-    def _connection_details(self, name: str) -> dict[str, str]:
-        """First value of each requested field for one profile, or ``{}``."""
-        try:
-            res = self._run(
-                [
-                    "nmcli",
-                    "-t",
-                    "-f",
-                    "connection.interface-name,connection.autoconnect,connection.autoconnect-priority",
-                    "connection",
-                    "show",
-                    name,
-                ]
-            )
-        except (RuntimeError, FileNotFoundError, subprocess.SubprocessError):
-            return {}
-        return {key: values[0] for key, values in self._parse_show(res.stdout).items() if values}
-
-    def _device_state(self, iface: str) -> str:
-        """nmcli's STATE word for *iface* (``unmanaged``, ``disconnected``, …).
-
-        Drives the cause-specific apply errors: "no profile" and "NetworkManager
-        isn't managing this device" need different operator actions.
+        The three are different and the callers rely on it: a read failure is
+        not evidence the device is gone, and telling an operator their plugged-in
+        adapter "is not present" because nmcli timed out contradicts the card
+        they just clicked.
         """
         try:
             res = self._run(["nmcli", "-t", "-f", "DEVICE,STATE", "device"])
         except (RuntimeError, FileNotFoundError, subprocess.SubprocessError):
-            return ""
+            return None
         for line in res.stdout.splitlines():
             name, _, state = line.partition(":")
             if name == iface:
@@ -261,20 +178,19 @@ class NetworkManagerAdapter(NetworkAdapter):
         return self._device_state(iface) != "unavailable"
 
     def _no_profile_message(self, iface: str) -> str:
-        """Say what the operator should check, not what the adapter didn't find."""
+        """Say what the operator should check, not what the adapter didn't find.
+
+        Kept to one short sentence: the on-screen Settings banner is a single
+        truncated line, so a second sentence is the half that gets cut.
+        """
         state = self._device_state(iface)
+        if state is None:
+            return f"Could not read {iface} from NetworkManager. Try Scan."
         if state == "unmanaged":
-            return (
-                f"{iface} is not managed by NetworkManager, so its IP settings can't be changed here. "
-                f"Remove it from /etc/network/interfaces or NetworkManager's unmanaged-devices list, "
-                f"then restart NetworkManager."
-            )
+            return f"{iface} is not managed by NetworkManager. See the help drawer."
         if not state:
-            return f"{iface} is not present on this system. Check the adapter is plugged in, then Scan."
-        return (
-            f"No saved network profile exists for {iface}. Connect the cable once so NetworkManager "
-            f"creates one, or create it manually with nmcli."
-        )
+            return f"{iface} is not present. Check the adapter, then Scan."
+        return f"No saved profile for {iface}. Connect the cable once to create one."
 
     def _parse_show(self, text: str) -> dict[str, list[str]]:
         out: dict[str, list[str]] = {}
@@ -543,21 +459,19 @@ class NetworkManagerAdapter(NetworkAdapter):
             # itself saved, and that is the pre-stage-before-the-show workflow:
             # the settings are persisted and take effect on next plug-in, so
             # reporting a hard failure would be wrong.
-            if not self._has_carrier(iface):
-                # Reported through partial_failures, not just the message: the
-                # web layer redirects the browser to the new address on a clean
-                # apply, and there is nothing listening there until the cable
-                # goes in. partial_failures is the existing channel that keeps
-                # the operator on the page with the note visible.
-                pending = f"{iface} has no link, so the settings take effect when the cable is connected."
+            if not self._has_carrier(iface) and not up_detail:
+                # Only when nmcli gave no reason of its own: a real failure -
+                # rfkill, a missing con-up grant - must not be reported as a
+                # cable problem just because the device reads "unavailable".
                 return ApplyResult(
                     ok=True,
-                    message=f"Saved to profile '{name}'. {pending}",
-                    partial_failures=(*partial, pending),
+                    pending=True,
+                    message=f"Saved. {iface} has no link yet.",
+                    partial_failures=tuple(partial),
                 )
             return ApplyResult(
                 ok=False,
-                message=f"Saved the settings, but {iface} could not be brought up. {up_detail}".strip(),
+                message=f"Saved, but {iface} could not be brought up. {up_detail}".strip(),
             )
         return ApplyResult(ok=True, message="Applied.", partial_failures=tuple(partial))
 
@@ -577,13 +491,10 @@ class NetworkManagerAdapter(NetworkAdapter):
             reason=f"Renew DHCP lease via NetworkManager profile {name}",
         )
         if not up_ok:
-            if not self._has_carrier(iface):
-                return ApplyResult(
-                    ok=False,
-                    message=f"{iface} has no link, so there is no network to request a lease from.",
-                )
-            return ApplyResult(
-                ok=False,
-                message=f"Could not renew the lease on {iface}. {up_detail}".strip(),
-            )
+            # Only claim it's the link when nmcli gave no reason of its own -
+            # a missing helper or an ungranted rule is not a cable problem, and
+            # sending the operator to check a cable hides the real fix.
+            if not up_detail and not self._has_carrier(iface):
+                return ApplyResult(ok=False, message=f"{iface} has no link, so there is no lease to request.")
+            return ApplyResult(ok=False, message=f"Could not renew {iface}. {up_detail}".strip())
         return ApplyResult(ok=True, message="Lease renewed.")

--- a/openfollow/network/nm_adapter.py
+++ b/openfollow/network/nm_adapter.py
@@ -436,7 +436,9 @@ class NetworkManagerAdapter(NetworkAdapter):
         if not ok:
             return ApplyResult(
                 ok=False,
-                message=f"Could not save the settings to profile '{name}'. {detail}".strip(),
+                message=f"Could not save the settings to profile '{name}'; nothing was changed ({detail})."
+                if detail
+                else f"Could not save the settings to profile '{name}'; nothing was changed.",
             )
 
         partial: list[str] = []
@@ -466,12 +468,14 @@ class NetworkManagerAdapter(NetworkAdapter):
                 return ApplyResult(
                     ok=True,
                     pending=True,
-                    message=f"Saved. {iface} has no link yet.",
+                    message=f"Saved; the settings take effect when {iface} has a link.",
                     partial_failures=tuple(partial),
                 )
             return ApplyResult(
                 ok=False,
-                message=f"Saved, but {iface} could not be brought up. {up_detail}".strip(),
+                message=f"Saved, but {iface} could not be brought up ({up_detail})."
+                if up_detail
+                else f"Saved, but {iface} could not be brought up.",
             )
         return ApplyResult(ok=True, message="Applied.", partial_failures=tuple(partial))
 
@@ -496,5 +500,8 @@ class NetworkManagerAdapter(NetworkAdapter):
             # sending the operator to check a cable hides the real fix.
             if not up_detail and not self._has_carrier(iface):
                 return ApplyResult(ok=False, message=f"{iface} has no link, so there is no lease to request.")
-            return ApplyResult(ok=False, message=f"Could not renew {iface}. {up_detail}".strip())
+            return ApplyResult(
+                ok=False,
+                message=f"Could not renew {iface} ({up_detail})." if up_detail else f"Could not renew {iface}.",
+            )
         return ApplyResult(ok=True, message="Lease renewed.")

--- a/openfollow/network/nm_adapter.py
+++ b/openfollow/network/nm_adapter.py
@@ -31,6 +31,11 @@ logger = logging.getLogger(__name__)
 
 _NMCLI_TIMEOUT = 8
 
+# Connection types that carry an IPv4 address the Network page can edit. Used
+# to keep the by-interface-name lookup from matching a bridge/bond/tun profile
+# that merely names the same device.
+_ADDRESSABLE_CONNECTION_TYPES = frozenset({"802-3-ethernet", "802-11-wireless", "vlan"})
+
 
 def _unescape_terse(value: str) -> str:
     """Reverse nmcli ``-t`` (terse) escaping in a field value: a literal
@@ -123,6 +128,14 @@ class NetworkManagerAdapter(NetworkAdapter):
         return out
 
     def _connection_for(self, iface: str) -> str | None:
+        """Return the profile that owns *iface*, active or not.
+
+        The ``DEVICE`` column is only populated for connections nmcli
+        considers **active**, so matching on it finds nothing once the carrier
+        drops and NetworkManager deactivates the profile. That is exactly the
+        pre-stage-a-static-address-before-the-show case, so the last resort
+        matches ``connection.interface-name`` instead.
+        """
         try:
             res = self._run(["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"])
         except (RuntimeError, FileNotFoundError, subprocess.SubprocessError):
@@ -140,7 +153,101 @@ class NetworkManagerAdapter(NetworkAdapter):
             name, _, dev = line.partition(":")
             if dev == iface:
                 return name
-        return None
+        return self._inactive_connection_for(iface)
+
+    def _inactive_connection_for(self, iface: str) -> str | None:
+        """Find a deactivated profile by its configured interface name.
+
+        Ranked so the choice is stable when a device has several profiles:
+        autoconnect first (that is the one NetworkManager would bring up),
+        then the higher autoconnect-priority, then name order as a tiebreak.
+        Without a deterministic order the operator's edit could land on a
+        different profile each time they pressed Apply.
+        """
+        try:
+            res = self._run(["nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"])
+        except (RuntimeError, FileNotFoundError, subprocess.SubprocessError):
+            return None
+
+        candidates: list[tuple[int, int, str]] = []
+        for line in res.stdout.splitlines():
+            name, _, kind = line.partition(":")
+            if not name or kind not in _ADDRESSABLE_CONNECTION_TYPES:
+                continue
+            details = self._connection_details(name)
+            if details.get("connection.interface-name") != iface:
+                continue
+            autoconnect = 0 if details.get("connection.autoconnect", "").lower() == "yes" else 1
+            try:
+                priority = -int(details.get("connection.autoconnect-priority", "0") or 0)
+            except ValueError:
+                priority = 0
+            candidates.append((autoconnect, priority, name))
+        if not candidates:
+            return None
+        return min(candidates)[2]
+
+    def _connection_details(self, name: str) -> dict[str, str]:
+        """First value of each requested field for one profile, or ``{}``."""
+        try:
+            res = self._run(
+                [
+                    "nmcli",
+                    "-t",
+                    "-f",
+                    "connection.interface-name,connection.autoconnect,connection.autoconnect-priority",
+                    "connection",
+                    "show",
+                    name,
+                ]
+            )
+        except (RuntimeError, FileNotFoundError, subprocess.SubprocessError):
+            return {}
+        return {key: values[0] for key, values in self._parse_show(res.stdout).items() if values}
+
+    def _device_state(self, iface: str) -> str:
+        """nmcli's STATE word for *iface* (``unmanaged``, ``disconnected``, …).
+
+        Drives the cause-specific apply errors: "no profile" and "NetworkManager
+        isn't managing this device" need different operator actions.
+        """
+        try:
+            res = self._run(["nmcli", "-t", "-f", "DEVICE,STATE", "device"])
+        except (RuntimeError, FileNotFoundError, subprocess.SubprocessError):
+            return ""
+        for line in res.stdout.splitlines():
+            name, _, state = line.partition(":")
+            if name == iface:
+                return state.strip().lower()
+        return ""
+
+    def _has_carrier(self, iface: str) -> bool:
+        """False only when nmcli explicitly reports no link on *iface*.
+
+        Distinguishes "activation failed because the cable is out" – the
+        pre-stage workflow, not an error – from a real activation failure. An
+        unreadable state counts as *having* carrier so an activation failure we
+        can't explain is still reported as one; downgrading it to
+        saved-but-pending would hide a real problem behind a reassuring
+        message.
+        """
+        return self._device_state(iface) != "unavailable"
+
+    def _no_profile_message(self, iface: str) -> str:
+        """Say what the operator should check, not what the adapter didn't find."""
+        state = self._device_state(iface)
+        if state == "unmanaged":
+            return (
+                f"{iface} is not managed by NetworkManager, so its IP settings can't be changed here. "
+                f"Remove it from /etc/network/interfaces or NetworkManager's unmanaged-devices list, "
+                f"then restart NetworkManager."
+            )
+        if not state:
+            return f"{iface} is not present on this system. Check the adapter is plugged in, then Scan."
+        return (
+            f"No saved network profile exists for {iface}. Connect the cable once so NetworkManager "
+            f"creates one, or create it manually with nmcli."
+        )
 
     def _parse_show(self, text: str) -> dict[str, list[str]]:
         out: dict[str, list[str]] = {}
@@ -301,7 +408,7 @@ class NetworkManagerAdapter(NetworkAdapter):
         if not name:
             return ApplyResult(
                 ok=False,
-                message=f"No NetworkManager connection profile bound to {iface}.",
+                message=self._no_profile_message(iface),
             )
         # Use long argv form to match sudoers rule. The explicit ``id``
         # keyword (``con mod id <name>``) makes a profile name beginning
@@ -384,7 +491,10 @@ class NetworkManagerAdapter(NetworkAdapter):
             reason=f"Modify NetworkManager profile {name}",
         )
         if not ok:
-            return ApplyResult(ok=False, message=detail or "nmcli con mod failed")
+            return ApplyResult(
+                ok=False,
+                message=f"Could not save the settings to profile '{name}'. {detail}".strip(),
+            )
 
         partial: list[str] = []
         # con down can fail; con up failure is fatal.
@@ -402,13 +512,29 @@ class NetworkManagerAdapter(NetworkAdapter):
             reason=f"Bring NetworkManager profile {name} up",
         )
         if not up_ok:
-            return ApplyResult(ok=False, message=up_detail or "nmcli con up failed")
+            # Activation can only fail for want of a carrier once the profile
+            # itself saved, and that is the pre-stage-before-the-show workflow:
+            # the settings are persisted and take effect on next plug-in, so
+            # reporting a hard failure would be wrong.
+            if not self._has_carrier(iface):
+                return ApplyResult(
+                    ok=True,
+                    message=(
+                        f"Saved to profile '{name}'. {iface} has no link, so the settings "
+                        f"take effect when the cable is connected."
+                    ),
+                    partial_failures=tuple(partial),
+                )
+            return ApplyResult(
+                ok=False,
+                message=f"Saved the settings, but {iface} could not be brought up. {up_detail}".strip(),
+            )
         return ApplyResult(ok=True, message="Applied.", partial_failures=tuple(partial))
 
     def renew_lease(self, iface: str) -> ApplyResult:
         name = self._connection_for(iface)
         if not name:
-            return ApplyResult(ok=False, message=f"No NetworkManager profile for {iface}.")
+            return ApplyResult(ok=False, message=self._no_profile_message(iface))
         # NM has no explicit renew verb; use down/up cycle.
         self._run_privileged(
             NETWORK_NM_CON_DOWN,
@@ -421,5 +547,13 @@ class NetworkManagerAdapter(NetworkAdapter):
             reason=f"Renew DHCP lease via NetworkManager profile {name}",
         )
         if not up_ok:
-            return ApplyResult(ok=False, message=up_detail or "nmcli con up failed")
+            if not self._has_carrier(iface):
+                return ApplyResult(
+                    ok=False,
+                    message=f"{iface} has no link, so there is no network to request a lease from.",
+                )
+            return ApplyResult(
+                ok=False,
+                message=f"Could not renew the lease on {iface}. {up_detail}".strip(),
+            )
         return ApplyResult(ok=True, message="Lease renewed.")

--- a/openfollow/web/help/general-network-interface.md
+++ b/openfollow/web/help/general-network-interface.md
@@ -24,8 +24,6 @@ A **This session** marker means your browser reached the station over that adapt
 
 **Lease remaining** – countdown on the active DHCP lease (read-only, refreshes every 5 s).
 
-**Setting an address before the cable is in.** You can configure an adapter that has no link yet – useful for pre-staging a static address before the unit goes on the show network. Apply saves the settings to the adapter's saved profile and tells you they are pending; they take effect the moment the cable is connected. Renewing a DHCP lease still needs a link, because there is no network to ask.
-
 > Applying may disconnect this web session. A static/manual address reloads the UI at the new address automatically; for DHCP, reconnect manually if the session drops.
 
 ## If DHCP is unavailable

--- a/openfollow/web/help/general-network-interface.md
+++ b/openfollow/web/help/general-network-interface.md
@@ -24,6 +24,8 @@ A **This session** marker means your browser reached the station over that adapt
 
 **Lease remaining** – countdown on the active DHCP lease (read-only, refreshes every 5 s).
 
+**Setting an address before the cable is in.** You can configure an adapter that has no link yet – useful for pre-staging a static address before the unit goes on the show network. Apply saves the settings to the adapter's saved profile and tells you they are pending; they take effect the moment the cable is connected. Renewing a DHCP lease still needs a link, because there is no network to ask.
+
 > Applying may disconnect this web session. A static/manual address reloads the UI at the new address automatically; for DHCP, reconnect manually if the session drops.
 
 ## If DHCP is unavailable

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -289,6 +289,10 @@ _GITHUB_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 # Allow-listed rather than interpolated: the label is rendered into HTML.
 # "auto" = nothing to fall back to (the station picker itself); "station" =
 # an empty pin follows ``psn_source_iface`` (every per-plane picker).
+# Longest interface name the kernel hands out (IFNAMSIZ - 1). A POST is not
+# bound by it, and a rejected name is echoed back to the operator.
+_IFNAME_MAX = 15
+
 _BLANK_IFACE_LABELS = {
     "auto": "-- Auto-detect --",
     "station": "-- Follow station interface --",
@@ -4420,16 +4424,29 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
             net.update(overrides)
         return net
 
-    def _resolve_network_iface(iface: str) -> str | None:
-        """Validate the posted interface against the adapter's live list,
-        defaulting to the active interface. A privileged adapter write must
-        never receive a raw/forged/empty POST value – the render path already
-        sanitises the same way (``iface if iface in names else …``). Returns
-        ``None`` when no interface is available (no adapter / read-only-empty)."""
+    def _resolve_network_iface(iface: str) -> tuple[str | None, str]:
+        """Validate the posted interface against the adapter's live list.
+
+        A privileged adapter write must never receive a raw/forged POST value.
+        Blank means "whichever interface the form defaulted to" and resolves to
+        the active one. A *named* interface the host does not have is an error,
+        never a substitution: applying it to whichever NIC happens to be active
+        would rewrite and bounce the one the operator is connected over, and the
+        page that posted it had simply gone stale behind an unplugged adapter.
+
+        Returns ``(iface, "")``, or ``(None, message)`` naming what to do.
+        """
         cfg = server.get_network_config(iface or None)
         if not cfg or not cfg.get("interfaces"):
-            return None
-        return cfg.get("active_interface") or None
+            return (None, "Network interface not available on this host.")
+        if iface and iface not in cfg["interfaces"]:
+            # Truncated because a POST is free to carry more than a kernel
+            # interface name can hold, and the banner echoes this back.
+            return (None, f"{iface[:_IFNAME_MAX]} is not present. Check the adapter, then Scan.")
+        resolved = cfg.get("active_interface") or None
+        if resolved is None:
+            return (None, "Network interface not available on this host.")
+        return (resolved, "")
 
     def _network_redirect_url(address: str) -> str:
         """Build a same-scheme/same-port URL on ``address`` so a static /
@@ -4524,13 +4541,13 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
     @app.post("/section/network/apply")
     def network_apply() -> Any:
         iface, method_value, fields = _parse_network_form()
-        resolved = _resolve_network_iface(iface)
+        resolved, resolve_error = _resolve_network_iface(iface)
         if resolved is None:
             return template(
                 "partials/network",
                 net=_build_network_form_context(
                     editable=True,
-                    banner={"kind": "error", "text": "Network interface not available on this host."},
+                    banner={"kind": "error", "text": resolve_error},
                 ),
             )
         iface = resolved
@@ -4651,13 +4668,13 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
 
     @app.post("/section/network/renew")
     def network_renew() -> Any:
-        iface = _resolve_network_iface((request.forms.get("iface") or "").strip())
+        iface, resolve_error = _resolve_network_iface((request.forms.get("iface") or "").strip())
         if iface is None:
             return template(
                 "partials/network",
                 net=_build_network_form_context(
                     editable=False,
-                    banner={"kind": "error", "text": "Network interface not available on this host."},
+                    banner={"kind": "error", "text": resolve_error},
                 ),
             )
         result = server.renew_network(iface)

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -4608,9 +4608,24 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
             method in (Ipv4Method.STATIC, Ipv4Method.DHCP_WITH_MANUAL_ADDRESS)
             and address
             and not result.partial_failures
+            # Nothing is serving that address yet, so a redirect lands on a
+            # dead page and the explanation is lost with the response body.
+            and not result.pending
         ):
             response.set_header("HX-Redirect", _network_redirect_url(address))
             return ""
+        if result.pending:
+            # Deliberately not "applied", and no reconnect advice: the
+            # interface never came up, so telling the operator to browse to the
+            # new address would send them nowhere.
+            return template(
+                "partials/network",
+                net=_build_network_form_context(
+                    iface=iface,
+                    editable=False,
+                    banner={"kind": "info", "text": result.message},
+                ),
+            )
         text = "Network settings applied."
         if result.partial_failures:
             text += " Warnings: " + "; ".join(result.partial_failures)

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -4618,12 +4618,18 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
             # Deliberately not "applied", and no reconnect advice: the
             # interface never came up, so telling the operator to browse to the
             # new address would send them nowhere.
+            pending_text = result.message
+            if result.partial_failures:
+                # This is the one path that keeps the operator on the page in
+                # order to explain itself, so dropping the caveats here loses
+                # them entirely - there is no redirect to read them after.
+                pending_text += " Warnings: " + "; ".join(result.partial_failures)
             return template(
                 "partials/network",
                 net=_build_network_form_context(
                     iface=iface,
                     editable=False,
-                    banner={"kind": "info", "text": result.message},
+                    banner={"kind": "info", "text": pending_text},
                 ),
             )
         text = "Network settings applied."

--- a/tests/test_network_adapter_dhcpcd.py
+++ b/tests/test_network_adapter_dhcpcd.py
@@ -636,7 +636,6 @@ class TestRenewErrors:
         assert result.ok is False
         # Names something the operator can act on, not an internal object.
         assert "privileged helper is not configured" in result.message
-        assert "Settings menu" in result.message
 
 
 class TestBuildBlockBranches:

--- a/tests/test_network_adapter_dhcpcd.py
+++ b/tests/test_network_adapter_dhcpcd.py
@@ -1197,3 +1197,59 @@ class TestApplyBoundaryValidation:
         )
         assert result.ok is False
         assert conf.read_text() == ""  # nothing written
+
+
+class TestPendingOnADeadLink:
+    """``dhcpcd -n`` returns 0 on a carrier-less interface - it only signals the
+    daemon - so without an explicit pending state the apply reads as clean and
+    the web layer redirects the browser to an address nothing is serving."""
+
+    def test_apply_reports_pending_when_the_link_is_down(self, adapter, monkeypatch) -> None:
+        a, _conf = adapter
+        monkeypatch.setattr(a, "_has_carrier", lambda _iface: False)
+        result = a.apply_ipv4(
+            "eth0",
+            Ipv4Config(method=Ipv4Method.STATIC, address="192.168.9.9", prefix=24),
+        )
+        assert result.ok is True
+        assert result.pending is True
+        assert "no link" in result.message
+
+    def test_apply_is_not_pending_with_a_link(self, adapter, monkeypatch) -> None:
+        a, _conf = adapter
+        monkeypatch.setattr(a, "_has_carrier", lambda _iface: True)
+        result = a.apply_ipv4(
+            "eth0",
+            Ipv4Config(method=Ipv4Method.STATIC, address="192.168.9.9", prefix=24),
+        )
+        assert result.ok is True
+        assert result.pending is False
+
+    def test_carrier_reads_the_kernel_operstate(self, adapter, tmp_path, monkeypatch) -> None:
+        a, _conf = adapter
+        import openfollow.network.dhcpcd_adapter as mod
+
+        class _Path:
+            def __init__(self, value: str) -> None:
+                self._value = value
+
+            def read_text(self, encoding: str = "utf-8") -> str:
+                return self._value
+
+        monkeypatch.setattr(mod, "Path", lambda _p: _Path("down\n"))
+        assert a._has_carrier("eth0") is False
+        monkeypatch.setattr(mod, "Path", lambda _p: _Path("up\n"))
+        assert a._has_carrier("eth0") is True
+
+    def test_an_unreadable_operstate_counts_as_having_carrier(self, adapter, monkeypatch) -> None:
+        """An apply we can't explain must never be downgraded to a reassuring
+        "saved, pending"."""
+        a, _conf = adapter
+        import openfollow.network.dhcpcd_adapter as mod
+
+        class _Missing:
+            def read_text(self, encoding: str = "utf-8") -> str:
+                raise OSError("no such file")
+
+        monkeypatch.setattr(mod, "Path", lambda _p: _Missing())
+        assert a._has_carrier("eth0") is True

--- a/tests/test_network_adapter_dhcpcd.py
+++ b/tests/test_network_adapter_dhcpcd.py
@@ -519,7 +519,9 @@ class TestApplyErrors:
         a._read_conf = boom
         result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
         assert result.ok is False
-        assert "Failed to update" in result.message
+        assert "Could not update" in result.message
+        # Says the interface was left alone, so the operator knows where they stand.
+        assert "Nothing was changed" in result.message
 
 
 class TestRenewErrors:
@@ -632,7 +634,9 @@ class TestRenewErrors:
         a = DhcpcdAdapter(conf_path=conf)  # broker omitted
         result = a.renew_lease("eth0")
         assert result.ok is False
-        assert "Broker" in result.message
+        # Names something the operator can act on, not an internal object.
+        assert "privileged helper is not configured" in result.message
+        assert "Settings menu" in result.message
 
 
 class TestBuildBlockBranches:
@@ -896,7 +900,7 @@ class TestApplyRollback:
         a = DhcpcdAdapter(conf_path=conf)  # no broker → bounce never happens
         result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
         assert result.ok is False
-        assert "Broker not configured" in result.message
+        assert "privileged helper is not configured" in result.message
         assert conf.read_text() == original
 
     def test_rebounce_attempted_after_double_failure(self, tmp_path) -> None:

--- a/tests/test_network_adapter_dhcpcd.py
+++ b/tests/test_network_adapter_dhcpcd.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 
 import pytest
@@ -448,7 +449,8 @@ class TestApplyErrors:
         a = DhcpcdAdapter(conf_path=conf, broker=broker)
         result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
         assert result.ok is False
-        assert "systemctl reload dhcpcd also failed" in result.message
+        assert "previous one was restored" in result.message
+        assert "reload boom" in result.message
 
     def test_release_partial_failure_is_warning(self, tmp_path) -> None:
         from openfollow.network.adapter import Ipv4Config, Ipv4Method
@@ -521,7 +523,7 @@ class TestApplyErrors:
         assert result.ok is False
         assert "Could not update" in result.message
         # Says the interface was left alone, so the operator knows where they stand.
-        assert "Nothing was changed" in result.message
+        assert "nothing was changed" in result.message
 
 
 class TestRenewErrors:
@@ -949,7 +951,8 @@ class TestApplyRollback:
         a = DhcpcdAdapter(conf_path=conf, broker=broker)
         result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
         assert result.ok is False
-        assert "systemctl reload dhcpcd also failed" in result.message
+        assert "previous one was restored" in result.message
+        assert "reload boom" in result.message
 
     def test_restore_failure_is_logged_not_raised(self, tmp_path, caplog) -> None:
         from openfollow.network.adapter import Ipv4Config, Ipv4Method
@@ -1213,7 +1216,7 @@ class TestPendingOnADeadLink:
         )
         assert result.ok is True
         assert result.pending is True
-        assert "no link" in result.message
+        assert "has a link" in result.message
 
     def test_apply_is_not_pending_with_a_link(self, adapter, monkeypatch) -> None:
         a, _conf = adapter
@@ -1253,3 +1256,43 @@ class TestPendingOnADeadLink:
 
         monkeypatch.setattr(mod, "Path", lambda _p: _Missing())
         assert a._has_carrier("eth0") is True
+
+
+class TestMessagesFitTheOnScreenBanner:
+    """Every operator-facing message must be one sentence.
+
+    The on-screen Settings banner is a single truncated line, so a second
+    sentence is the half that gets cut - and it is reliably the actionable
+    half, because the first sentence says what broke and the second says what
+    to do about it. Asserting the shape here means a regression fails CI
+    rather than waiting for someone to read it on a device.
+    """
+
+    # ". " before a capital is the two-sentence signature. It cannot match a
+    # path like ``dhcpcd.conf`` or an address like ``192.168.1.5``, which is
+    # why the check is not simply "contains a period".
+    _SECOND_SENTENCE = re.compile(r"\.\s+[A-Z]")
+
+    def _messages(self, broker: FakeBroker, tmp_path) -> list[str]:
+        """Drive the failure paths and collect what the operator would see."""
+        out: list[str] = []
+        adapter = DhcpcdAdapter(conf_path=str(tmp_path / "dhcpcd.conf"), broker=broker)
+
+        out.append(adapter.apply_ipv4("bad iface!", Ipv4Config(method=Ipv4Method.DHCP)).message)
+
+        def _boom() -> str:
+            raise OSError("read crashed")
+
+        adapter._read_conf = _boom  # type: ignore[method-assign]
+        out.append(adapter.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP)).message)
+        return [m for m in out if m]
+
+    def test_no_message_carries_a_second_sentence(self, broker: FakeBroker, tmp_path) -> None:
+        offenders = [m for m in self._messages(broker, tmp_path) if self._SECOND_SENTENCE.search(m)]
+        assert offenders == [], f"multi-sentence operator messages: {offenders}"
+
+    def test_the_detector_would_catch_a_two_sentence_message(self) -> None:
+        """Guards the guard: a check that never matches proves nothing."""
+        assert self._SECOND_SENTENCE.search("Could not update the file. Nothing was changed.")
+        assert not self._SECOND_SENTENCE.search("Could not update /etc/dhcpcd.conf; nothing was changed.")
+        assert not self._SECOND_SENTENCE.search("Saved; eth0 is at 192.168.1.5 now.")

--- a/tests/test_network_adapter_nm.py
+++ b/tests/test_network_adapter_nm.py
@@ -269,6 +269,44 @@ class TestInactiveProfileLookup:
         self._details(responses, "Alpha", iface="eth0")
         assert a._connection_for("eth0") == "Alpha"
 
+    def test_profiles_are_read_once_for_many_interfaces(self, adapter) -> None:
+        """Reading a profile's interface-name needs its own nmcli call, and
+        _connection_for runs once per interface via get_state. Uncached, one
+        page render on a station with several down interfaces costs dozens of
+        subprocess spawns on a web request thread."""
+        a, captured, responses = adapter
+        self._no_active(responses)
+        self._profiles(responses, "A:802-3-ethernet\nB:802-3-ethernet\n")
+        self._details(responses, "A", iface="eth0")
+        self._details(responses, "B", iface="eth1")
+
+        for _ in range(4):
+            assert a._connection_for("eth0") == "A"
+            assert a._connection_for("eth1") == "B"
+
+        detail_calls = [c for c in captured if "connection.interface-name,connection.autoconnect" in " ".join(c)]
+        assert len(detail_calls) == 2, "profile details re-read per interface per call"
+
+    def test_a_worse_candidate_does_not_displace_the_best(self, adapter) -> None:
+        """Ranking runs while the map is built, so a later profile must lose
+        to an earlier better one rather than overwriting it."""
+        a, _captured, responses = adapter
+        self._no_active(responses)
+        self._profiles(responses, "Auto:802-3-ethernet\nManual:802-3-ethernet\n")
+        self._details(responses, "Auto", iface="eth0", autoconnect="yes")
+        self._details(responses, "Manual", iface="eth0", autoconnect="no")
+        assert a._connection_for("eth0") == "Auto"
+
+    def test_a_profile_bound_to_no_interface_is_ignored(self, adapter) -> None:
+        """A profile that matches by MAC rather than name has an empty
+        interface-name; treating "" as a match would hand every unnamed
+        interface the same profile."""
+        a, _captured, responses = adapter
+        self._no_active(responses)
+        self._profiles(responses, "Roaming:802-3-ethernet\n")
+        self._details(responses, "Roaming", iface="")
+        assert a._connection_for("eth0") is None
+
     def test_unreadable_priority_does_not_break_the_lookup(self, adapter) -> None:
         a, _captured, responses = adapter
         self._no_active(responses)
@@ -292,6 +330,11 @@ class TestInactiveProfileLookup:
         assert result.ok is True
         assert "no link" in result.message
         assert "Wired" in result.message
+        # Reported through partial_failures too: the web layer redirects the
+        # browser to the new address on a CLEAN apply, and nothing is listening
+        # there until the cable goes in. This is what keeps the operator on the
+        # page with the note visible instead of on a dead one.
+        assert any("no link" in note for note in result.partial_failures)
 
     def test_an_activation_failure_with_a_link_is_still_a_failure(self, adapter) -> None:
         """Only an explicit no-carrier state downgrades to pending; anything

--- a/tests/test_network_adapter_nm.py
+++ b/tests/test_network_adapter_nm.py
@@ -215,10 +215,13 @@ class TestActionableMessages:
         assert "No saved profile" in result.message
         assert "Connect the cable once" in result.message
 
-    def test_absent_device_says_to_check_the_adapter(self, adapter) -> None:
+    @pytest.mark.parametrize("device_list", ["", "eth1:connected\nwlan0:disconnected\n"])
+    def test_absent_device_says_to_check_the_adapter(self, adapter, device_list: str) -> None:
+        """Absent whether the device table is empty or simply lists others -
+        the second is the realistic case and used to fall through the loop."""
         a, _captured, responses = adapter
         self._no_profile(responses)
-        _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout="")
+        _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout=device_list)
         result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
         assert "is not present" in result.message
 
@@ -251,6 +254,47 @@ class TestActionableMessages:
             _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout=f"eth0:{state}\n")
             message = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP)).message
             assert len(message) <= 80, f"{message!r} will be truncated on the HUD"
+
+    def test_apply_reports_pending_when_the_link_is_down(self, adapter) -> None:
+        """The settings persisted; the interface just never came up. Reporting
+        a hard failure would be wrong, and reporting a clean apply would send
+        the browser to an address nothing is serving."""
+        a, _captured, responses = adapter
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"],
+            stdout="Wired:eth0\n",
+        )
+        _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout="eth0:unavailable\n")
+        # con mod ok, con down ok, con up fails with no reason of its own.
+        a._broker.exceptions = [None, None, make_failure("")]
+        result = a.apply_ipv4(
+            "eth0",
+            Ipv4Config(method=Ipv4Method.STATIC, address="192.168.1.50", prefix=24),
+        )
+        assert result.ok is True
+        assert result.pending is True
+        assert "no link" in result.message
+
+    def test_a_named_activation_failure_is_not_pending(self, adapter) -> None:
+        """rfkill and an ungranted con-up both leave the device 'unavailable',
+        so keying on device state alone would tell the operator to plug in a
+        cable that isn't the problem."""
+        a, _captured, responses = adapter
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"],
+            stdout="HomeWifi:wlan0\n",
+        )
+        _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout="wlan0:unavailable\n")
+        a._broker.exceptions = [None, None, make_failure("Wi-Fi radio disabled by rfkill")]
+        result = a.apply_ipv4(
+            "wlan0",
+            Ipv4Config(method=Ipv4Method.STATIC, address="192.168.1.50", prefix=24),
+        )
+        assert result.ok is False
+        assert result.pending is False
+        assert "rfkill" in result.message
 
     def test_renew_without_a_link_explains_why(self, adapter) -> None:
         a, _captured, responses = adapter

--- a/tests/test_network_adapter_nm.py
+++ b/tests/test_network_adapter_nm.py
@@ -179,234 +179,12 @@ class TestApplyIpv4:
         a, _captured, responses = adapter
         _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"], stdout="")
         _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show"], stdout="")
+        # Device absent from nmcli entirely: says to check the adapter, which
+        # is the only one of the three causes that fits an unknown device.
+        _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout="")
         result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
         assert result.ok is False
-        # Says what the operator should check, not what the adapter didn't find.
-        assert "eth0" in result.message
-        assert "No NetworkManager connection profile bound" not in result.message
-
-
-class TestInactiveProfileLookup:
-    """nmcli fills the DEVICE column only for *active* connections, so a
-    profile whose carrier dropped is invisible to a DEVICE match. Pre-staging a
-    static address before plugging into the show network is exactly when a
-    static address matters most."""
-
-    def _no_active(self, responses) -> None:
-        _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"], stdout="")
-        _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show"], stdout="")
-
-    def _profiles(self, responses, rows: str) -> None:
-        _set(responses, ["nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"], stdout=rows)
-
-    def _details(self, responses, name: str, *, iface: str, autoconnect: str = "yes", priority: str = "0") -> None:
-        _set(
-            responses,
-            [
-                "nmcli",
-                "-t",
-                "-f",
-                "connection.interface-name,connection.autoconnect,connection.autoconnect-priority",
-                "connection",
-                "show",
-                name,
-            ],
-            stdout=(
-                f"connection.interface-name:{iface}\n"
-                f"connection.autoconnect:{autoconnect}\n"
-                f"connection.autoconnect-priority:{priority}\n"
-            ),
-        )
-
-    def test_finds_a_deactivated_profile_by_interface_name(self, adapter) -> None:
-        a, _captured, responses = adapter
-        self._no_active(responses)
-        self._profiles(responses, "Wired connection 1:802-3-ethernet\n")
-        self._details(responses, "Wired connection 1", iface="eth0")
-        assert a._connection_for("eth0") == "Wired connection 1"
-
-    def test_ignores_a_profile_for_another_interface(self, adapter) -> None:
-        a, _captured, responses = adapter
-        self._no_active(responses)
-        self._profiles(responses, "Other:802-3-ethernet\n")
-        self._details(responses, "Other", iface="eth1")
-        assert a._connection_for("eth0") is None
-
-    def test_ignores_non_addressable_connection_types(self, adapter) -> None:
-        """A bridge or tun profile naming the same device is not something the
-        Network page can hand an IPv4 address to."""
-        a, _captured, responses = adapter
-        self._no_active(responses)
-        self._profiles(responses, "br0:bridge\ntun0:tun\n")
-        self._details(responses, "br0", iface="eth0")
-        assert a._connection_for("eth0") is None
-
-    def test_autoconnect_profile_wins(self, adapter) -> None:
-        """NetworkManager would bring that one up, so it is the one an
-        operator's edit should land on."""
-        a, _captured, responses = adapter
-        self._no_active(responses)
-        self._profiles(responses, "Manual:802-3-ethernet\nAuto:802-3-ethernet\n")
-        self._details(responses, "Manual", iface="eth0", autoconnect="no")
-        self._details(responses, "Auto", iface="eth0", autoconnect="yes")
-        assert a._connection_for("eth0") == "Auto"
-
-    def test_higher_autoconnect_priority_wins(self, adapter) -> None:
-        a, _captured, responses = adapter
-        self._no_active(responses)
-        self._profiles(responses, "Low:802-3-ethernet\nHigh:802-3-ethernet\n")
-        self._details(responses, "Low", iface="eth0", priority="1")
-        self._details(responses, "High", iface="eth0", priority="10")
-        assert a._connection_for("eth0") == "High"
-
-    def test_name_order_breaks_a_tie(self, adapter) -> None:
-        """Deterministic: without an order the edit could land on a different
-        profile each time Apply is pressed."""
-        a, _captured, responses = adapter
-        self._no_active(responses)
-        self._profiles(responses, "Bravo:802-3-ethernet\nAlpha:802-3-ethernet\n")
-        self._details(responses, "Bravo", iface="eth0")
-        self._details(responses, "Alpha", iface="eth0")
-        assert a._connection_for("eth0") == "Alpha"
-
-    def test_profiles_are_read_once_for_many_interfaces(self, adapter) -> None:
-        """Reading a profile's interface-name needs its own nmcli call, and
-        _connection_for runs once per interface via get_state. Uncached, one
-        page render on a station with several down interfaces costs dozens of
-        subprocess spawns on a web request thread."""
-        a, captured, responses = adapter
-        self._no_active(responses)
-        self._profiles(responses, "A:802-3-ethernet\nB:802-3-ethernet\n")
-        self._details(responses, "A", iface="eth0")
-        self._details(responses, "B", iface="eth1")
-
-        for _ in range(4):
-            assert a._connection_for("eth0") == "A"
-            assert a._connection_for("eth1") == "B"
-
-        detail_calls = [c for c in captured if "connection.interface-name,connection.autoconnect" in " ".join(c)]
-        assert len(detail_calls) == 2, "profile details re-read per interface per call"
-
-    def test_a_worse_candidate_does_not_displace_the_best(self, adapter) -> None:
-        """Ranking runs while the map is built, so a later profile must lose
-        to an earlier better one rather than overwriting it."""
-        a, _captured, responses = adapter
-        self._no_active(responses)
-        self._profiles(responses, "Auto:802-3-ethernet\nManual:802-3-ethernet\n")
-        self._details(responses, "Auto", iface="eth0", autoconnect="yes")
-        self._details(responses, "Manual", iface="eth0", autoconnect="no")
-        assert a._connection_for("eth0") == "Auto"
-
-    def test_a_profile_bound_to_no_interface_is_ignored(self, adapter) -> None:
-        """A profile that matches by MAC rather than name has an empty
-        interface-name; treating "" as a match would hand every unnamed
-        interface the same profile."""
-        a, _captured, responses = adapter
-        self._no_active(responses)
-        self._profiles(responses, "Roaming:802-3-ethernet\n")
-        self._details(responses, "Roaming", iface="")
-        assert a._connection_for("eth0") is None
-
-    def test_unreadable_priority_does_not_break_the_lookup(self, adapter) -> None:
-        a, _captured, responses = adapter
-        self._no_active(responses)
-        self._profiles(responses, "Wired:802-3-ethernet\n")
-        self._details(responses, "Wired", iface="eth0", priority="not-a-number")
-        assert a._connection_for("eth0") == "Wired"
-
-    def test_link_down_apply_saves_and_reports_pending(self, adapter) -> None:
-        """The whole point of the fallback: the settings persist and take
-        effect on next plug-in, so this is not a failure."""
-        a, _captured, responses = adapter
-        self._no_active(responses)
-        self._profiles(responses, "Wired:802-3-ethernet\n")
-        self._details(responses, "Wired", iface="eth0")
-        _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout="eth0:unavailable\n")
-        a._broker.exceptions = [None, None, make_failure("no carrier")]
-        result = a.apply_ipv4(
-            "eth0",
-            Ipv4Config(method=Ipv4Method.STATIC, address="192.168.1.50", prefix=24),
-        )
-        assert result.ok is True
-        assert "no link" in result.message
-        assert "Wired" in result.message
-        # Reported through partial_failures too: the web layer redirects the
-        # browser to the new address on a CLEAN apply, and nothing is listening
-        # there until the cable goes in. This is what keeps the operator on the
-        # page with the note visible instead of on a dead one.
-        assert any("no link" in note for note in result.partial_failures)
-
-    def test_an_activation_failure_with_a_link_is_still_a_failure(self, adapter) -> None:
-        """Only an explicit no-carrier state downgrades to pending; anything
-        else must keep surfacing as an error rather than a reassuring note."""
-        a, _captured, responses = adapter
-        _set(
-            responses,
-            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"],
-            stdout="Wired:eth0\n",
-        )
-        _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout="eth0:disconnected\n")
-        a._broker.exceptions = [None, None, make_failure("activation failed")]
-        result = a.apply_ipv4(
-            "eth0",
-            Ipv4Config(method=Ipv4Method.STATIC, address="192.168.1.50", prefix=24),
-        )
-        assert result.ok is False
-        assert "activation failed" in result.message
-
-
-class TestLookupSubprocessFailures:
-    """nmcli being unavailable mid-lookup must degrade, not raise: the Network
-    page is the operator's recovery surface and has to keep rendering."""
-
-    def _raise(self, a, monkeypatch, failing: list[str]) -> None:
-        original = a._run
-
-        def _run(argv, *, check=True):
-            # Compare a prefix of the SAME length, or a shorter marker never
-            # matches and the failure is silently never injected.
-            if list(argv)[: len(failing)] == failing:
-                raise RuntimeError("nmcli gone")
-            return original(argv, check=check)
-
-        monkeypatch.setattr(a, "_run", _run)
-
-    def test_profile_list_failure_reports_no_profile(self, adapter, monkeypatch) -> None:
-        a, _captured, responses = adapter
-        _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"], stdout="")
-        _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show"], stdout="")
-        self._raise(a, monkeypatch, ["nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"])
-        assert a._connection_for("eth0") is None
-
-    def test_detail_read_failure_skips_that_profile(self, adapter, monkeypatch) -> None:
-        a, _captured, responses = adapter
-        _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"], stdout="")
-        _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show"], stdout="")
-        _set(responses, ["nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"], stdout="Wired:802-3-ethernet\n")
-        self._raise(
-            a,
-            monkeypatch,
-            [
-                "nmcli",
-                "-t",
-                "-f",
-                "connection.interface-name,connection.autoconnect,connection.autoconnect-priority",
-            ],
-        )
-        assert a._connection_for("eth0") is None
-
-    def test_device_state_failure_falls_back_to_the_generic_message(self, adapter, monkeypatch) -> None:
-        a, _captured, responses = adapter
-        for argv in (
-            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"],
-            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show"],
-            ["nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"],
-        ):
-            _set(responses, argv, stdout="")
-        self._raise(a, monkeypatch, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"])
-        result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
-        assert result.ok is False
-        assert "not present on this system" in result.message
+        assert "is not present" in result.message
 
 
 class TestActionableMessages:
@@ -428,14 +206,13 @@ class TestActionableMessages:
         result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
         assert result.ok is False
         assert "not managed by NetworkManager" in result.message
-        assert "unmanaged-devices" in result.message
 
     def test_known_device_without_a_profile_says_how_to_get_one(self, adapter) -> None:
         a, _captured, responses = adapter
         self._no_profile(responses)
         _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout="eth0:disconnected\n")
         result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
-        assert "No saved network profile" in result.message
+        assert "No saved profile" in result.message
         assert "Connect the cable once" in result.message
 
     def test_absent_device_says_to_check_the_adapter(self, adapter) -> None:
@@ -443,7 +220,37 @@ class TestActionableMessages:
         self._no_profile(responses)
         _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout="")
         result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
-        assert "not present on this system" in result.message
+        assert "is not present" in result.message
+
+    def test_an_unreadable_device_state_is_not_reported_as_absent(self, adapter, monkeypatch) -> None:
+        """nmcli timing out is not evidence the adapter is gone. Telling the
+        operator their plugged-in NIC "is not present" contradicts the card
+        they just clicked to get here."""
+        a, _captured, responses = adapter
+        self._no_profile(responses)
+        original = a._run
+
+        def _run(argv, *, check=True):
+            if list(argv)[:5] == ["nmcli", "-t", "-f", "DEVICE,STATE", "device"]:
+                raise RuntimeError("nmcli wedged")
+            return original(argv, check=check)
+
+        monkeypatch.setattr(a, "_run", _run)
+        result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
+        assert result.ok is False
+        assert "Could not read" in result.message
+        assert "not present" not in result.message
+
+    def test_every_apply_message_fits_the_on_screen_banner(self, adapter) -> None:
+        """The Settings > Network banner is one truncated line, so a message
+        long enough to wrap loses exactly the actionable half - and that banner
+        is the operator's surface when the web UI is unreachable."""
+        a, _captured, responses = adapter
+        self._no_profile(responses)
+        for state in ("", "unmanaged", "disconnected"):
+            _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout=f"eth0:{state}\n")
+            message = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP)).message
+            assert len(message) <= 80, f"{message!r} will be truncated on the HUD"
 
     def test_renew_without_a_link_explains_why(self, adapter) -> None:
         a, _captured, responses = adapter
@@ -453,10 +260,27 @@ class TestActionableMessages:
             stdout="Wired:eth0\n",
         )
         _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout="eth0:unavailable\n")
-        a._broker.exceptions = [None, make_failure("no carrier")]
+        # nmcli itself gave no reason, so the link explanation is the right one.
+        a._broker.exceptions = [None, make_failure("")]
         result = a.renew_lease("eth0")
         assert result.ok is False
         assert "no link" in result.message
+
+    def test_renew_does_not_blame_the_cable_for_a_real_failure(self, adapter) -> None:
+        """A missing helper or an ungranted rule is not a link problem, and
+        sending the operator to check a cable hides the actual fix."""
+        a, _captured, responses = adapter
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"],
+            stdout="Wired:eth0\n",
+        )
+        _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout="eth0:unavailable\n")
+        a._broker.exceptions = [None, make_failure("not authorised")]
+        result = a.renew_lease("eth0")
+        assert result.ok is False
+        assert "not authorised" in result.message
+        assert "no link" not in result.message
 
     def test_save_failure_names_the_profile(self, adapter) -> None:
         a, _captured, responses = adapter
@@ -490,10 +314,11 @@ class TestRenewLease:
         a, _captured, responses = adapter
         _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"], stdout="")
         _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show"], stdout="")
+        _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout="eth0:disconnected\n")
         result = a.renew_lease("eth0")
         assert result.ok is False
-        assert "eth0" in result.message
-        assert "No NetworkManager profile for" not in result.message
+        # Names the cause the operator can act on, not adapter state.
+        assert "No saved profile" in result.message
 
     def test_renew_propagates_up_failure(self, adapter) -> None:
         a, _captured, responses = adapter
@@ -1099,7 +924,7 @@ class TestBrokerNotConfigured:
         monkeypatch.setattr(a, "_run", _run)
         result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
         assert result.ok is False
-        assert "Broker" in result.message
+        assert "privileged helper is not configured" in result.message
 
     def test_renew_without_broker_returns_broker_message(self, monkeypatch) -> None:
         import subprocess as sp
@@ -1114,7 +939,8 @@ class TestBrokerNotConfigured:
         monkeypatch.setattr(a, "_run", _run)
         result = a.renew_lease("eth0")
         assert result.ok is False
-        assert "Broker" in result.message
+        # Names something the operator can act on, not an internal object.
+        assert "privileged helper is not configured" in result.message
 
     def test_apply_privilege_error_surfaces(self, adapter) -> None:
         """A PrivilegeError on the modify step surfaces with the

--- a/tests/test_network_adapter_nm.py
+++ b/tests/test_network_adapter_nm.py
@@ -181,7 +181,252 @@ class TestApplyIpv4:
         _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show"], stdout="")
         result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
         assert result.ok is False
-        assert "No NetworkManager" in result.message
+        # Says what the operator should check, not what the adapter didn't find.
+        assert "eth0" in result.message
+        assert "No NetworkManager connection profile bound" not in result.message
+
+
+class TestInactiveProfileLookup:
+    """nmcli fills the DEVICE column only for *active* connections, so a
+    profile whose carrier dropped is invisible to a DEVICE match. Pre-staging a
+    static address before plugging into the show network is exactly when a
+    static address matters most."""
+
+    def _no_active(self, responses) -> None:
+        _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"], stdout="")
+        _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show"], stdout="")
+
+    def _profiles(self, responses, rows: str) -> None:
+        _set(responses, ["nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"], stdout=rows)
+
+    def _details(self, responses, name: str, *, iface: str, autoconnect: str = "yes", priority: str = "0") -> None:
+        _set(
+            responses,
+            [
+                "nmcli",
+                "-t",
+                "-f",
+                "connection.interface-name,connection.autoconnect,connection.autoconnect-priority",
+                "connection",
+                "show",
+                name,
+            ],
+            stdout=(
+                f"connection.interface-name:{iface}\n"
+                f"connection.autoconnect:{autoconnect}\n"
+                f"connection.autoconnect-priority:{priority}\n"
+            ),
+        )
+
+    def test_finds_a_deactivated_profile_by_interface_name(self, adapter) -> None:
+        a, _captured, responses = adapter
+        self._no_active(responses)
+        self._profiles(responses, "Wired connection 1:802-3-ethernet\n")
+        self._details(responses, "Wired connection 1", iface="eth0")
+        assert a._connection_for("eth0") == "Wired connection 1"
+
+    def test_ignores_a_profile_for_another_interface(self, adapter) -> None:
+        a, _captured, responses = adapter
+        self._no_active(responses)
+        self._profiles(responses, "Other:802-3-ethernet\n")
+        self._details(responses, "Other", iface="eth1")
+        assert a._connection_for("eth0") is None
+
+    def test_ignores_non_addressable_connection_types(self, adapter) -> None:
+        """A bridge or tun profile naming the same device is not something the
+        Network page can hand an IPv4 address to."""
+        a, _captured, responses = adapter
+        self._no_active(responses)
+        self._profiles(responses, "br0:bridge\ntun0:tun\n")
+        self._details(responses, "br0", iface="eth0")
+        assert a._connection_for("eth0") is None
+
+    def test_autoconnect_profile_wins(self, adapter) -> None:
+        """NetworkManager would bring that one up, so it is the one an
+        operator's edit should land on."""
+        a, _captured, responses = adapter
+        self._no_active(responses)
+        self._profiles(responses, "Manual:802-3-ethernet\nAuto:802-3-ethernet\n")
+        self._details(responses, "Manual", iface="eth0", autoconnect="no")
+        self._details(responses, "Auto", iface="eth0", autoconnect="yes")
+        assert a._connection_for("eth0") == "Auto"
+
+    def test_higher_autoconnect_priority_wins(self, adapter) -> None:
+        a, _captured, responses = adapter
+        self._no_active(responses)
+        self._profiles(responses, "Low:802-3-ethernet\nHigh:802-3-ethernet\n")
+        self._details(responses, "Low", iface="eth0", priority="1")
+        self._details(responses, "High", iface="eth0", priority="10")
+        assert a._connection_for("eth0") == "High"
+
+    def test_name_order_breaks_a_tie(self, adapter) -> None:
+        """Deterministic: without an order the edit could land on a different
+        profile each time Apply is pressed."""
+        a, _captured, responses = adapter
+        self._no_active(responses)
+        self._profiles(responses, "Bravo:802-3-ethernet\nAlpha:802-3-ethernet\n")
+        self._details(responses, "Bravo", iface="eth0")
+        self._details(responses, "Alpha", iface="eth0")
+        assert a._connection_for("eth0") == "Alpha"
+
+    def test_unreadable_priority_does_not_break_the_lookup(self, adapter) -> None:
+        a, _captured, responses = adapter
+        self._no_active(responses)
+        self._profiles(responses, "Wired:802-3-ethernet\n")
+        self._details(responses, "Wired", iface="eth0", priority="not-a-number")
+        assert a._connection_for("eth0") == "Wired"
+
+    def test_link_down_apply_saves_and_reports_pending(self, adapter) -> None:
+        """The whole point of the fallback: the settings persist and take
+        effect on next plug-in, so this is not a failure."""
+        a, _captured, responses = adapter
+        self._no_active(responses)
+        self._profiles(responses, "Wired:802-3-ethernet\n")
+        self._details(responses, "Wired", iface="eth0")
+        _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout="eth0:unavailable\n")
+        a._broker.exceptions = [None, None, make_failure("no carrier")]
+        result = a.apply_ipv4(
+            "eth0",
+            Ipv4Config(method=Ipv4Method.STATIC, address="192.168.1.50", prefix=24),
+        )
+        assert result.ok is True
+        assert "no link" in result.message
+        assert "Wired" in result.message
+
+    def test_an_activation_failure_with_a_link_is_still_a_failure(self, adapter) -> None:
+        """Only an explicit no-carrier state downgrades to pending; anything
+        else must keep surfacing as an error rather than a reassuring note."""
+        a, _captured, responses = adapter
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"],
+            stdout="Wired:eth0\n",
+        )
+        _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout="eth0:disconnected\n")
+        a._broker.exceptions = [None, None, make_failure("activation failed")]
+        result = a.apply_ipv4(
+            "eth0",
+            Ipv4Config(method=Ipv4Method.STATIC, address="192.168.1.50", prefix=24),
+        )
+        assert result.ok is False
+        assert "activation failed" in result.message
+
+
+class TestLookupSubprocessFailures:
+    """nmcli being unavailable mid-lookup must degrade, not raise: the Network
+    page is the operator's recovery surface and has to keep rendering."""
+
+    def _raise(self, a, monkeypatch, failing: list[str]) -> None:
+        original = a._run
+
+        def _run(argv, *, check=True):
+            # Compare a prefix of the SAME length, or a shorter marker never
+            # matches and the failure is silently never injected.
+            if list(argv)[: len(failing)] == failing:
+                raise RuntimeError("nmcli gone")
+            return original(argv, check=check)
+
+        monkeypatch.setattr(a, "_run", _run)
+
+    def test_profile_list_failure_reports_no_profile(self, adapter, monkeypatch) -> None:
+        a, _captured, responses = adapter
+        _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"], stdout="")
+        _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show"], stdout="")
+        self._raise(a, monkeypatch, ["nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"])
+        assert a._connection_for("eth0") is None
+
+    def test_detail_read_failure_skips_that_profile(self, adapter, monkeypatch) -> None:
+        a, _captured, responses = adapter
+        _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"], stdout="")
+        _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show"], stdout="")
+        _set(responses, ["nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"], stdout="Wired:802-3-ethernet\n")
+        self._raise(
+            a,
+            monkeypatch,
+            [
+                "nmcli",
+                "-t",
+                "-f",
+                "connection.interface-name,connection.autoconnect,connection.autoconnect-priority",
+            ],
+        )
+        assert a._connection_for("eth0") is None
+
+    def test_device_state_failure_falls_back_to_the_generic_message(self, adapter, monkeypatch) -> None:
+        a, _captured, responses = adapter
+        for argv in (
+            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"],
+            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show"],
+            ["nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"],
+        ):
+            _set(responses, argv, stdout="")
+        self._raise(a, monkeypatch, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"])
+        result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
+        assert result.ok is False
+        assert "not present on this system" in result.message
+
+
+class TestActionableMessages:
+    """Each cause needs a different operator action, so each needs its own
+    message - "no profile bound" described adapter state and told them nothing."""
+
+    def _no_profile(self, responses) -> None:
+        for argv in (
+            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"],
+            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show"],
+            ["nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"],
+        ):
+            _set(responses, argv, stdout="")
+
+    def test_unmanaged_device_says_how_to_hand_it_to_networkmanager(self, adapter) -> None:
+        a, _captured, responses = adapter
+        self._no_profile(responses)
+        _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout="eth0:unmanaged\n")
+        result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
+        assert result.ok is False
+        assert "not managed by NetworkManager" in result.message
+        assert "unmanaged-devices" in result.message
+
+    def test_known_device_without_a_profile_says_how_to_get_one(self, adapter) -> None:
+        a, _captured, responses = adapter
+        self._no_profile(responses)
+        _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout="eth0:disconnected\n")
+        result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
+        assert "No saved network profile" in result.message
+        assert "Connect the cable once" in result.message
+
+    def test_absent_device_says_to_check_the_adapter(self, adapter) -> None:
+        a, _captured, responses = adapter
+        self._no_profile(responses)
+        _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout="")
+        result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
+        assert "not present on this system" in result.message
+
+    def test_renew_without_a_link_explains_why(self, adapter) -> None:
+        a, _captured, responses = adapter
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"],
+            stdout="Wired:eth0\n",
+        )
+        _set(responses, ["nmcli", "-t", "-f", "DEVICE,STATE", "device"], stdout="eth0:unavailable\n")
+        a._broker.exceptions = [None, make_failure("no carrier")]
+        result = a.renew_lease("eth0")
+        assert result.ok is False
+        assert "no link" in result.message
+
+    def test_save_failure_names_the_profile(self, adapter) -> None:
+        a, _captured, responses = adapter
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"],
+            stdout="Wired:eth0\n",
+        )
+        a._broker.exceptions = [make_failure("read-only")]
+        result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
+        assert result.ok is False
+        assert "Wired" in result.message
+        assert "read-only" in result.message
 
 
 class TestRenewLease:
@@ -204,7 +449,8 @@ class TestRenewLease:
         _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show"], stdout="")
         result = a.renew_lease("eth0")
         assert result.ok is False
-        assert "No NetworkManager" in result.message
+        assert "eth0" in result.message
+        assert "No NetworkManager profile for" not in result.message
 
     def test_renew_propagates_up_failure(self, adapter) -> None:
         a, _captured, responses = adapter

--- a/tests/test_network_adapter_nm.py
+++ b/tests/test_network_adapter_nm.py
@@ -274,7 +274,7 @@ class TestActionableMessages:
         )
         assert result.ok is True
         assert result.pending is True
-        assert "no link" in result.message
+        assert "has a link" in result.message
 
     def test_a_named_activation_failure_is_not_pending(self, adapter) -> None:
         """rfkill and an ungranted con-up both leave the device 'unavailable',

--- a/tests/test_web_network_write.py
+++ b/tests/test_web_network_write.py
@@ -862,3 +862,34 @@ def test_a_clean_apply_still_redirects(net_server) -> None:
         },
     )
     assert "hx-redirect" in headers
+
+
+def test_a_pending_apply_still_shows_its_warnings(net_server) -> None:
+    """Pending is the one path that keeps the operator on the page in order to
+    explain itself, so warnings dropped here are lost outright - there is no
+    later redirect where they could resurface.
+
+    Both backends can return pending with caveats (an ``nmcli con down``
+    failure, a dhcpcd reload fallback), and those are the caveats that tell an
+    operator the save is not the whole story.
+    """
+    fake, base = net_server
+    fake.apply_result = ApplyResult(
+        ok=True,
+        pending=True,
+        message="Saved; the settings take effect when eth0 has a link.",
+        partial_failures=("dhcpcd -n: rebind refused (fell back to systemctl reload)",),
+    )
+    status, body = _post(
+        base,
+        "/section/network/apply",
+        {
+            "iface": "eth0",
+            "method": "static",
+            "address": "192.168.9.9",
+            "subnet_mask": "255.255.255.0",
+        },
+    )
+    assert status == 200
+    assert "take effect when eth0 has a link" in body
+    assert "rebind refused" in body, "the pending banner dropped its warnings"

--- a/tests/test_web_network_write.py
+++ b/tests/test_web_network_write.py
@@ -806,17 +806,11 @@ def test_card_synthesises_rows_when_no_interface_provider_is_wired(net_server) -
     assert "10.0.0.5" in body
 
 
-def test_pre_staging_a_static_address_does_not_redirect_to_a_dead_address(net_server) -> None:
-    """Saving a static address while the cable is out is a supported workflow.
-    It reports success, so the clean-apply branch would send the browser to an
-    address with no carrier behind it - the operator loses the UI and never
-    sees the note explaining the settings are pending."""
+def test_a_pending_apply_does_not_redirect_to_a_dead_address(net_server) -> None:
+    """The interface never came up, so nothing is serving the new address.
+    Redirecting there loses the UI and discards the explanation with the body."""
     fake, base = net_server
-    fake.apply_result = ApplyResult(
-        ok=True,
-        message="Saved to profile 'Wired'. eth0 has no link, so the settings take effect when the cable is connected.",
-        partial_failures=("eth0 has no link, so the settings take effect when the cable is connected.",),
-    )
+    fake.apply_result = ApplyResult(ok=True, pending=True, message="Saved. eth0 has no link yet.")
     status, body, headers = _post_resp(
         base,
         "/section/network/apply",
@@ -829,4 +823,42 @@ def test_pre_staging_a_static_address_does_not_redirect_to_a_dead_address(net_se
     )
     assert status == 200
     assert "hx-redirect" not in headers
-    assert "no link" in body
+    assert "no link yet" in body
+    # The settings were still written - this is "saved", not "failed".
+    assert fake.applied and fake.applied[0][0] == "eth0"
+
+
+def test_a_pending_apply_does_not_advise_reconnecting(net_server) -> None:
+    """The partial-failure path tells the operator to reconnect at the new
+    address. For a pending apply that is the one thing they must not do."""
+    fake, base = net_server
+    fake.apply_result = ApplyResult(ok=True, pending=True, message="Saved. eth0 has no link yet.")
+    _status, body, _headers = _post_resp(
+        base,
+        "/section/network/apply",
+        {
+            "iface": "eth0",
+            "method": "static",
+            "address": "192.168.9.9",
+            "subnet_mask": "255.255.255.0",
+        },
+    )
+    assert "Reconnect at" not in body
+    assert "applied" not in body.lower()
+
+
+def test_a_clean_apply_still_redirects(net_server) -> None:
+    """The pending gate must not suppress the normal static-apply redirect."""
+    fake, base = net_server
+    fake.apply_result = ApplyResult(ok=True, message="Applied.")
+    _status, _body, headers = _post_resp(
+        base,
+        "/section/network/apply",
+        {
+            "iface": "eth0",
+            "method": "static",
+            "address": "192.168.9.9",
+            "subnet_mask": "255.255.255.0",
+        },
+    )
+    assert "hx-redirect" in headers

--- a/tests/test_web_network_write.py
+++ b/tests/test_web_network_write.py
@@ -71,6 +71,7 @@ class FakeNetwork:
         self.dns = list(dns)
         self.lease_display = lease_display
         self.applied: list[tuple[str, object]] = []
+        self.omit_active = False
         self.renewed: list[str] = []
         self.apply_result = ApplyResult(ok=True)
         self.renew_result = ApplyResult(ok=True)
@@ -79,6 +80,10 @@ class FakeNetwork:
     def config_provider(self, iface: str | None = None) -> dict | None:
         if not self.interfaces:
             return {"interfaces": [], "writable": self.writable, "backend": "fake"}
+        if self.omit_active:
+            # A snapshot that lists interfaces but names no active one: the
+            # write path must not read a bind target out of it.
+            return {"interfaces": self.interfaces, "writable": self.writable, "backend": "fake"}
         active = iface if iface in self.interfaces else self.interfaces[0]
         return {
             "interfaces": self.interfaces,
@@ -288,9 +293,13 @@ def test_apply_static_calls_adapter_and_redirects_to_new_ip(net_server) -> None:
     assert "192.168.1.50" in headers.get("hx-redirect", "")
 
 
-def test_apply_unknown_iface_defaults_to_active(net_server) -> None:
+def test_apply_unknown_iface_touches_nothing(net_server) -> None:
+    """An interface the host does not have must not be silently redirected onto
+    the active one. Substituting reconfigures and bounces the NIC the operator
+    is connected over - on a station that means PSN, OSC and the beacon all drop
+    - and the page that posted it had only gone stale behind a pulled adapter."""
     fake, base = net_server
-    status, _, headers = _post_resp(
+    status, body, headers = _post_resp(
         base,
         "/section/network/apply",
         {
@@ -301,9 +310,71 @@ def test_apply_unknown_iface_defaults_to_active(net_server) -> None:
         },
     )
     assert status == 200
-    assert len(fake.applied) == 1
-    assert fake.applied[0][0] == "eth0"  # not the forged "bogus0"
-    assert "192.168.1.50" in headers.get("hx-redirect", "")
+    assert fake.applied == []  # neither "bogus0" nor the active interface
+    assert "hx-redirect" not in {k.lower() for k in headers}
+    assert "bogus0 is not present" in body
+    assert "Scan" in body
+
+
+def test_apply_unknown_iface_message_is_bounded(net_server) -> None:
+    """The rejected name is echoed back, and a POST is not bound by IFNAMSIZ."""
+    fake, base = net_server
+    _status, body, _headers = _post_resp(
+        base,
+        "/section/network/apply",
+        {"iface": "b" * 400, "method": "dhcp"},
+    )
+    assert fake.applied == []
+    assert "b" * 400 not in body
+    assert "b" * 15 in body
+
+
+def test_apply_blank_iface_still_defaults_to_active(net_server) -> None:
+    """Blank is the form's own default, not a forged value - it must keep
+    resolving to the active interface or Apply breaks on the ordinary path."""
+    fake, base = net_server
+    status, _body, _headers = _post_resp(
+        base,
+        "/section/network/apply",
+        {
+            "iface": "",
+            "method": "static",
+            "address": "192.168.1.50",
+            "subnet_mask": "255.255.255.0",
+        },
+    )
+    assert status == 200
+    assert [iface for iface, _cfg in fake.applied] == ["eth0"]
+
+
+def test_apply_snapshot_without_an_active_interface_touches_nothing(net_server) -> None:
+    """The snapshot names the interfaces but not which one is active, so there
+    is no target to write to. Falling through to the adapter with whatever
+    ``active_interface`` happened to be missing would apply somewhere nobody
+    chose."""
+    fake, base = net_server
+    fake.omit_active = True
+    status, body, _headers = _post_resp(
+        base,
+        "/section/network/apply",
+        {"iface": "", "method": "dhcp"},
+    )
+    assert status == 200
+    assert fake.applied == []
+    assert "not available on this host" in body
+
+
+def test_renew_unknown_iface_touches_nothing(net_server) -> None:
+    """Same substitution, same consequence: renewing the lease on the NIC the
+    operator arrived over drops the session they are holding."""
+    fake, base = net_server
+    _status, body, _headers = _post_resp(
+        base,
+        "/section/network/renew",
+        {"iface": "bogus0"},
+    )
+    assert fake.renewed == []
+    assert "bogus0 is not present" in body
 
 
 def test_apply_dhcp_manual_redirects_to_manual_address(net_server) -> None:

--- a/tests/test_web_network_write.py
+++ b/tests/test_web_network_write.py
@@ -804,3 +804,29 @@ def test_card_synthesises_rows_when_no_interface_provider_is_wired(net_server) -
     assert "eth0" in body and "wlan0" in body
     # Only the open interface carries detail on this path.
     assert "10.0.0.5" in body
+
+
+def test_pre_staging_a_static_address_does_not_redirect_to_a_dead_address(net_server) -> None:
+    """Saving a static address while the cable is out is a supported workflow.
+    It reports success, so the clean-apply branch would send the browser to an
+    address with no carrier behind it - the operator loses the UI and never
+    sees the note explaining the settings are pending."""
+    fake, base = net_server
+    fake.apply_result = ApplyResult(
+        ok=True,
+        message="Saved to profile 'Wired'. eth0 has no link, so the settings take effect when the cable is connected.",
+        partial_failures=("eth0 has no link, so the settings take effect when the cable is connected.",),
+    )
+    status, body, headers = _post_resp(
+        base,
+        "/section/network/apply",
+        {
+            "iface": "eth0",
+            "method": "static",
+            "address": "192.168.9.9",
+            "subnet_mask": "255.255.255.0",
+        },
+    )
+    assert status == 200
+    assert "hx-redirect" not in headers
+    assert "no link" in body


### PR DESCRIPTION
**Partially closes #51** - the actionable-messages half. The inactive-profile
lookup is deferred to its own PR; see below.

Stacked on #66.

## What landed

### Messages that name an action

`"No NetworkManager connection profile bound to eth0"` described adapter state.
The condition has three causes needing three different operator actions, so it
now probes `nmcli device status` and answers accordingly - device unmanaged, no
profile ever created, or device absent. The same pass covers the other bare
messages in both backends: `nmcli con mod failed`, `nmcli con up failed`,
`Broker not configured.`, `Failed to update dhcpcd.conf`.

Every message is **one short sentence**. The on-screen Settings banner is a
single truncated line, so the multi-sentence versions I first wrote lost exactly
the actionable half at both 1280 and 1920 - including, absurdly, the one
advising the operator to use the on-screen Settings menu.

`_device_state` distinguishes *absent* from *unreadable*. An nmcli timeout was
being reported as "not present on this system" for an adapter the operator had
just clicked on.

### `ApplyResult.pending`

A third outcome: the settings were saved but the interface never came up.

This was previously signalled through `partial_failures`, which already means
"activated, with caveats" - so the banner said *applied* and offered reconnect
advice for an interface that had not come up. The web layer now keys both the
redirect suppression and the banner on `pending`.

**dhcpcd sets it too, fixing a pre-existing bug**: `dhcpcd -n` returns 0 on a
carrier-less interface (it only signals the daemon), so that backend has always
returned a clean success and had the browser redirected to an address nothing
was serving.

A no-carrier device no longer downgrades a *real* failure to pending. rfkill and
an ungranted `con-up` both leave the device `unavailable`, so keying on device
state alone told an operator with a soft-blocked radio to plug in a cable that
does not exist. The link explanation is used only when nmcli gave no reason of
its own.

## What was deferred, and why

The first version of this PR added a third pass to `_connection_for` matching
`connection.interface-name`, so a deactivated profile could be found. Review
showed it made previously-unreachable paths reachable without anyone tracing
what those paths do:

- **Pre-staging a `DHCP with manual address` on a link-down interface silently
  wrote a wrong subnet.** The route forces `prefix=None, router=None` for
  non-static methods, and the branch sources them from a lease that does not
  exist on a dead link - so it persisted a hardcoded `/24`, no gateway, no DNS,
  and reported success. On a `/16` show LAN the station comes up on the wrong
  subnet. Before the lookup this combination hard-failed and mutated nothing.
- It rewrote and bounced profiles for devices NetworkManager does not manage.
- It widened *Renew DHCP lease* from "re-lease" to "bring this interface up",
  activating a profile an operator had deliberately deactivated.
- Its type filter was inverted: it admitted bridge and bond **port** profiles
  (type `802-3-ethernet`, naming the enslaved device) and excluded the
  **masters** (type `bridge`) that actually own an IPv4 address.
- It split nmcli terse output without unescaping, so any profile whose name
  contains a colon was invisible - in a module that defines `_unescape_terse`
  for exactly that.

Each wants a guard designed in rather than bolted on afterwards, so it gets its
own PR. The help paragraph describing the pre-stage workflow moves with it,
since without the lookup NetworkManager still reports "no saved profile".

## Verification

`make ci-remote` green on the Pi (aarch64 / Python 3.13): lint, mypy, bandit,
1009 tests, 100.00% coverage, build. Both adapters at 100% line + branch.

**Not hardware-validated.** Needs a Pi to confirm each message reaches the
on-screen banner intact, and that a link-down apply on dhcpcd now keeps the
operator on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
