### PR TITLE
fix(osc): correct the bundled Eos and ADM-OSC template wire formats

### DIFF
--- a/openfollow/osc/template.py
+++ b/openfollow/osc/template.py
@@ -155,6 +155,11 @@ PLACEHOLDERS: frozenset[str] = _SOURCES
 # see ``_is_ascii_digit``.
 _RANGE_PREFIX_RE = re.compile(r"(-?[0-9]+(?:\.[0-9]+)?)-(-?[0-9]+(?:\.[0-9]+)?)")
 
+# Six decimals is a micrometre at stage scale. The precision must stay
+# non-zero: :func:`_format_value` trims trailing zeros, and a ``".0f"``
+# render carries no decimal point to stop the trim at.
+_FLOAT_FORMAT: str = ".6f"
+
 
 class RenderError(ValueError):
     """Raised when a placeholder cannot be resolved at render time.
@@ -1017,9 +1022,9 @@ def render(ct: CompiledTemplate, rc: RenderContext) -> str:
 def _format_value(value: Any) -> str:
     """Stringify a slot value for string-rendered OSC templates.
 
-    Integers render as decimal strings. Other numerics use ``format(...,
-    "g")``, which trims trailing zeros (``1.0`` → ``"1"``) and may emit
-    exponent notation at extreme magnitudes. Reached by multi-part
+    Integers render as decimal strings. Other numerics render fixed-point
+    with trailing zeros trimmed (``1.0`` → ``"1"``, ``2.5`` → ``"2.5"``),
+    never in exponent notation at any magnitude. Reached by multi-part
     templates; single-slot args go through :func:`osc_arg_for` to keep
     their OSC typetag.
     """
@@ -1027,7 +1032,9 @@ def _format_value(value: Any) -> str:
         return str(int(value))
     if isinstance(value, int):
         return str(value)
-    return format(float(value), "g")
+    # A finite value always renders a decimal point, so the trim can't eat
+    # significant digits; ``inf`` / ``nan`` carry none and pass through.
+    return format(float(value), _FLOAT_FORMAT).rstrip("0").rstrip(".")
 
 
 def _wire_type(slot: _Slot) -> str:
@@ -1140,11 +1147,22 @@ class BuiltinTemplate:
 # ``builtin.trigger`` always being populated. All share the one read-only
 # ``MappingProxyType`` instance – sharing is safe since it's immutable.
 BUILTIN_TEMPLATES: tuple[BuiltinTemplate, ...] = (
+    # Augment3d shares our stage frame (X lateral, Y depth, Z height) and
+    # metres, so the marker position maps across 1:1.
     BuiltinTemplate(
         id="etc",
         name="ETC Eos",
+        address="/eos/chan/[markerid]/xyz",
+        args=("[x]", "[y]", "[z]"),
+        trigger=_DEFAULT_STREAM_30HZ_TRIGGER,
+    ),
+    # Patch variant: same position, plus three rotation args. The ``0.0``
+    # literals type as OSC ``f`` – Eos rejects the ``i`` a bare ``0`` gives.
+    BuiltinTemplate(
+        id="etc-patch",
+        name="ETC Eos (Patch)",
         address="/eos/set/patch/[markerid]/augment3d/position",
-        args=("[x]", "[z]", "[y]", "0", "0", "0"),
+        args=("[x]", "[y]", "[z]", "0.0", "0.0", "0.0"),
         trigger=_DEFAULT_STREAM_30HZ_TRIGGER,
     ),
     # ``id`` stays ``adm-osc`` so existing rows referencing it keep

--- a/openfollow/osc/template.py
+++ b/openfollow/osc/template.py
@@ -1166,13 +1166,13 @@ BUILTIN_TEMPLATES: tuple[BuiltinTemplate, ...] = (
         trigger=_DEFAULT_STREAM_30HZ_TRIGGER,
     ),
     # ``id`` stays ``adm-osc`` so existing rows referencing it keep
-    # resolving. Third arg is a literal ``0``, not the marker's absolute
-    # Z, so the 2D variant stays 2D.
+    # resolving. Third arg is a literal, not the marker's absolute Z, so
+    # the 2D variant stays 2D; ADM-OSC types the triplet as three floats.
     BuiltinTemplate(
         id="adm-osc",
         name="ADM-OSC 2D",
         address="/adm/obj/[markerid]/xyz",
-        args=("[x.frac]", "[y.frac]", "0"),
+        args=("[x.frac]", "[y.frac]", "0.0"),
         trigger=_DEFAULT_STREAM_30HZ_TRIGGER,
     ),
     # 3D variant: ``[z.frac]`` for height. Requires

--- a/openfollow/templates/system/osc_output.adm-osc.oftemplate
+++ b/openfollow/templates/system/osc_output.adm-osc.oftemplate
@@ -6,7 +6,7 @@
   "is_system": true,
   "payload": {
     "address": "/adm/obj/[markerid]/xyz",
-    "args": ["[x.frac]", "[y.frac]", "0"],
+    "args": ["[x.frac]", "[y.frac]", "0.0"],
     "trigger": {"kind": "stream", "rate_hz": 30}
   }
 }

--- a/openfollow/templates/system/osc_output.etc-eos-patch.oftemplate
+++ b/openfollow/templates/system/osc_output.etc-eos-patch.oftemplate
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "type": "osc_output",
+  "id": "system-osc_output-etc-eos-patch",
+  "name": "ETC Eos (Patch)",
+  "is_system": true,
+  "payload": {
+    "address": "/eos/set/patch/[markerid]/augment3d/position",
+    "args": ["[x]", "[y]", "[z]", "0.0", "0.0", "0.0"],
+    "trigger": {"kind": "stream", "rate_hz": 30}
+  }
+}

--- a/openfollow/templates/system/osc_output.etc-eos.oftemplate
+++ b/openfollow/templates/system/osc_output.etc-eos.oftemplate
@@ -5,8 +5,8 @@
   "name": "ETC Eos",
   "is_system": true,
   "payload": {
-    "address": "/eos/set/patch/[markerid]/augment3d/position",
-    "args": ["[x]", "[z]", "[y]", "0", "0", "0"],
+    "address": "/eos/chan/[markerid]/xyz",
+    "args": ["[x]", "[y]", "[z]"],
     "trigger": {"kind": "stream", "rate_hz": 30}
   }
 }

--- a/openfollow/web/help/osc_bindings.md
+++ b/openfollow/web/help/osc_bindings.md
@@ -114,6 +114,8 @@ Read-only panels showing what the transmitter is doing right now.
 
 **Template** dropdown + **+ New transmitter** – choose a template and click the button to add a transmitter pre-filled with its address and arguments. Leave the dropdown on *empty* to start with a blank transmitter. Drag the ⋮⋮ handle on the left of a collapsed transmitter to reorder – order is cosmetic, transmitters evaluate independently.
 
+The two ETC templates target the same Augment3d object by different routes. **ETC Eos** moves a Scenic Element Movable in Live, so its position is a channel parameter the console can record into a cue. **ETC Eos (Patch)** writes the object's patch position instead, which never lands in cue data but is a patch edit. Both expect the marker ID to match the Eos channel number, and both send metres along Augment3d's own axes, so X and Y need no conversion. Height does: `[z]` is measured from the PSN origin, while Augment3d measures from its own origin. If your **Grid** section sets a non-zero *Z offset*, put the Augment3d origin at the same height, or the element floats by that difference.
+
 ## Saving & sharing
 
 - **Save** – write the transmitter's current settings to disk. Changes apply immediately but are lost on reload unless saved.

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -4063,6 +4063,11 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
                 select_value=f"file:{entry.filename}",
             )
             (system if entry.is_system else user).append(view)
+        # By display name, not the loader's filename order: a slug suffix
+        # sorts a variant above the entry it varies ("etc-eos-patch" before
+        # "etc-eos"), which reads as the wrong default in the picker.
+        user.sort(key=lambda v: v.name.casefold())
+        system.sort(key=lambda v: v.name.casefold())
         return user, system
 
     @app.get("/")

--- a/openfollow/web/templates/partials/osc_bindings.tpl
+++ b/openfollow/web/templates/partials/osc_bindings.tpl
@@ -267,7 +267,7 @@
  contenteditable="true"
  spellcheck="false"
  data-osc-message-editor="{{row.id}}"
- data-osc-message-placeholder="/eos/set/patch/[markerid]/augment3d/position [x] [z] [y] 0 0 0"
+ data-osc-message-placeholder="/eos/chan/[markerid]/xyz [x] [y] [z]"
  data-osc-unresolved-placeholders="{{json.dumps(list(row_unresolved))}}"
  data-osc-placeholder-names="{{json.dumps(list(placeholders))}}"
  data-osc-registered-marker-ids="{{json.dumps(list(_registered_marker_ids))}}"

--- a/tests/test_osc_template.py
+++ b/tests/test_osc_template.py
@@ -240,10 +240,39 @@ def test_render_consecutive_placeholders() -> None:
     assert render(ct, _ctx(pos=(1.0, 2.0, 3.0))) == "123"
 
 
-def test_render_uses_g_format_for_floats() -> None:
-    """`g` format trims trailing zeros so [x] doesn't read as 1.0000000000."""
+def test_render_trims_trailing_zeros() -> None:
+    """Trailing zeros are trimmed so [x] doesn't read as 1.0000000000."""
     ct = compile_template("[x]")
     assert render(ct, _ctx(pos=(1.0, 0.0, 0.0))) == "1"
+
+
+@pytest.mark.parametrize(
+    ("x", "expected"),
+    [
+        (0.0000032, "0.000003"),  # an EMA glide decaying toward zero
+        (-0.0000032, "-0.000003"),
+        (1e-12, "0"),  # below stage resolution – reads as zero, not 1e-12
+        (1.25e9, "1250000000"),
+        (-1234.5678, "-1234.5678"),
+        (0.0, "0"),
+    ],
+)
+def test_render_never_emits_exponent_notation(x: float, expected: str) -> None:
+    """A console parsing a rendered position rejects ``3.2e-06``; the
+    renderer must spell every magnitude out in full."""
+    rendered = render(compile_template("[x]"), _ctx(pos=(x, 0.0, 0.0)))
+    assert "e" not in rendered.lower()
+    assert rendered == expected
+
+
+@pytest.mark.parametrize(
+    ("x", "expected"),
+    [(float("inf"), "inf"), (float("-inf"), "-inf"), (float("nan"), "nan")],
+)
+def test_render_spells_out_non_finite_positions(x: float, expected: str) -> None:
+    """A non-finite position renders with no decimal point, so the
+    trailing-zero trim passes it through whole."""
+    assert render(compile_template("[x]"), _ctx(pos=(x, 0.0, 0.0))) == expected
 
 
 def test_absolute_placeholders_pass_through_when_outside_grid() -> None:
@@ -778,21 +807,40 @@ def test_render_default_slot_raises_when_marker_id_is_none(
 
 
 def test_builtin_etc_eos_wire_format() -> None:
-    """Args order X, Z, Y, 0, 0, 0 – the Z-up→Y-up swap is done by
-    placeholder choice, not code."""
+    """The marker id addresses the Eos channel; three float args carry
+    the position."""
     tpl = builtin_by_id("etc")
+    assert tpl is not None
+    addr_ct = compile_template(tpl.address)
+    arg_cts = [compile_template(a) for a in tpl.args]
+    rc = _ctx(pos=(1.0, 2.0, 3.0), marker_id=5)
+    assert render(addr_ct, rc) == "/eos/chan/5/xyz"
+    typed = [osc_arg_for(ct, rc) for ct in arg_cts]
+    assert typed == [
+        ("f", pytest.approx(1.0)),
+        ("f", pytest.approx(2.0)),
+        ("f", pytest.approx(3.0)),
+    ]
+
+
+def test_builtin_etc_eos_patch_wire_format() -> None:
+    """Position plus three rotation args, all floats – a bare ``0``
+    would type as ``i`` and Eos rejects the message."""
+    tpl = builtin_by_id("etc-patch")
     assert tpl is not None
     addr_ct = compile_template(tpl.address)
     arg_cts = [compile_template(a) for a in tpl.args]
     rc = _ctx(pos=(1.0, 2.0, 3.0), marker_id=5)
     assert render(addr_ct, rc) == "/eos/set/patch/5/augment3d/position"
     typed = [osc_arg_for(ct, rc) for ct in arg_cts]
-    assert typed[0] == ("f", pytest.approx(1.0))  # [x]
-    assert typed[1] == ("f", pytest.approx(3.0))  # [z]
-    assert typed[2] == ("f", pytest.approx(2.0))  # [y]
-    assert typed[3] == ("i", 0)
-    assert typed[4] == ("i", 0)
-    assert typed[5] == ("i", 0)
+    assert typed == [
+        ("f", pytest.approx(1.0)),
+        ("f", pytest.approx(2.0)),
+        ("f", pytest.approx(3.0)),
+        ("f", pytest.approx(0.0)),
+        ("f", pytest.approx(0.0)),
+        ("f", pytest.approx(0.0)),
+    ]
 
 
 def test_builtin_adm_osc_2d_uses_fractional_xy_zero_z() -> None:
@@ -857,14 +905,20 @@ def test_builtin_templates_have_unique_ids() -> None:
     assert len(ids) == len(set(ids))
 
 
-@pytest.mark.parametrize("template_id", ["etc", "adm-osc", "adm-osc-3d", "dnb-abs"])
+@pytest.mark.parametrize(
+    "template_id",
+    ["etc", "etc-patch", "adm-osc", "adm-osc-3d", "dnb-abs"],
+)
 def test_builtin_template_carries_stream_30hz_trigger_pre_fill(template_id: str) -> None:
     tpl = builtin_by_id(template_id)
     assert tpl is not None
     assert tpl.trigger == {"kind": "stream", "rate_hz": 30}
 
 
-@pytest.mark.parametrize("template_id", ["etc", "adm-osc", "dnb-abs"])
+@pytest.mark.parametrize(
+    "template_id",
+    ["etc", "etc-patch", "adm-osc", "adm-osc-3d", "dnb-abs"],
+)
 def test_builtin_template_trigger_is_immutable(template_id: str) -> None:
     """The trigger field is a read-only ``MappingProxyType`` – mutation
     raises ``TypeError``."""

--- a/tests/test_osc_template.py
+++ b/tests/test_osc_template.py
@@ -844,8 +844,10 @@ def test_builtin_etc_eos_patch_wire_format() -> None:
 
 
 def test_builtin_adm_osc_2d_uses_fractional_xy_zero_z() -> None:
-    """Args ``[x.frac]``, ``[y.frac]``, ``0``. The id stays ``adm-osc``
-    for compat with stored ``template_id``."""
+    """Args ``[x.frac]``, ``[y.frac]``, ``0.0``. ADM-OSC types the
+    triplet as three floats, so the flat-Z literal must not land as an
+    ``i``. The id stays ``adm-osc`` for compat with stored
+    ``template_id``."""
     tpl = builtin_by_id("adm-osc")
     assert tpl is not None
     assert tpl.name == "ADM-OSC 2D"
@@ -856,7 +858,7 @@ def test_builtin_adm_osc_2d_uses_fractional_xy_zero_z() -> None:
     typed = [osc_arg_for(ct, rc) for ct in arg_cts]
     assert typed[0] == ("f", pytest.approx(0.5))  # 2.5 / 5
     assert typed[1] == ("f", pytest.approx(-0.5))  # -1.5 / 3
-    assert typed[2] == ("i", 0)  # literal zero, irrespective of pos.z
+    assert typed[2] == ("f", pytest.approx(0.0))  # flat, irrespective of pos.z
 
 
 def test_builtin_adm_osc_3d_uses_fractional_xyz() -> None:

--- a/tests/test_templates_unit.py
+++ b/tests/test_templates_unit.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from openfollow.osc.template import BUILTIN_TEMPLATES
 from openfollow.templates import (
     TEMPLATE_FILE_SUFFIX,
     TEMPLATE_LEGACY_SUFFIX,
@@ -922,6 +923,8 @@ class TestSlugify:
         [
             ("My Cue", "my-cue"),
             ("ETC Eos", "etc-eos"),
+            # Pins the bundled patch template's filename to the slug rule.
+            ("ETC Eos (Patch)", "etc-eos-patch"),
             ("d&b absolute", "d-b-absolute"),
             ("Indoor / Outdoor!", "indoor-outdoor"),
             ("café", "cafe"),  # NFKD strips accents
@@ -1107,25 +1110,42 @@ class TestDeleteUserTemplate:
 class TestBootstrap:
     def test_seeds_bundled_templates(self, tmp_path: Path) -> None:
         n = seed_system_templates(tmp_path)
-        assert n == 4
+        assert n == 5
         sysdir = tmp_path / "system"
         files = sorted(p.name for p in sysdir.glob(f"*{TEMPLATE_FILE_SUFFIX}"))
         assert files == [
             "osc_output.adm-osc-3d.oftemplate",
             "osc_output.adm-osc.oftemplate",
             "osc_output.dnb-absolute.oftemplate",
+            "osc_output.etc-eos-patch.oftemplate",
             "osc_output.etc-eos.oftemplate",
         ]
 
     def test_seeded_files_load_cleanly(self, tmp_path: Path) -> None:
         seed_system_templates(tmp_path)
         loaded = list_templates(tmp_path)
-        assert len(loaded) == 4
+        assert len(loaded) == 5
         for entry in loaded:
             assert entry.error == "", entry.error
             assert entry.is_system is True
             assert entry.template is not None
             assert entry.template.type == "osc_output"
+
+    def test_seeded_payloads_match_the_in_code_builtins(self, tmp_path: Path) -> None:
+        """The bundled files and ``BUILTIN_TEMPLATES`` carry the same
+        addresses and args; keyed by display name, which both spell."""
+        seed_system_templates(tmp_path)
+        on_disk = {
+            entry.template.name: entry.template.payload
+            for entry in list_templates(tmp_path)
+            if entry.template is not None
+        }
+        assert sorted(on_disk) == sorted(t.name for t in BUILTIN_TEMPLATES)
+        for builtin in BUILTIN_TEMPLATES:
+            payload = on_disk[builtin.name]
+            assert payload["address"] == builtin.address
+            assert payload["args"] == list(builtin.args)
+            assert payload["trigger"] == dict(builtin.trigger)
 
     def test_idempotent_overwrite(self, tmp_path: Path) -> None:
         # A re-seed restores a mutated file.

--- a/tests/test_web_osc_bindings.py
+++ b/tests/test_web_osc_bindings.py
@@ -1513,14 +1513,45 @@ def test_add_with_builtin_template_populates_address_and_args(live_server) -> No
     cfg = load_config(cfg_path)
     row = cfg.osc_transmitters.transmitters[0]
     assert row.name == "ETC Eos"
-    assert row.address.startswith("/eos/")
-    assert row.args  # non-empty
+    assert row.address == "/eos/chan/[markerid]/xyz"
+    assert row.args == ["[x]", "[y]", "[z]"]
+
+
+def test_add_with_patch_template_keeps_rotations_float_typed(live_server) -> None:
+    """The rotation literals must survive the apply + ``__post_init__``
+    round-trip as ``"0.0"``; normalised to ``"0"`` they would go on the
+    wire as OSC ``i`` and Eos rejects the message."""
+    _, base, cfg_path = live_server
+    _post_form(
+        base,
+        "/section/osc_bindings/add",
+        {"template_id": "file:osc_output.etc-eos-patch.oftemplate"},
+    )
+    row = load_config(cfg_path).osc_transmitters.transmitters[0]
+    assert row.address == "/eos/set/patch/[markerid]/augment3d/position"
+    assert row.args == ["[x]", "[y]", "[z]", "0.0", "0.0", "0.0"]
+
+
+def test_template_dropdown_lists_defaults_by_display_name(live_server) -> None:
+    """Filename order puts a slug-suffixed variant above the entry it
+    varies; the picker must read in display-name order instead."""
+    _, base, _ = live_server
+    _, body = _get(base, "/section/osc_bindings")
+    listed = re.findall(r'<option value="file:[^"]+">([^<]+)</option>', body)
+    assert listed == [
+        "ADM-OSC 2D",
+        "ADM-OSC 3D",
+        "d&amp;b absolute",
+        "ETC Eos",
+        "ETC Eos (Patch)",
+    ]
 
 
 @pytest.mark.parametrize(
     "template_filename,template_name",
     [
         ("osc_output.etc-eos.oftemplate", "ETC Eos"),
+        ("osc_output.etc-eos-patch.oftemplate", "ETC Eos (Patch)"),
         # Filename stays ``adm-osc`` while the display name carries the
         # 2D/3D suffix, so existing rows whose template_id references this
         # file keep resolving.

--- a/tests/test_web_templates.py
+++ b/tests/test_web_templates.py
@@ -520,7 +520,7 @@ class TestApplyOscOutput:
         assert len(rows) == 1
         assert rows[0].name == "ADM-OSC 2D"
         assert rows[0].address == "/adm/obj/[markerid]/xyz"
-        assert rows[0].args == ["[x.frac]", "[y.frac]", "0"]
+        assert rows[0].args == ["[x.frac]", "[y.frac]", "0.0"]
         assert rows[0].id == payload["row_id"]
 
     def test_apply_restores_extended_fields(self, live_server) -> None:

--- a/tests/test_web_templates.py
+++ b/tests/test_web_templates.py
@@ -191,6 +191,7 @@ class TestBootstrap:
             "osc_output.adm-osc-3d.oftemplate",
             "osc_output.adm-osc.oftemplate",
             "osc_output.dnb-absolute.oftemplate",
+            "osc_output.etc-eos-patch.oftemplate",
             "osc_output.etc-eos.oftemplate",
         ]
 
@@ -207,7 +208,13 @@ class TestList:
         assert status == 200
         payload = json.loads(body)
         names = sorted(t["name"] for t in payload["templates"])
-        assert names == ["ADM-OSC 2D", "ADM-OSC 3D", "ETC Eos", "d&b absolute"]
+        assert names == [
+            "ADM-OSC 2D",
+            "ADM-OSC 3D",
+            "ETC Eos",
+            "ETC Eos (Patch)",
+            "d&b absolute",
+        ]
         for entry in payload["templates"]:
             assert entry["is_system"] is True
             assert entry["type"] == "osc_output"
@@ -225,7 +232,7 @@ class TestList:
         assert status == 200
         names = sorted(t["name"] for t in json.loads(body)["templates"])
         assert "Mine" in names
-        assert len(names) == 5
+        assert len(names) == 6
 
     def test_filters_by_type(self, live_server) -> None:
         _, base, cfg_path = live_server


### PR DESCRIPTION
## What was wrong

### ETC Eos

The bundled **ETC Eos** OSC output template sent the wrong thing on two counts.

**1. The axis order was swapped.** The args were `["[x]", "[z]", "[y]", ...]`, described in a comment as a "Z-up → Y-up swap". [ETC's Augment3d documentation](https://www.etcconnect.com/WebDocs/Controls/EosFamilyOnlineHelp/en/Content/20_Augment3d/01_Augment3d_Edit_Mode/XYZ_Origin.htm) states the frame is **X left/right, Y front/back, Z height**, in metres by default. That is the PSN frame OpenFollow already uses, so the mapping is 1:1 and the swap was putting a performer's height into the depth slot.

**2. It used the patch path, not the one ETC confirms.** The verified syntax is `/eos/chan/99/xyz=0,5,0`. ETC's `=` is *notation*, not a wire character. From their OSC docs:

> Eos uses the equals (=) character to separate address patterns from any included arguments. Third-party OSC devices may require a different character, and may not be able to interpret incoming messages that use equals.

On the wire that is address `/eos/chan/99/xyz` carrying three OSC arguments, which matches the working form operators report as `/eos/chan/801/xyz 10.0 10.0 0.0`.

### ADM-OSC 2D

The [ADM-OSC specification](https://immersive-audio-live.github.io/ADM-OSC/) types `/adm/obj/<n>/xyz` as **three float32 arguments**, all axes normalised −1.0…1.0. The 2D template carried its flat-Z placeholder as the literal `"0"`, which `classify_osc_literal` types as OSC `i`, so every packet went out as `,ffi`. A receiver that validates the type tag string, or unpacks three floats positionally, drops or mis-parses it. (The x/y ranges were already correct — `.frac` normalises by grid extent to −1…1.)

## What ships

Both Eos routes are real and serve different needs, so both are bundled:

| Template | Address | Args |
|---|---|---|
| **ETC Eos** (default) | `/eos/chan/[markerid]/xyz` | `[x] [y] [z]` |
| **ETC Eos (Patch)** | `/eos/set/patch/[markerid]/augment3d/position` | `[x] [y] [z] 0.0 0.0 0.0` |

`/eos/chan/N/xyz` drives a Scenic Element Movable in **Live**, where the position is a channel parameter a record can capture. `/eos/set/patch/...` never touches cue data but is a patch edit.

Every bundled template is now type-consistent:

```
osc_output.adm-osc.oftemplate         /adm/obj/5/xyz                        ,fff
osc_output.adm-osc-3d.oftemplate      /adm/obj/5/xyz                        ,fff
osc_output.dnb-absolute.oftemplate    /dbaudio1/.../source_position_xyz/1/5 ,fff
osc_output.etc-eos.oftemplate         /eos/chan/5/xyz                       ,fff
osc_output.etc-eos-patch.oftemplate   /eos/set/patch/5/augment3d/position   ,ffffff
```

## Carried along

- **Float rendering.** Template floats now render fixed-point instead of `%g`, so a coordinate decaying toward zero through an EMA glide cannot reach the wire as `1e-06`.
- **Picker ordering.** The template dropdown now sorts by display name. The loader sorts by filename, where a slug suffix sorts a variant *above* the entry it varies (`etc-eos-patch` < `etc-eos`), so "ETC Eos (Patch)" would have read as the default. This also un-inverts "ADM-OSC 2D" / "ADM-OSC 3D".
- **Drift guard.** `BUILTIN_TEMPLATES` duplicates the bundled payloads; a new test pins the two against each other so a future edit can't land in only one.

## Verification

Wire bytes decoded from the bundled files, e.g. `/eos/chan/5/xyz` `,fff` `[1.5, 4.25, 2.75]` — height in the third slot — and the patch form `,ffffff` with float rotations.

Every new regression test was mutation-checked (swap the axes back in the file and in the code, restore `%g`, retype the rotations as ints, revert the ADM-OSC literal, drop the name sort) — each mutation turns its test red, so none of them pass regardless of the code.

`make ci-remote` green: 100% coverage, build OK. **It fell back to running locally on the Mac; neither testing Pi was reachable**, so the aarch64 run is still owed.

## Still outstanding

**Hardware verification against a physical Eos console.** The axis convention is documented, not observed. No test can catch a wrong convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)