### PR TITLE
feat(network): create and address tagged VLAN interfaces

### DIFF
--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -177,6 +177,23 @@ Network page silently falls back to a read-only view. This also matches the Ansi
 deploy path, which already assumes NetworkManager. The `.deb`'s
 `NetworkManager-wait-online` timeout drop-in bounds a cable-less boot to ~15 s.
 
+NetworkManager also owns tagged-VLAN sub-interfaces, which the Network page creates
+and removes via two sudoers grants beside the existing `nmcli con mod` / `up` / `down`
+rules:
+
+```
+/usr/bin/nmcli con add *
+/usr/bin/nmcli con delete *
+```
+
+Both are wildcarded because the profile name is operator-influenced. The narrowing is
+in the app layer rather than the sudoers rule: it refuses to delete a profile that is
+not a VLAN, and refuses to delete the interface serving the current request. That
+placement yields an actionable error rather than a bare sudo failure, and the threat
+model here is a web user holding the PIN, not someone with shell access. The runtime
+drop-in renders both from `ALL_CAPABILITIES`; only the Ansible playbook mirrors them
+by hand.
+
 **No-DHCP fallback.** All three install routes – the image layer, the Ansible
 playbook and the `.deb` – write
 `/etc/NetworkManager/conf.d/10-openfollow-dhcp-fallback.conf`:

--- a/openfollow/network/adapter.py
+++ b/openfollow/network/adapter.py
@@ -24,14 +24,14 @@ class NetworkInterface:
     is_up: bool
 
 
-_LOOPBACK_NAMES = frozenset({"lo", "lo0"})
+LOOPBACK_NAMES = frozenset({"lo", "lo0"})
 
 
 def is_loopback(iface: NetworkInterface) -> bool:
     """Return True if interface is loopback (matches kind or well-known names)."""
     if (iface.kind or "").lower() == "loopback":
         return True
-    return iface.name in _LOOPBACK_NAMES
+    return iface.name in LOOPBACK_NAMES
 
 
 @dataclass(frozen=True)
@@ -84,6 +84,13 @@ class NetworkState:
 
 
 @dataclass(frozen=True)
+class VlanInterface:
+    name: str
+    parent: str
+    vlan_id: int
+
+
+@dataclass(frozen=True)
 class ApplyResult:
     ok: bool
     message: str = ""
@@ -97,6 +104,9 @@ class ApplyResult:
     serving anything yet, so redirecting a browser at it lands on nothing.
     Every backend that can persist settings without activating them has to set
     this - the web layer keys the redirect and the banner on it."""
+
+
+VLAN_UNSUPPORTED_MESSAGE = "This network backend cannot create VLAN interfaces."
 
 
 class NetworkAdapter(ABC):
@@ -123,6 +133,29 @@ class NetworkAdapter(ABC):
     def is_writable(self) -> bool:
         """Return True if this adapter can mutate host state."""
         return True
+
+    # ---- VLAN sub-interfaces --------------------------------------------
+    #
+    # Creating the link is the whole of the new work: once ``eth0.10`` exists
+    # it is an ordinary netdev, so listing, addressing and pinning it all run
+    # through the paths above unchanged. Backends that do not own links report
+    # unsupported here and the UI omits the controls entirely.
+
+    def supports_vlans(self) -> bool:
+        """Return True if this backend can create and remove VLAN links."""
+        return False
+
+    def list_vlans(self) -> list[VlanInterface]:
+        """Return the VLAN sub-interfaces this backend knows about."""
+        return []
+
+    def create_vlan(self, parent: str, vlan_id: int) -> ApplyResult:
+        """Create a ``<parent>.<vlan_id>`` VLAN link."""
+        return ApplyResult(ok=False, message=VLAN_UNSUPPORTED_MESSAGE)
+
+    def delete_vlan(self, name: str) -> ApplyResult:
+        """Remove the VLAN link named ``name``."""
+        return ApplyResult(ok=False, message=VLAN_UNSUPPORTED_MESSAGE)
 
     def get_ipv6_state(self, iface: str) -> None:
         """Stub for future IPv6 support."""

--- a/openfollow/network/nm_adapter.py
+++ b/openfollow/network/nm_adapter.py
@@ -40,6 +40,35 @@ _NMCLI_TIMEOUT = 8
 _NO_BROKER_MESSAGE = "Cannot change network settings - the privileged helper is not configured."
 
 
+def _split_terse(line: str) -> list[str]:
+    """Split one nmcli ``-t`` row on its *unescaped* field separators.
+
+    ``nmcli -t`` emits a literal ``:`` inside a value as ``\\:``, so splitting
+    on every colon shifts each field after a colon-bearing one: a profile named
+    ``Wired connection: office`` yields a fragment where the UUID belongs, and
+    the device column lands on the type. Unescapes as it goes, so callers get
+    finished values.
+    """
+    fields: list[str] = []
+    current: list[str] = []
+    i = 0
+    n = len(line)
+    while i < n:
+        char = line[i]
+        if char == "\\" and i + 1 < n:
+            current.append(line[i + 1])
+            i += 2
+        elif char == ":":
+            fields.append("".join(current))
+            current = []
+            i += 1
+        else:
+            current.append(char)
+            i += 1
+    fields.append("".join(current))
+    return fields
+
+
 def _unescape_terse(value: str) -> str:
     """Reverse nmcli ``-t`` (terse) escaping in a field value: a literal
     ``:`` is emitted as ``\\:`` and a literal ``\\`` as ``\\\\``. Without
@@ -527,7 +556,7 @@ class NetworkManagerAdapter(NetworkAdapter):
         out: list[tuple[str, str]] = []
         device_by_uuid: dict[str, str] = {}
         for line in res.stdout.splitlines():
-            parts = [_unescape_terse(p) for p in line.split(":")]
+            parts = _split_terse(line)
             if len(parts) < 4:
                 continue
             name, uuid, kind, device = parts[0], parts[1], parts[2], parts[3]

--- a/openfollow/network/nm_adapter.py
+++ b/openfollow/network/nm_adapter.py
@@ -17,10 +17,13 @@ from openfollow.network.adapter import (
     NetworkAdapter,
     NetworkInterface,
     NetworkState,
+    VlanInterface,
 )
-from openfollow.network.validate import validate_apply
+from openfollow.network.validate import validate_apply, vlan_interface_name
 from openfollow.privilege.broker import PrivilegeBroker, PrivilegeError
 from openfollow.privilege.capabilities import (
+    NETWORK_NM_CON_ADD,
+    NETWORK_NM_CON_DELETE,
     NETWORK_NM_CON_DOWN,
     NETWORK_NM_CON_MOD,
     NETWORK_NM_CON_UP,
@@ -505,3 +508,103 @@ class NetworkManagerAdapter(NetworkAdapter):
                 message=f"Could not renew {iface} ({up_detail})." if up_detail else f"Could not renew {iface}.",
             )
         return ApplyResult(ok=True, message="Lease renewed.")
+
+    # ---- VLAN sub-interfaces --------------------------------------------
+
+    def supports_vlans(self) -> bool:
+        return True
+
+    def _vlan_profiles(self) -> tuple[list[tuple[str, str]], dict[str, str]]:
+        """Return ``([(profile name, device)], {uuid: device})`` for the
+        connection list, filtered to VLAN profiles. The UUID map covers every
+        profile, not just VLANs, because it exists to resolve a VLAN's parent
+        reference back to an interface name."""
+        try:
+            res = self._run(["nmcli", "-t", "-f", "NAME,UUID,TYPE,DEVICE", "connection", "show"])
+        except (RuntimeError, FileNotFoundError, subprocess.SubprocessError) as exc:
+            logger.warning("nmcli VLAN profile list failed: %s", exc)
+            return ([], {})
+        out: list[tuple[str, str]] = []
+        device_by_uuid: dict[str, str] = {}
+        for line in res.stdout.splitlines():
+            parts = [_unescape_terse(p) for p in line.split(":")]
+            if len(parts) < 4:
+                continue
+            name, uuid, kind, device = parts[0], parts[1], parts[2], parts[3]
+            device_by_uuid[uuid] = device
+            if kind == "vlan":
+                out.append((name, device))
+        return (out, device_by_uuid)
+
+    def list_vlans(self) -> list[VlanInterface]:
+        profiles, device_by_uuid = self._vlan_profiles()
+        vlans: list[VlanInterface] = []
+        for name, device in profiles:
+            try:
+                res = self._run(["nmcli", "-t", "-f", "vlan.parent,vlan.id", "connection", "show", "id", name])
+            except (RuntimeError, FileNotFoundError, subprocess.SubprocessError):
+                continue
+            parsed = self._parse_show(res.stdout)
+            raw_parent = (parsed.get("vlan.parent") or [""])[0]
+            raw_id = (parsed.get("vlan.id") or [""])[0]
+            try:
+                vlan_id = int(raw_id)
+            except ValueError:
+                continue
+            # ``vlan.parent`` holds either the parent interface name or the
+            # UUID of the parent's own profile, depending on how the VLAN was
+            # created. Resolve the UUID form back to a device so the caller
+            # always gets a name.
+            parent = device_by_uuid.get(raw_parent, raw_parent)
+            if not parent or not device:
+                continue
+            vlans.append(VlanInterface(name=device, parent=parent, vlan_id=vlan_id))
+        return vlans
+
+    def create_vlan(self, parent: str, vlan_id: int) -> ApplyResult:
+        name = vlan_interface_name(parent, vlan_id)
+        ok, detail = self._run_privileged(
+            NETWORK_NM_CON_ADD,
+            [
+                "/usr/bin/nmcli",
+                "con",
+                "add",
+                "type",
+                "vlan",
+                "con-name",
+                name,
+                "ifname",
+                name,
+                "dev",
+                parent,
+                "id",
+                str(vlan_id),
+            ],
+            reason=f"Create VLAN {vlan_id} on {parent}",
+        )
+        if not ok:
+            return ApplyResult(ok=False, message=detail or f"Could not create VLAN {vlan_id} on {parent}.")
+        return ApplyResult(ok=True, message=f"Created {name}. Give it an address with Configure.")
+
+    def delete_vlan(self, name: str) -> ApplyResult:
+        profile = self._vlan_profile_name(name)
+        if profile is None:
+            return ApplyResult(ok=False, message=f"{name} is not a VLAN interface.")
+        ok, detail = self._run_privileged(
+            NETWORK_NM_CON_DELETE,
+            ["/usr/bin/nmcli", "con", "delete", "id", profile],
+            reason=f"Delete VLAN profile {profile}",
+        )
+        if not ok:
+            return ApplyResult(ok=False, message=detail or f"Could not delete {name}.")
+        return ApplyResult(ok=True, message=f"Deleted {name}.")
+
+    def _vlan_profile_name(self, iface: str) -> str | None:
+        """Return the VLAN profile bound to ``iface``, or None when ``iface``
+        is not a VLAN. This is the check that keeps ``con delete`` – a
+        wildcarded grant – off an operator's physical-NIC profile."""
+        profiles, _ = self._vlan_profiles()
+        for name, device in profiles:
+            if device == iface:
+                return name
+        return None

--- a/openfollow/network/nm_adapter.py
+++ b/openfollow/network/nm_adapter.py
@@ -69,6 +69,20 @@ def _split_terse(line: str) -> list[str]:
     return fields
 
 
+def _name_and_device(line: str) -> tuple[str, str]:
+    """Split one ``NAME,DEVICE`` row, tolerating a colon in the profile name.
+
+    ``partition(":")`` cuts at the escaped colon inside the name, so the device
+    column lands in the remainder and never matches - which makes a profile
+    called ``Wired connection: office`` invisible to every lookup, and reports
+    "no profile bound to eth0" for an interface that has one.
+    """
+    fields = _split_terse(line)
+    if len(fields) < 2:
+        return ("", "")
+    return (fields[0], fields[1])
+
+
 def _unescape_terse(value: str) -> str:
     """Reverse nmcli ``-t`` (terse) escaping in a field value: a literal
     ``:`` is emitted as ``\\:`` and a literal ``\\`` as ``\\\\``. Without
@@ -165,7 +179,7 @@ class NetworkManagerAdapter(NetworkAdapter):
         except (RuntimeError, FileNotFoundError, subprocess.SubprocessError):
             return None
         for line in res.stdout.splitlines():
-            name, _, dev = line.partition(":")
+            name, dev = _name_and_device(line)
             if dev == iface:
                 return name
         # Fallback to any profile bound to this device
@@ -174,7 +188,7 @@ class NetworkManagerAdapter(NetworkAdapter):
         except (RuntimeError, FileNotFoundError, subprocess.SubprocessError):
             return None
         for line in res.stdout.splitlines():
-            name, _, dev = line.partition(":")
+            name, dev = _name_and_device(line)
             if dev == iface:
                 return name
         return None

--- a/openfollow/network/validate.py
+++ b/openfollow/network/validate.py
@@ -16,6 +16,7 @@ _MAX_DNS = 3
 _VLAN_ID_MIN = 1
 _VLAN_ID_MAX = 4094
 _IFNAMSIZ = 15
+VLAN_ID_RANGE_MESSAGE = f"VLAN ID must be a whole number between {_VLAN_ID_MIN} and {_VLAN_ID_MAX}."
 
 
 def parse_ipv4(value: str | None) -> str | None:
@@ -167,7 +168,7 @@ def validate_vlan_create(
 
     parsed = parse_vlan_id(vlan_id)
     if parsed is None:
-        errors.append(f"VLAN ID must be a whole number between {_VLAN_ID_MIN} and {_VLAN_ID_MAX}.")
+        errors.append(VLAN_ID_RANGE_MESSAGE)
     elif name:
         derived = vlan_interface_name(name, parsed)
         if len(derived) > _IFNAMSIZ:

--- a/openfollow/network/validate.py
+++ b/openfollow/network/validate.py
@@ -7,10 +7,15 @@ from __future__ import annotations
 import ipaddress
 import re
 
-from openfollow.network.adapter import Ipv4Method
+from openfollow.network.adapter import LOOPBACK_NAMES, Ipv4Method
 
 _DNS_SEP_RE = re.compile(r"[\s,;]+")
 _MAX_DNS = 3
+# 0 and 4095 are reserved by 802.1Q; IFNAMSIZ caps a Linux interface name at
+# 15 usable characters, which the derived ``<parent>.<id>`` has to fit inside.
+_VLAN_ID_MIN = 1
+_VLAN_ID_MAX = 4094
+_IFNAMSIZ = 15
 
 
 def parse_ipv4(value: str | None) -> str | None:
@@ -105,6 +110,71 @@ def parse_dns_list(value: str | None) -> list[str]:
         if len(out) >= _MAX_DNS:
             break
     return out
+
+
+def parse_vlan_id(value: str | int | None) -> int | None:
+    """Return the 802.1Q VLAN ID, or ``None`` when it is not one.
+
+    ``bool`` is an ``int`` subclass and ``int(12.5)`` truncates, so both are
+    rejected outright rather than coerced – a VLAN ID that quietly became a
+    different VLAN ID would put stage traffic on the wrong tag. Digit strings
+    are screened the same way ``parse_prefix`` screens a prefix, because
+    ``str.isdigit`` is True for Unicode digits that ``int()`` handles
+    differently.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        vlan_id = value
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text.isascii() or not text.isdigit():
+            return None
+        vlan_id = int(text)
+    else:
+        return None
+    return vlan_id if _VLAN_ID_MIN <= vlan_id <= _VLAN_ID_MAX else None
+
+
+def vlan_interface_name(parent: str, vlan_id: int) -> str:
+    """Return the interface name a VLAN on ``parent`` gets."""
+    return f"{parent.strip()}.{vlan_id}"
+
+
+def validate_vlan_create(
+    parent: str,
+    vlan_id: str | int | None,
+    *,
+    interfaces: list[str] | tuple[str, ...],
+    vlan_names: list[str] | tuple[str, ...] = (),
+) -> list[str]:
+    """Return human-readable errors for a VLAN create request; empty when valid.
+
+    ``interfaces`` is every device the backend reports and ``vlan_names`` the
+    subset that are themselves VLANs – the parent has to be in the first and
+    out of the second, because a VLAN on a VLAN is QinQ and is out of scope.
+    """
+    errors: list[str] = []
+    name = (parent or "").strip()
+    if not name:
+        errors.append("Choose a parent interface.")
+    elif name not in interfaces:
+        errors.append(f"{name} is not a network interface on this station.")
+    elif name in vlan_names:
+        errors.append(f"{name} is already a VLAN. A VLAN cannot be stacked on another VLAN.")
+    elif name in LOOPBACK_NAMES:
+        errors.append("The loopback interface cannot carry a VLAN.")
+
+    parsed = parse_vlan_id(vlan_id)
+    if parsed is None:
+        errors.append(f"VLAN ID must be a whole number between {_VLAN_ID_MIN} and {_VLAN_ID_MAX}.")
+    elif name:
+        derived = vlan_interface_name(name, parsed)
+        if len(derived) > _IFNAMSIZ:
+            errors.append(f"The interface name {derived} is longer than the {_IFNAMSIZ} characters Linux allows.")
+        elif derived in interfaces:
+            errors.append(f"{derived} already exists.")
+    return errors
 
 
 def validate_apply(

--- a/openfollow/privilege/capabilities.py
+++ b/openfollow/privilege/capabilities.py
@@ -144,6 +144,24 @@ NETWORK_NM_CON_DOWN = Capability(
     sudoers_pattern="/usr/bin/nmcli con down *",
 )
 
+# VLAN sub-interfaces are created and removed as NetworkManager profiles. The
+# grants are wildcarded like ``con mod`` because the profile name is
+# operator-influenced; the app layer refuses to delete anything that is not a
+# VLAN, or the interface the request arrived on, before either is invoked.
+NETWORK_NM_CON_ADD = Capability(
+    name="network.nm.con_add",
+    probe_argv=("/usr/bin/nmcli", "con", "add", _PROBE_PLACEHOLDER),
+    description="Create a NetworkManager connection profile (VLAN)",
+    sudoers_pattern="/usr/bin/nmcli con add *",
+)
+
+NETWORK_NM_CON_DELETE = Capability(
+    name="network.nm.con_delete",
+    probe_argv=("/usr/bin/nmcli", "con", "delete", _PROBE_PLACEHOLDER),
+    description="Delete a NetworkManager connection profile (VLAN)",
+    sudoers_pattern="/usr/bin/nmcli con delete *",
+)
+
 # /etc/dhcpcd.conf is rewritten atomically in two privileged steps: stage the
 # full file to the sibling ``.tmp`` (``tee`` truncates in place, so a killed /
 # timed-out / OOM'd write can only corrupt the tmp – never the live conf), then
@@ -538,6 +556,8 @@ ALL_CAPABILITIES: tuple[Capability, ...] = (
     NETWORK_NM_CON_MOD,
     NETWORK_NM_CON_UP,
     NETWORK_NM_CON_DOWN,
+    NETWORK_NM_CON_ADD,
+    NETWORK_NM_CON_DELETE,
     NETWORK_DHCPCD_CONF_WRITE_TMP,
     NETWORK_DHCPCD_CONF_COMMIT,
     NETWORK_DHCPCD_RELOAD,

--- a/openfollow/services.py
+++ b/openfollow/services.py
@@ -2150,6 +2150,9 @@ class AppRuntimeServices:
             network_interfaces_provider=self._network_interfaces_provider,
             network_apply_handler=self._handle_network_apply,
             network_renew_handler=self._handle_network_renew,
+            network_vlan_provider=self._network_vlan_provider,
+            network_vlan_create_handler=self._handle_network_vlan_create,
+            network_vlan_delete_handler=self._handle_network_vlan_delete,
             # Privilege capability snapshot for the diagnostics bundle.
             privilege_states_provider=self._privilege_states_provider,
             marker_catalog_provider=lambda: self._app._marker_catalog,
@@ -2475,6 +2478,47 @@ class AppRuntimeServices:
             return ApplyResult(ok=False, message="Read-only host – cannot renew.")
         with self._network_op_lock:
             return cast(ApplyResult, adapter.renew_lease(iface))
+
+    def _network_vlan_provider(self) -> dict[str, Any]:
+        """Whether this backend owns VLAN links, and the ones that exist."""
+        adapter = getattr(self, "_network_adapter", None)
+        if adapter is None or not adapter.supports_vlans():
+            return {"supported": False, "vlans": []}
+        try:
+            vlans = adapter.list_vlans()
+        except Exception:  # noqa: BLE001
+            logger.exception("VLAN list read failed")
+            return {"supported": True, "vlans": []}
+        return {
+            "supported": True,
+            "vlans": [{"name": v.name, "parent": v.parent, "vlan_id": v.vlan_id} for v in vlans],
+        }
+
+    def _handle_network_vlan_create(self, parent: str, vlan_id: int) -> ApplyResult:
+        """Create a VLAN sub-interface, serialised with the other network
+        writes (see :meth:`_handle_network_apply`)."""
+        from openfollow.network.adapter import ApplyResult
+
+        adapter = getattr(self, "_network_adapter", None)
+        if adapter is None:
+            return ApplyResult(ok=False, message="No network adapter available.")
+        if not adapter.is_writable():
+            return ApplyResult(ok=False, message="Read-only host – cannot create a VLAN.")
+        with self._network_op_lock:
+            return cast(ApplyResult, adapter.create_vlan(parent, vlan_id))
+
+    def _handle_network_vlan_delete(self, name: str) -> ApplyResult:
+        """Delete a VLAN sub-interface, serialised with the other network
+        writes (see :meth:`_handle_network_apply`)."""
+        from openfollow.network.adapter import ApplyResult
+
+        adapter = getattr(self, "_network_adapter", None)
+        if adapter is None:
+            return ApplyResult(ok=False, message="No network adapter available.")
+        if not adapter.is_writable():
+            return ApplyResult(ok=False, message="Read-only host – cannot delete a VLAN.")
+        with self._network_op_lock:
+            return cast(ApplyResult, adapter.delete_vlan(name))
 
     def _privilege_states_provider(self) -> dict[str, str]:
         """Snapshot every capability's state for the web UI.

--- a/openfollow/web/help/general-network-interface.md
+++ b/openfollow/web/help/general-network-interface.md
@@ -39,6 +39,22 @@ Your computer needs an address on the same network to reach a `169.254` one. Mos
 
 A station with a `Static` address never uses the fallback – it already has the address you gave it.
 
+## Tagged VLANs
+
+Many venues deliver one Ethernet run carrying several tagged 802.1Q VLANs rather than a separate cable per network. **+ Add VLAN** creates a sub-interface on top of a physical adapter for one tag, so a single cable can carry lighting, video, and management traffic on separate networks.
+
+A VLAN sub-interface behaves like any other adapter once it exists: it appears in the list as `eth0.10`, takes its own address, and every row in **Interface Assignment** can point at it. That is how PSN reaches the lighting VLAN while OTP goes out on another, over one cable.
+
+- **Parent interface** – the physical adapter carrying the tags. The switch port it plugs into must be configured as a trunk (tagged) port for that VLAN, or no traffic arrives. A VLAN cannot be stacked on another VLAN.
+- **VLAN ID** – `1`–`4094`, matching the tag the switch sends. `0` and `4095` are reserved by the standard.
+- The name is derived as `<parent>.<id>` and cannot be chosen.
+
+The parent keeps its own untagged address; adding VLANs does not take it away. Each new sub-interface starts with no address – use **Configure** on its row to give it one. A tagged lighting VLAN frequently has no DHCP server, in which case the fallback above applies to it too.
+
+**Delete VLAN** appears inside a VLAN row's own settings, so it can only ever remove the adapter named at the top of that form. It is refused for the adapter your browser arrived on – reconnect over another network first. Anything pinned to a deleted VLAN stops sending until it is reassigned.
+
+VLAN creation needs NetworkManager. On a station using another network backend the controls are not shown.
+
 **Modes:** the form opens in **View mode** – fields are locked so settings can't change by mistake. Use **Switch to edit view** to unlock them; **Edit mode** then shows Apply / Renew / Cancel. On a station whose network backend is read-only, the form shows a **Read only** badge instead – configure from the on-screen **Settings → Network** menu, or see openfollow.app for troubleshooting and how to enable web editing.
 
 **Buttons:**
@@ -46,4 +62,6 @@ A station with a `Static` address never uses the fallback – it already has the
 - **Switch to edit view** – unlocks the fields (enters Edit mode). Absent when the backend is read-only.
 - **Apply** – validates and commits the form. Invalid input is rejected and nothing is written.
 - **Renew DHCP lease** – requests a fresh lease (DHCP methods only).
+- **+ Add VLAN** – creates a tagged sub-interface (Edit mode, NetworkManager only).
+- **Delete VLAN** – removes the sub-interface whose settings are open.
 - **Cancel** – discards unsaved edits and returns to View mode.

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -68,8 +68,20 @@ from openfollow.configuration import (
 # namespace at call time (tests monkeypatch it for persist-failure paths).
 from openfollow.marker_catalog import save_catalog
 from openfollow.net_utils import get_local_ipv4_addresses
-from openfollow.network.adapter import Ipv4Config, Ipv4Method
-from openfollow.network.validate import parse_prefix, validate_apply
+from openfollow.network.adapter import (
+    LOOPBACK_NAMES,
+    VLAN_UNSUPPORTED_MESSAGE,
+    Ipv4Config,
+    Ipv4Method,
+)
+from openfollow.network.validate import (
+    VLAN_ID_RANGE_MESSAGE,
+    parse_prefix,
+    parse_vlan_id,
+    validate_apply,
+    validate_vlan_create,
+    vlan_interface_name,
+)
 from openfollow.templates import (
     TEMPLATE_FILE_SUFFIX,
     TEMPLATE_LEGACY_SUFFIX,
@@ -4409,9 +4421,26 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
                 }
                 for name in net["interfaces"]
             ]
+        # A VLAN row carries its tag so the operator can tell eth0.10 apart
+        # from a physical NIC that happens to be named with a dot, and so the
+        # delete control renders only where deleting is meaningful.
+        vlan_info = server.get_network_vlans()
+        vlan_ids = {str(v.get("name", "")): v.get("vlan_id") for v in vlan_info.get("vlans", [])}
+        net["supports_vlans"] = bool(vlan_info.get("supported"))
         net["iface_rows"] = [
-            {**row, "method_label": _NETWORK_METHOD_LABELS.get(row.get("method", ""), row.get("method", ""))}
+            {
+                **row,
+                "method_label": _NETWORK_METHOD_LABELS.get(row.get("method", ""), row.get("method", "")),
+                "vlan_id": vlan_ids.get(str(row.get("name", ""))),
+            }
             for row in rows
+        ]
+        # A VLAN cannot parent another VLAN (no QinQ) and loopback carries no
+        # tags, so neither is offered as a parent.
+        net["vlan_parents"] = [
+            name
+            for name in (str(row.get("name", "")) for row in rows)
+            if name and name not in vlan_ids and name not in LOOPBACK_NAMES
         ]
         net["session_iface"] = request_local_iface(request.environ)
         # One interface is always the current one – the same interface the card
@@ -4447,6 +4476,24 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         if resolved is None:
             return (None, "Network interface not available on this host.")
         return (resolved, "")
+
+    def _network_vlan_response(
+        *,
+        iface: str | None = None,
+        banner: dict[str, str] | None = None,
+    ) -> Any:
+        """Re-render the card after a VLAN create / delete.
+
+        The interface list is force-refreshed because a VLAN that was just
+        created (or removed) has to appear (or vanish) immediately – waiting
+        out the TTL would show the operator a list that contradicts the banner
+        they are reading.
+        """
+        server.get_network_interfaces(force=True)
+        return template(
+            "partials/network",
+            net=_build_network_form_context(iface=iface, editable=True, banner=banner),
+        )
 
     def _network_redirect_url(address: str) -> str:
         """Build a same-scheme/same-port URL on ``address`` so a static /
@@ -4665,6 +4712,60 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
                 banner={"kind": "ok", "text": text},
             ),
         )
+
+    @app.post("/section/network/vlan/create")
+    def network_vlan_create() -> Any:
+        parent = (request.forms.get("vlan_parent") or "").strip()
+        raw_id = (request.forms.get("vlan_id") or "").strip()
+        vlans = server.get_network_vlans()
+        if not vlans.get("supported"):
+            return _network_vlan_response(
+                banner={"kind": "error", "text": VLAN_UNSUPPORTED_MESSAGE},
+            )
+        vlan_id = parse_vlan_id(raw_id)
+        if vlan_id is None:
+            return _network_vlan_response(banner={"kind": "error", "text": VLAN_ID_RANGE_MESSAGE})
+        names = [str(row.get("name", "")) for row in server.get_network_interfaces()]
+        vlan_names = [str(v.get("name", "")) for v in vlans.get("vlans", [])]
+        errors = validate_vlan_create(parent, vlan_id, interfaces=names, vlan_names=vlan_names)
+        if errors:
+            return _network_vlan_response(banner={"kind": "error", "text": errors[0]})
+        with _config_write_lock:
+            result = server.create_network_vlan(parent, vlan_id)
+        if not result.ok:
+            return _network_vlan_response(banner={"kind": "error", "text": result.message})
+        return _network_vlan_response(
+            iface=vlan_interface_name(parent, vlan_id),
+            banner={"kind": "ok", "text": result.message},
+        )
+
+    @app.post("/section/network/vlan/delete")
+    def network_vlan_delete() -> Any:
+        name = (request.forms.get("iface") or "").strip()
+        vlans = server.get_network_vlans()
+        if not vlans.get("supported"):
+            return _network_vlan_response(
+                banner={"kind": "error", "text": VLAN_UNSUPPORTED_MESSAGE},
+            )
+        if name not in [str(v.get("name", "")) for v in vlans.get("vlans", [])]:
+            return _network_vlan_response(
+                banner={"kind": "error", "text": f"{name or 'That interface'} is not a VLAN and cannot be deleted."},
+            )
+        # Deleting the interface the browser arrived on cuts the operator's own
+        # session mid-request, and the page they would need to undo it is the
+        # one that just became unreachable.
+        if name and name == request_local_iface(request.environ):
+            return _network_vlan_response(
+                iface=name,
+                banner={
+                    "kind": "error",
+                    "text": f"This session is connected over {name}. Reconnect on another interface to delete it.",
+                },
+            )
+        with _config_write_lock:
+            result = server.delete_network_vlan(name)
+        banner_kind = "ok" if result.ok else "error"
+        return _network_vlan_response(banner={"kind": banner_kind, "text": result.message})
 
     @app.post("/section/network/renew")
     def network_renew() -> Any:

--- a/openfollow/web/server.py
+++ b/openfollow/web/server.py
@@ -202,6 +202,9 @@ class ConfigWebServer:
         network_interfaces_provider: (Callable[[], list[dict[str, Any]]] | None) = None,
         network_apply_handler: Callable[[str, Any], ApplyResult] | None = None,
         network_renew_handler: Callable[[str], ApplyResult] | None = None,
+        network_vlan_provider: Callable[[], dict[str, Any]] | None = None,
+        network_vlan_create_handler: Callable[[str, int], ApplyResult] | None = None,
+        network_vlan_delete_handler: Callable[[str], ApplyResult] | None = None,
         # Privilege capability snapshot for the diagnostics bundle; optional for tests.
         privilege_states_provider: Callable[[], dict[str, str]] | None = None,
         # Shared marker catalog (id/name/color) + multicast sync.
@@ -276,6 +279,9 @@ class ConfigWebServer:
         self._network_ifaces_lock = threading.Lock()
         self._network_apply_handler = network_apply_handler
         self._network_renew_handler = network_renew_handler
+        self._network_vlan_provider = network_vlan_provider
+        self._network_vlan_create_handler = network_vlan_create_handler
+        self._network_vlan_delete_handler = network_vlan_delete_handler
         self._psn_source_advisory_provider = psn_source_advisory_provider
         self._privilege_states_provider = privilege_states_provider
         self._marker_catalog_provider = marker_catalog_provider
@@ -460,6 +466,46 @@ class ConfigWebServer:
             return self._network_renew_handler(iface)
         except Exception as exc:  # noqa: BLE001
             logger.exception("network_renew handler raised")
+            return ApplyResult(ok=False, message=str(exc))
+
+    def get_network_vlans(self) -> dict[str, Any]:
+        """Return ``{"supported": bool, "vlans": [{name, parent, vlan_id}]}``.
+
+        Reported unsupported when unwired or when the provider fails, so the
+        card omits the VLAN controls rather than offering a button that cannot
+        work.
+        """
+        empty: dict[str, Any] = {"supported": False, "vlans": []}
+        if self._network_vlan_provider is None:
+            return empty
+        try:
+            return self._network_vlan_provider()
+        except Exception:  # noqa: BLE001
+            logger.exception("Network VLAN provider raised")
+            return empty
+
+    def create_network_vlan(self, parent: str, vlan_id: int) -> ApplyResult:
+        """Create a VLAN sub-interface on ``parent``; always returns ApplyResult."""
+        from openfollow.network.adapter import ApplyResult
+
+        if self._network_vlan_create_handler is None:
+            return ApplyResult(ok=False, message="Network writes are not available on this build.")
+        try:
+            return self._network_vlan_create_handler(parent, vlan_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("network_vlan_create handler raised")
+            return ApplyResult(ok=False, message=str(exc))
+
+    def delete_network_vlan(self, name: str) -> ApplyResult:
+        """Delete the VLAN sub-interface ``name``; always returns ApplyResult."""
+        from openfollow.network.adapter import ApplyResult
+
+        if self._network_vlan_delete_handler is None:
+            return ApplyResult(ok=False, message="Network writes are not available on this build.")
+        try:
+            return self._network_vlan_delete_handler(name)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("network_vlan_delete handler raised")
             return ApplyResult(ok=False, message=str(exc))
 
     def get_psn_source_advisory(self) -> dict[str, str]:

--- a/openfollow/web/templates/base.tpl
+++ b/openfollow/web/templates/base.tpl
@@ -863,6 +863,16 @@
  background: rgba(125, 229, 159, 0.12);
  border: 1px solid rgba(125, 229, 159, 0.35);
  }
+ .ia-badge.vlan {
+ color: var(--muted);
+ background: rgba(255, 255, 255, 0.06);
+ border: 1px solid rgba(255, 255, 255, 0.16);
+ }
+ .ia-vlan-add {
+ margin-top: 0.8rem;
+ padding-top: 0.8rem;
+ border-top: 1px solid rgba(255, 255, 255, 0.08);
+ }
  .ia-legend {
  display: flex;
  align-items: center;

--- a/openfollow/web/templates/partials/network.tpl
+++ b/openfollow/web/templates/partials/network.tpl
@@ -25,6 +25,10 @@
 % _session = _net.get("session_iface", "")
 % _editing = _net.get("editing_iface", "")
 % _polls = _net.get("available") and not _editable
+%# Creating a link is an Edit-mode action on a backend that owns links; on a
+%# read-only or non-NetworkManager stack the card renders exactly as before.
+% _vlan_parents = _net.get("vlan_parents", [])
+% _vlan_add = bool(_editable and _net.get("supports_vlans") and _vlan_parents)
 <form id="network-config-section" class="network-config"
 % if _editable:
       hx-post="/section/network/apply" hx-target="#network-interface"
@@ -95,6 +99,9 @@
                         %# their own session is arriving on.
                         <span class="ia-badge session" title="Your browser reached this station over this interface">This session</span>
                         % end
+                        % if row.get("vlan_id") is not None:
+                        <span class="ia-badge vlan">VLAN {{row.get("vlan_id")}}</span>
+                        % end
                     </td>
                     <td class="{{'' if _addr else 'muted'}}">{{(_addr + ('/' + str(_prefix) if _prefix else '')) if _addr else '(no address)'}}</td>
                     <td class="muted">{{row.get('method_label', '')}}</td>
@@ -113,7 +120,11 @@
                 % if _open:
                 <tr class="ia-editor-row"><td colspan="5"><div class="ia-editor">
                     <div class="ia-editor-head">
-                        <h4 class="group-title">Configure <code>{{_name}}</code></h4>
+                        <h4 class="group-title">Configure <code>{{_name}}</code>
+                            % if row.get("vlan_id") is not None:
+                            <span class="ia-badge vlan">VLAN {{row.get("vlan_id")}}</span>
+                            % end
+                        </h4>
                     </div>
 
                     % if _name == _session:
@@ -194,6 +205,14 @@
                                 hx-post="/section/network/renew" hx-target="#network-interface"
                                 hx-swap="innerHTML" hx-include="closest form">Renew DHCP lease</button>
                         % end
+                        %# Delete lives inside the open editor, so it can only
+                        %# ever be aimed at the interface named in the header.
+                        % if row.get("vlan_id") is not None:
+                        <button type="button" class="danger"
+                                hx-post="/section/network/vlan/delete" hx-target="#network-interface"
+                                hx-swap="innerHTML" hx-include="closest form"
+                                hx-confirm="Delete {{_name}}? Any function pinned to it stops sending until it is reassigned.">Delete VLAN</button>
+                        % end
                         %# Back to View mode on the same row. Targeting /edit
                         %# would re-render the editor, leaving no way out of
                         %# Edit mode short of a page reload.
@@ -213,6 +232,10 @@
             <span><span class="ia-dot up"></span> up with an address</span>
             <span><span class="ia-dot down"></span> no address</span>
             <span class="ia-legend-actions">
+                % if _vlan_add:
+                <button type="button" class="secondary small"
+                        onclick="this.closest('.group').querySelector('.ia-vlan-add').hidden = false; this.hidden = true;">+ Add VLAN</button>
+                % end
                 %# Keeps the open interface in the path so re-reading the
                 %# adapter list doesn't move the expansion (and, in Edit mode,
                 %# doesn't discard what the operator has typed).
@@ -221,6 +244,30 @@
                         hx-target="#network-interface" hx-swap="innerHTML">Scan</button>
             </span>
         </div>
+
+        % if _vlan_add:
+        <div class="ia-vlan-add" hidden>
+            <h4 class="group-title">Add VLAN</h4>
+            <div class="network-grid">
+                <label for="net-vlan-parent">Parent interface</label>
+                <select id="net-vlan-parent" name="vlan_parent">
+                    % for _parent in _vlan_parents:
+                    <option value="{{_parent}}">{{_parent}}</option>
+                    % end
+                </select>
+
+                <label for="net-vlan-id">VLAN ID</label>
+                <input type="number" id="net-vlan-id" name="vlan_id" min="1" max="4094" step="1" placeholder="10">
+            </div>
+            <div class="actions">
+                <button type="button" class="save-btn"
+                        hx-post="/section/network/vlan/create" hx-target="#network-interface"
+                        hx-swap="innerHTML" hx-include="closest form">Create</button>
+                <button type="button" class="ghost-btn"
+                        onclick="var b=this.closest('.group'); b.querySelector('.ia-vlan-add').hidden = true; b.querySelector('.ia-legend-actions button').hidden = false;">Cancel</button>
+            </div>
+        </div>
+        % end
         % end
     </div>
     % end

--- a/scripts/ansible/install-raspberry-pi.yml
+++ b/scripts/ansible/install-raspberry-pi.yml
@@ -1061,6 +1061,8 @@
           {{ openfollow_user }} ALL=(root) NOPASSWD: /usr/bin/nmcli con mod *
           {{ openfollow_user }} ALL=(root) NOPASSWD: /usr/bin/nmcli con up *
           {{ openfollow_user }} ALL=(root) NOPASSWD: /usr/bin/nmcli con down *
+          {{ openfollow_user }} ALL=(root) NOPASSWD: /usr/bin/nmcli con add *
+          {{ openfollow_user }} ALL=(root) NOPASSWD: /usr/bin/nmcli con delete *
           {{ openfollow_user }} ALL=(root) NOPASSWD: /usr/bin/tee /etc/dhcpcd.conf.tmp
           {{ openfollow_user }} ALL=(root) NOPASSWD: /usr/bin/mv /etc/dhcpcd.conf.tmp /etc/dhcpcd.conf
           {{ openfollow_user }} ALL=(root) NOPASSWD: /usr/bin/systemctl reload dhcpcd

--- a/scripts/hw_validation/README.md
+++ b/scripts/hw_validation/README.md
@@ -174,6 +174,15 @@ validation step cannot install one. `vlan_tag_probe.py` is a raw `AF_PACKET`
 socket in the bundled venv's Python. A tcpdump-based check reports "no traffic"
 on every station, which reads as a pass.
 
+**A tag is in the frame on the way out and in socket metadata on the way in.**
+The kernel lifts an 802.1Q header off on ingress, so reading the ethernet header
+alone finds the tag at the sender and nothing at the receiver - a delivered
+frame reports as untagged, which reads as a leak. The probe asks for
+`PACKET_AUXDATA` and recovers the tag from there, the same source tcpdump uses
+to print `vlan 10`. Note also that a capture sees a multicast group only if
+something on that host has joined it: without a joiner the switch prunes the
+group and the capture reports zero frames, which reads as "never arrived".
+
 **A VLAN is not pinnable until it has an address.** The interface pickers list
 interfaces that *have* an IPv4, so a freshly created VLAN is absent from them
 until `Configure` gives it one. The Create banner says so; the script skips the

--- a/scripts/hw_validation/README.md
+++ b/scripts/hw_validation/README.md
@@ -18,7 +18,8 @@ to grow into a fuller two-Pi validation suite (see the tracking issue).
 | `osc_socket_options_probe.py` | DUT | Builds clients via the deployed `OscService._make_client` and asserts the broadcast/multicast socket options (#482). |
 | `eos_console_probe.py` | workstation | Drives the deployed `OscTransmitterManager` at an Eos console / ETCnomad. `verify` reads Eos's own parameter values back and asserts the bundled ETC Eos templates' X/Y/Z mapping, exiting `0` (mapping correct) / `1` (mismatch or setup fault). `test` / `sweep` / `stream` drive the console for an operator to watch; their exit code reports only whether the sends reached the socket. |
 | `marker_catalog_two_station.py` | workstation | Reproduces the clock-skew marker-rename revert across two stations: steps station B's clock ahead, renames on A, asserts the rename holds on both. Exits `0` (PASS) / `1` (FAIL). |
-| `multi_interface_two_station.py` | workstation | Drives the multi-interface feature end-to-end: creates a tagged VLAN from the web UI, asserts it becomes a pinnable netdev, exercises the delete guards, then proves PSN leaves tagged on the pinned NIC, never leaks to another, and **stops** when its interface goes down. Exits `0` (PASS) / `1` (FAIL). |
+| `multi_interface_two_station.py` | workstation | Drives the multi-interface feature end-to-end: creates a tagged VLAN from the web UI, asserts it becomes a pinnable netdev, exercises the delete guards, then proves PSN leaves tagged on the pinned NIC and **stops** when its interface is unavailable. Exits `0` (PASS) / `1` (FAIL). |
+| `vlan_tag_probe.py` | DUT | Dependency-free raw-socket capture reporting the 802.1Q tag on each frame. A station ships no `tcpdump` and no uplink to install one. |
 
 ## DUT-local probes (no companion)
 
@@ -141,34 +142,61 @@ python3 scripts/hw_validation/raw_udp_probe.py send --host <DUT_IP> --port 8765
 ## Multi-interface networking (two stations)
 
 `multi_interface_two_station.py` runs from a **workstation** and drives the DUT
-over HTTP + SSH. It is the hardware half of issue #50 – the parts a fake-socket
-test cannot reach, because they depend on a real switch, real 802.1Q tags, and a
-real interface going down.
+over HTTP + SSH. It is the hardware half of issue #50 - the parts a fake-socket
+test cannot reach, because they depend on real frames on a real wire.
 
 ```sh
 python3 scripts/hw_validation/multi_interface_two_station.py \
-    --dut <DUT_IP> --parent eth0 --other-nic wlan0 --vlan-id 10 \
+    --dut <DUT_IP> --parent eth0 --vlan-id 10 \
     --ssh-user openfollow --ssh-key ~/.ssh/openfollow_pi --pin <WEB_PIN>
 ```
 
-The two load-bearing checks are the last ones:
+The two load-bearing checks:
 
-- **Traffic separation** – with PSN pinned to `eth0.10`, `tcpdump -e` on the
-  parent must show PSN frames carrying `vlan 10`, and the other NIC must show
-  none. If PSN appears on the office LAN the feature has failed at its purpose.
-- **Fail closed** – taking the pinned interface down must make PSN **stop**. It
-  must not reappear on another NIC. On a show, a dead output is diagnosable and
-  a misrouted one is not.
+- **Traffic separation** - with PSN pinned to `eth0.10`, every PSN frame on the
+  parent carries `vlan 10` and none from this station is untagged. If PSN
+  appears untagged on the office LAN the feature has failed at its purpose.
+- **Fail closed** - pinning to an interface that has no address must make PSN
+  **stop**, closing its sockets rather than rebinding. On a show a dead output
+  is diagnosable and a misrouted one is not.
 
-The DUT's `--parent` NIC has to be on a **trunk (tagged) switch port** carrying
-the VLAN, or there is nothing to capture and those steps report as skipped
-rather than passing vacuously. Give the VLAN an address in Network Settings
-before the run, otherwise the traffic phases skip too.
+### Four things that make this harder than it looks
+
+**A trunk port is not needed for the tagging check.** Tagging is done by the
+host: sending via `eth0.10` makes the kernel add the VLAN header before the
+frame reaches `eth0`, so capturing on the parent proves the pin is honoured
+even on an access port. Only end-to-end delivery to a second station needs a
+trunk. Capture on the **parent** - the VLAN interface sees its own frames
+untagged.
+
+**There is no `tcpdump` on a station**, and the offline contract means a
+validation step cannot install one. `vlan_tag_probe.py` is a raw `AF_PACKET`
+socket in the bundled venv's Python. A tcpdump-based check reports "no traffic"
+on every station, which reads as a pass.
+
+**A VLAN is not pinnable until it has an address.** The interface pickers list
+interfaces that *have* an IPv4, so a freshly created VLAN is absent from them
+until `Configure` gives it one. The Create banner says so; the script skips the
+traffic phases rather than reporting a false failure.
+
+**Do not set the pin through `/api/config/interface_assignment`.**
+`psn_source_iface` is device-local, so the JSON section API strips it and
+answers `{"success": true}` having written nothing - every later assertion then
+measures the old pin. The panel's form POST to `/section/interface_assignment`
+is the working path, and the script re-reads the pin to confirm it landed.
+
+### Why the fail-closed check has no cross-station control
+
+Suspending PSN stops the *receiver* as well, which drops the DUT's IGMP
+membership for the group. The switch then prunes it from that port, so **every**
+station's PSN vanishes from the capture, not just the DUT's. A second station is
+therefore not a usable control here; the DUT's own closed send socket plus the
+journal line naming the interface are the direct evidence, and that is what the
+script asserts.
 
 The script restores what it changed in a `finally`: the PSN pin returns to its
 original value and the VLAN it created is deleted. It refuses to start if the
 VLAN name already exists, so cleanup can never remove one you rely on.
 
-`--companion` currently only confirms the second station's web UI is reachable;
-end-to-end receipt on the tagged network is still an eyes-on check of its viewer
-markers.
+`--other-nic` and `--companion` are optional; both skip loudly when absent
+rather than passing vacuously.

--- a/scripts/hw_validation/README.md
+++ b/scripts/hw_validation/README.md
@@ -18,6 +18,7 @@ to grow into a fuller two-Pi validation suite (see the tracking issue).
 | `osc_socket_options_probe.py` | DUT | Builds clients via the deployed `OscService._make_client` and asserts the broadcast/multicast socket options (#482). |
 | `eos_console_probe.py` | workstation | Drives the deployed `OscTransmitterManager` at an Eos console / ETCnomad. `verify` reads Eos's own parameter values back and asserts the bundled ETC Eos templates' X/Y/Z mapping, exiting `0` (mapping correct) / `1` (mismatch or setup fault). `test` / `sweep` / `stream` drive the console for an operator to watch; their exit code reports only whether the sends reached the socket. |
 | `marker_catalog_two_station.py` | workstation | Reproduces the clock-skew marker-rename revert across two stations: steps station B's clock ahead, renames on A, asserts the rename holds on both. Exits `0` (PASS) / `1` (FAIL). |
+| `multi_interface_two_station.py` | workstation | Drives the multi-interface feature end-to-end: creates a tagged VLAN from the web UI, asserts it becomes a pinnable netdev, exercises the delete guards, then proves PSN leaves tagged on the pinned NIC, never leaks to another, and **stops** when its interface goes down. Exits `0` (PASS) / `1` (FAIL). |
 
 ## DUT-local probes (no companion)
 
@@ -136,3 +137,38 @@ python3 scripts/hw_validation/raw_udp_probe.py listen --port 8765
 # companion
 python3 scripts/hw_validation/raw_udp_probe.py send --host <DUT_IP> --port 8765
 ```
+
+## Multi-interface networking (two stations)
+
+`multi_interface_two_station.py` runs from a **workstation** and drives the DUT
+over HTTP + SSH. It is the hardware half of issue #50 – the parts a fake-socket
+test cannot reach, because they depend on a real switch, real 802.1Q tags, and a
+real interface going down.
+
+```sh
+python3 scripts/hw_validation/multi_interface_two_station.py \
+    --dut <DUT_IP> --parent eth0 --other-nic wlan0 --vlan-id 10 \
+    --ssh-user openfollow --ssh-key ~/.ssh/openfollow_pi --pin <WEB_PIN>
+```
+
+The two load-bearing checks are the last ones:
+
+- **Traffic separation** – with PSN pinned to `eth0.10`, `tcpdump -e` on the
+  parent must show PSN frames carrying `vlan 10`, and the other NIC must show
+  none. If PSN appears on the office LAN the feature has failed at its purpose.
+- **Fail closed** – taking the pinned interface down must make PSN **stop**. It
+  must not reappear on another NIC. On a show, a dead output is diagnosable and
+  a misrouted one is not.
+
+The DUT's `--parent` NIC has to be on a **trunk (tagged) switch port** carrying
+the VLAN, or there is nothing to capture and those steps report as skipped
+rather than passing vacuously. Give the VLAN an address in Network Settings
+before the run, otherwise the traffic phases skip too.
+
+The script restores what it changed in a `finally`: the PSN pin returns to its
+original value and the VLAN it created is deleted. It refuses to start if the
+VLAN name already exists, so cleanup can never remove one you rely on.
+
+`--companion` currently only confirms the second station's web UI is reachable;
+end-to-end receipt on the tagged network is still an eyes-on check of its viewer
+markers.

--- a/scripts/hw_validation/multi_interface_two_station.py
+++ b/scripts/hw_validation/multi_interface_two_station.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import pathlib
 import subprocess
 import sys
 import time
@@ -54,7 +55,9 @@ import urllib.parse
 import urllib.request
 
 CAPTURE_SECONDS = 8
-SETTLE_SECONDS = 4
+SETTLE_SECONDS = 6
+_VENV_PYTHON = "/opt/openfollow/venv/bin/python"
+_REMOTE_PROBE_DIR = "/tmp"  # noqa: S108 - a throwaway copy of a repo script on the DUT
 
 
 # --------------------------------------------------------------------------- #
@@ -180,19 +183,63 @@ def capture_psn(
     nic: str,
     mcast: str,
     seconds: int = CAPTURE_SECONDS,
-) -> str:
-    """Return tcpdump's link-level output for PSN traffic on ``nic``.
+) -> list[dict]:
+    """Return the PSN frames seen on ``nic``, each with its 802.1Q tag.
 
-    ``-e`` prints the ethernet header, which is what carries the 802.1Q tag –
-    without it a tagged and an untagged frame look identical.
+    Uses the bundled ``vlan_tag_probe.py`` rather than ``tcpdump``: a station
+    ships neither tcpdump nor an uplink to install one, so a tcpdump-based
+    check reports "no traffic" on every station and reads as a pass.
+
+    Capture on the **parent**, not the VLAN. Tagging happens on egress to the
+    parent, so the VLAN interface itself sees its own frames untagged.
     """
-    cmd = f"sudo timeout {seconds + 2} tcpdump -l -n -e -c 40 -i {nic} host {mcast} 2>/dev/null || true"
-    result = ssh(ssh_base, host, cmd, timeout=seconds + 20)
-    return result.stdout
+    remote = f"{_REMOTE_PROBE_DIR}/vlan_tag_probe.py"
+    cmd = f"sudo {_VENV_PYTHON} {remote} --iface {nic} --dst {mcast} --seconds {seconds} --json"
+    result = ssh(ssh_base, host, cmd, timeout=seconds + 25)
+    try:
+        parsed = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+    return parsed if isinstance(parsed, list) else []
+
+
+def push_probe(ssh_base: list[str], host: str) -> bool:
+    """Copy the capture probe onto the DUT. Returns False if it cannot land."""
+    local = pathlib.Path(__file__).resolve().with_name("vlan_tag_probe.py")
+    try:
+        source = local.read_text()
+    except OSError:
+        return False
+    written = ssh(
+        ssh_base,
+        host,
+        f"cat > {_REMOTE_PROBE_DIR}/vlan_tag_probe.py <<'OF_PROBE_EOF'\n{source}\nOF_PROBE_EOF\necho ok",
+        timeout=30,
+    )
+    return "ok" in written.stdout
+
+
+def tags_in(frames: list[dict], source_ip: str = "") -> set[str]:
+    """Distinct tags among ``frames``, optionally only those from ``source_ip``."""
+    return {
+        ("untagged" if f.get("vlan") is None else f"vlan {f['vlan']}")
+        for f in frames
+        if not source_ip or f.get("src") == source_ip
+    }
 
 
 def set_psn_pin(web: Web, iface: str) -> tuple[int, str]:
-    return web.post_json("/api/config/interface_assignment", {"psn_source_iface": iface})
+    """Set the station pin through the panel's form POST.
+
+    NOT ``/api/config/interface_assignment``: ``psn_source_iface`` is
+    device-local, so the JSON section API strips it and answers
+    ``{"success": true}`` having written nothing. A pin set that way silently
+    never applies, and every downstream assertion then measures the old pin.
+    """
+    return web.post_form(
+        "/section/interface_assignment",
+        {"psn_source_iface": iface, "otp_output.source_iface": ""},
+    )
 
 
 def read_psn_pin(web: Web) -> str:
@@ -277,53 +324,95 @@ def phase_guards(rep: Report, web: Web, args, vlan_name: str) -> None:
 
 def phase_traffic_separation(rep: Report, web: Web, ssh_base: list[str], args, vlan_name: str) -> None:
     print("\n[4] Traffic separation")
-    if not iface_address(ssh_base, args.dut, vlan_name):
-        rep.skip(
-            "PSN leaves tagged on the parent NIC",
-            f"{vlan_name} has no address; give it one in Network Settings first",
-        )
-        rep.skip("PSN does not leak to the other NIC", "no address on the VLAN")
+    vlan_addr = iface_address(ssh_base, args.dut, vlan_name).split("/")[0]
+    if not vlan_addr:
+        # A VLAN with no address is not offered as a pin at all: the interface
+        # pickers are built from interfaces that HAVE an IPv4, so an unaddressed
+        # VLAN cannot be selected and nothing downstream would be measuring the
+        # pin. Give it an address in Network Settings first.
+        rep.skip("PSN leaves tagged on the parent NIC", f"{vlan_name} has no address")
+        rep.skip("PSN stops when its interface goes dark", f"{vlan_name} has no address")
         return
 
     status, _body = set_psn_pin(web, vlan_name)
     if not rep.check("PSN pin accepted", status == 200, f"HTTP {status}"):
         return
+    if not rep.check(
+        "pin persisted",
+        read_psn_pin(web) == vlan_name,
+        "the pin did not reach config - a device-local field was stripped",
+    ):
+        return
     time.sleep(SETTLE_SECONDS)
 
-    tagged = capture_psn(ssh_base, args.dut, args.parent, args.psn_mcast)
+    frames = capture_psn(ssh_base, args.dut, args.parent, args.psn_mcast)
+    ours = tags_in(frames, vlan_addr)
     rep.check(
         "PSN leaves tagged on the parent NIC",
-        f"vlan {args.vlan_id}" in tagged,
-        f"no 802.1Q tag {args.vlan_id} seen on {args.parent}",
+        ours == {f"vlan {args.vlan_id}"},
+        f"frames from {vlan_addr} carried {sorted(ours) or ['nothing']}",
+    )
+    rep.check(
+        "no untagged PSN from this station",
+        not any(f.get("vlan") is None and f.get("src") == vlan_addr for f in frames),
+        "the same station sent untagged PSN while pinned",
     )
     if args.other_nic:
         leaked = capture_psn(ssh_base, args.dut, args.other_nic, args.psn_mcast)
         rep.check(
             "PSN does not leak to the other NIC",
-            args.psn_mcast not in leaked,
-            f"PSN frames seen on {args.other_nic} – the pin is not holding",
+            not any(f.get("src") == vlan_addr for f in leaked),
+            f"PSN from {vlan_addr} seen on {args.other_nic}",
         )
     else:
-        rep.skip("PSN does not leak to the other NIC", "no --other-nic given")
+        rep.skip("PSN does not leak to the other NIC", "no --other-nic given (needs a second interface)")
 
 
-def phase_fail_closed(rep: Report, ssh_base: list[str], args, vlan_name: str) -> None:
-    print("\n[5] Fail closed when the pinned interface goes dark")
-    if not iface_address(ssh_base, args.dut, vlan_name):
-        rep.skip("PSN stops rather than moving interface", "the VLAN had no address to lose")
+def phase_fail_closed(rep: Report, web: Web, ssh_base: list[str], args) -> None:
+    """The load-bearing rule: a configured interface with no address must stop
+    the plane, never move it. Pinning to an absent interface exercises it
+    without needing a second NIC or a link to unplug.
+
+    Note the capture cannot use another station as a control here. Suspending
+    PSN stops the receiver too, which drops this port's IGMP membership, so the
+    switch prunes the group and every station's PSN disappears from the capture
+    - not just ours. The pinned station's own send socket is the direct
+    evidence, so that is what this asserts.
+    """
+    print("\n[5] Fail closed when the pinned interface is unavailable")
+    absent = f"{args.parent}9999"
+    status, _body = set_psn_pin(web, absent)
+    if not rep.check("pin to an absent interface accepted", status == 200, f"HTTP {status}"):
         return
-    ssh(ssh_base, args.dut, f"sudo nmcli con down {vlan_name} >/dev/null 2>&1 || true")
     time.sleep(SETTLE_SECONDS)
-    try:
-        nics = [args.parent] + ([args.other_nic] if args.other_nic else [])
-        seen_on = [nic for nic in nics if args.psn_mcast in capture_psn(ssh_base, args.dut, nic, args.psn_mcast)]
-        rep.check(
-            "PSN stops rather than moving interface",
-            not seen_on,
-            f"PSN reappeared on {', '.join(seen_on)} after its pinned interface went down",
-        )
-    finally:
-        ssh(ssh_base, args.dut, f"sudo nmcli con up {vlan_name} >/dev/null 2>&1 || true")
+
+    sockets = ssh(
+        ssh_base,
+        args.dut,
+        f"sudo ss -unap 2>/dev/null | grep -c '{args.psn_mcast}' || true",
+    ).stdout.strip()
+    rep.check(
+        "PSN sockets are closed, not rebound",
+        sockets in ("", "0"),
+        f"{sockets} PSN socket(s) still open on a down pin",
+    )
+    frames = capture_psn(ssh_base, args.dut, args.parent, args.psn_mcast)
+    rep.check(
+        "no PSN on the wire while suspended",
+        not frames,
+        f"{len(frames)} PSN frames still leaving",
+    )
+    logged = ssh(
+        ssh_base,
+        args.dut,
+        "sudo journalctl -u openfollow --since '-2min' --no-pager"
+        " | grep -c 'will not be sent on another interface' || true",
+    ).stdout.strip()
+    rep.check(
+        "the operator is told why it stopped",
+        logged not in ("", "0"),
+        "nothing in the journal names the down interface",
+    )
 
 
 def phase_companion(rep: Report, args, vlan_name: str) -> None:
@@ -383,6 +472,10 @@ def main() -> int:
         print(f"{vlan_name} already exists – choose a free --vlan-id so cleanup can't remove a real one.")
         return 2
 
+    if not push_probe(ssh_base, args.dut):
+        print("Could not copy vlan_tag_probe.py onto the DUT.", file=sys.stderr)
+        return 2
+
     web = Web(args.dut, args.pin)
     original_pin = read_psn_pin(web)
     print(f"Original PSN pin: {original_pin or '(auto-detect)'}")
@@ -394,7 +487,7 @@ def main() -> int:
             phase_no_extra_plumbing(rep, web, vlan_name)
             phase_guards(rep, web, args, vlan_name)
             phase_traffic_separation(rep, web, ssh_base, args, vlan_name)
-            phase_fail_closed(rep, ssh_base, args, vlan_name)
+            phase_fail_closed(rep, web, ssh_base, args)
             phase_companion(rep, args, vlan_name)
     finally:
         print("\n[cleanup]")

--- a/scripts/hw_validation/multi_interface_two_station.py
+++ b/scripts/hw_validation/multi_interface_two_station.py
@@ -149,9 +149,13 @@ class Report:
     def __init__(self) -> None:
         self.rows: list[tuple[str, bool, str]] = []
 
-    def check(self, name: str, ok: bool, detail: str = "") -> bool:
-        self.rows.append((name, ok, detail))
-        print(f"  [{'PASS' if ok else 'FAIL'}] {name}{f' – {detail}' if detail else ''}", flush=True)
+    def check(self, name: str, ok: bool, detail: str = "", *, on_fail: str = "") -> bool:
+        """*detail* is evidence and prints either way; *on_fail* explains a
+        failure and prints only when there is one. Printing a failure
+        explanation beside PASS makes a green run read like a red one."""
+        shown = detail if ok else (on_fail or detail)
+        self.rows.append((name, ok, shown))
+        print(f"  [{'PASS' if ok else 'FAIL'}] {name}{f' - {shown}' if shown else ''}", flush=True)
         return ok
 
     def skip(self, name: str, why: str) -> None:
@@ -263,7 +267,7 @@ def phase_vlan_lifecycle(rep: Report, web: Web, ssh_base: list[str], args, vlan_
     if not rep.check(
         "create reported success",
         "Created" in body or vlan_name in body,
-        "banner did not confirm creation",
+        on_fail="banner did not confirm creation",
     ):
         print(f"      body excerpt: {body[:400]}")
         return False
@@ -271,23 +275,32 @@ def phase_vlan_lifecycle(rep: Report, web: Web, ssh_base: list[str], args, vlan_
     return rep.check(
         f"{vlan_name} exists as a netdev on the DUT",
         netdev_exists(ssh_base, args.dut, vlan_name),
-        "ip link does not show it",
+        on_fail="ip link does not show it",
     )
 
 
-def phase_no_extra_plumbing(rep: Report, web: Web, vlan_name: str) -> None:
+def phase_no_extra_plumbing(rep: Report, web: Web, ssh_base: list[str], args, vlan_name: str) -> None:
     print("\n[2] A VLAN is an ordinary netdev (no extra plumbing)")
     _status, card = web.get("/section/network/edit")
     rep.check(
         "VLAN appears in the Network Settings list",
         vlan_name in card,
-        "not in the interface list",
+        on_fail="not in the interface list",
     )
+    # Same ordering the traffic phase respects: the pickers list interfaces that
+    # HAVE an IPv4, so a VLAN is absent from them until something addresses it.
+    # Reporting that as a failure blames the feature for its documented
+    # sequence. A station provisioned with the DHCP-fallback drop-in self-
+    # assigns a link-local here within seconds; one without it stays empty until
+    # Configure gives it an address.
+    if not iface_address(ssh_base, args.dut, vlan_name):
+        rep.skip("VLAN is offered as a plane pin", f"{vlan_name} has no address yet")
+        return
     _status, picker = web.get("/network/interfaces/by_name")
     rep.check(
         "VLAN is offered as a plane pin",
         f'value="{vlan_name}"' in picker,
-        "not offered in the interface picker",
+        on_fail="not offered in the interface picker",
     )
 
 
@@ -297,13 +310,13 @@ def phase_guards(rep: Report, web: Web, args, vlan_name: str) -> None:
     rep.check(
         "deleting a non-VLAN adapter is refused",
         "is not a VLAN" in body,
-        "the parent NIC was not protected",
+        on_fail="the parent NIC was not protected",
     )
     _status, body = web.post_form("/section/network/vlan/delete", {"iface": "definitely-not-real"})
     rep.check(
         "deleting an unknown adapter is refused",
         "is not a VLAN" in body,
-        "an unknown name was not rejected",
+        on_fail="an unknown name was not rejected",
     )
     # The session guard only fires when the browser arrived over the interface
     # being deleted, which needs the request to come in on the VLAN itself.
@@ -313,7 +326,7 @@ def phase_guards(rep: Report, web: Web, args, vlan_name: str) -> None:
         rep.check(
             "deleting this session's own adapter is refused",
             "This session is connected over" in body,
-            "the session guard did not fire",
+            on_fail="the session guard did not fire",
         )
     else:
         rep.skip(
@@ -340,7 +353,7 @@ def phase_traffic_separation(rep: Report, web: Web, ssh_base: list[str], args, v
     if not rep.check(
         "pin persisted",
         read_psn_pin(web) == vlan_name,
-        "the pin did not reach config - a device-local field was stripped",
+        on_fail="the pin did not reach config - a device-local field was stripped",
     ):
         return
     time.sleep(SETTLE_SECONDS)
@@ -355,7 +368,7 @@ def phase_traffic_separation(rep: Report, web: Web, ssh_base: list[str], args, v
     rep.check(
         "no untagged PSN from this station",
         not any(f.get("vlan") is None and f.get("src") == vlan_addr for f in frames),
-        "the same station sent untagged PSN while pinned",
+        on_fail="the same station sent untagged PSN while pinned",
     )
     if args.other_nic:
         leaked = capture_psn(ssh_base, args.dut, args.other_nic, args.psn_mcast)
@@ -394,13 +407,13 @@ def phase_fail_closed(rep: Report, web: Web, ssh_base: list[str], args) -> None:
     rep.check(
         "PSN sockets are closed, not rebound",
         sockets in ("", "0"),
-        f"{sockets} PSN socket(s) still open on a down pin",
+        f"{sockets or '0'} PSN socket(s) open",
     )
     frames = capture_psn(ssh_base, args.dut, args.parent, args.psn_mcast)
     rep.check(
         "no PSN on the wire while suspended",
         not frames,
-        f"{len(frames)} PSN frames still leaving",
+        f"{len(frames)} PSN frames on the wire",
     )
     logged = ssh(
         ssh_base,
@@ -411,7 +424,7 @@ def phase_fail_closed(rep: Report, web: Web, ssh_base: list[str], args) -> None:
     rep.check(
         "the operator is told why it stopped",
         logged not in ("", "0"),
-        "nothing in the journal names the down interface",
+        on_fail="nothing in the journal names the down interface",
     )
 
 
@@ -484,7 +497,7 @@ def main() -> int:
     try:
         created = phase_vlan_lifecycle(rep, web, ssh_base, args, vlan_name)
         if created:
-            phase_no_extra_plumbing(rep, web, vlan_name)
+            phase_no_extra_plumbing(rep, web, ssh_base, args, vlan_name)
             phase_guards(rep, web, args, vlan_name)
             phase_traffic_separation(rep, web, ssh_base, args, vlan_name)
             phase_fail_closed(rep, web, ssh_base, args)

--- a/scripts/hw_validation/multi_interface_two_station.py
+++ b/scripts/hw_validation/multi_interface_two_station.py
@@ -496,9 +496,18 @@ def main() -> int:
         if created:
             status, _body = web.post_form("/section/network/vlan/delete", {"iface": vlan_name})
             gone = not netdev_exists(ssh_base, args.dut, vlan_name)
-            print(f"  {vlan_name} deleted (HTTP {status}), netdev gone: {gone}")
             if not gone:
-                print(f"  WARNING: {vlan_name} still present – remove it with: sudo nmcli con delete {vlan_name}")
+                # The web delete refuses the interface the request arrived on -
+                # by design, and exactly the case when the run was pointed at
+                # the VLAN's own address to exercise that guard. Refusing is
+                # correct; leaving the VLAN behind while claiming the station
+                # was restored is not, so fall back to removing it over SSH.
+                print(f"  web delete did not remove {vlan_name} (HTTP {status}); removing over SSH")
+                ssh(ssh_base, args.dut, f"sudo nmcli con delete {vlan_name} >/dev/null 2>&1 || true")
+                gone = not netdev_exists(ssh_base, args.dut, vlan_name)
+            print(f"  {vlan_name} removed: {gone}")
+            if not gone:
+                print(f"  WARNING: {vlan_name} still present - remove it with: sudo nmcli con delete {vlan_name}")
 
     failures = rep.failed()
     print(f"\n{'FAIL' if failures else 'PASS'} – {len(rep.rows) - len(failures)}/{len(rep.rows)} checks passed")

--- a/scripts/hw_validation/multi_interface_two_station.py
+++ b/scripts/hw_validation/multi_interface_two_station.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""Multi-interface networking validation across two stations (issue #50).
+
+Runs from a WORKSTATION and drives a **device under test (DUT)** over HTTP +
+SSH, optionally confirming end-to-end delivery at a **companion** station.
+
+What it proves, in order:
+
+  1. **VLAN lifecycle** – create a tagged sub-interface from the web UI and see
+     it appear as a real netdev on the DUT.
+  2. **No extra plumbing** – the same sub-interface shows up in the Network
+     Settings list *and* in the interface picker every plane pins through.
+     This is the claim the VLAN design rests on: a VLAN is an ordinary netdev.
+  3. **Guards** – deleting a non-VLAN adapter is refused, and so is deleting
+     the adapter this HTTP session arrived on.
+  4. **Traffic separation** – with PSN pinned to the VLAN, the parent NIC
+     carries PSN frames tagged with that VLAN ID and the other NIC carries
+     none. This is the whole point of the feature: PSN must not leak onto the
+     office LAN.
+  5. **Fail closed** – take the pinned VLAN down and PSN must **stop**, not
+     reappear on another interface. A dead output is diagnosable on a show; a
+     misrouted one is not.
+
+Everything it changes is restored in a ``finally``: the PSN pin returns to its
+original value and the VLAN it created is deleted.
+
+Requirements:
+  - HTTP reachability to the DUT's web UI (``--pin`` if one is set);
+  - passwordless SSH (key auth) to the DUT as a sudo-capable user, for
+    ``ip``/``tcpdump``/``nmcli`` reads;
+  - the DUT's ``--parent`` NIC plugged into a **trunk (tagged) switch port**
+    carrying ``--vlan-id``, or steps 4-5 have nothing to capture;
+  - a second NIC named by ``--other-nic`` to prove PSN does *not* leak there.
+
+NOT part of ``make ci`` – it needs real hardware, a trunk port, and root.
+
+    python3 scripts/hw_validation/multi_interface_two_station.py \\
+        --dut 192.168.1.10 --parent eth0 --other-nic wlan0 --vlan-id 10 \\
+        --ssh-user openfollow --ssh-key ~/.ssh/openfollow_pi --pin 0303
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+CAPTURE_SECONDS = 8
+SETTLE_SECONDS = 4
+
+
+# --------------------------------------------------------------------------- #
+# Transport
+# --------------------------------------------------------------------------- #
+
+
+def build_ssh_base(user: str, key: str) -> list[str]:
+    return [
+        "ssh",
+        "-o",
+        "IdentitiesOnly=yes",
+        "-o",
+        "IdentityAgent=none",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=8",
+        "-i",
+        os.path.expanduser(key),
+        f"{user}@__HOST__",
+    ]
+
+
+def ssh(ssh_base: list[str], host: str, cmd: str, timeout: int = 30) -> subprocess.CompletedProcess[str]:
+    argv = [a.replace("__HOST__", host) for a in ssh_base]
+    return subprocess.run([*argv, cmd], capture_output=True, text=True, timeout=timeout)
+
+
+class Web:
+    """Web UI client that carries the auth cookie when a PIN is configured."""
+
+    def __init__(self, ip: str, pin: str = "") -> None:
+        self.ip = ip
+        self.opener = urllib.request.build_opener(
+            urllib.request.HTTPCookieProcessor(),
+        )
+        if pin:
+            self._login(pin)
+
+    def _login(self, pin: str) -> None:
+        body = urllib.parse.urlencode({"pin": pin}).encode()
+        req = urllib.request.Request(f"http://{self.ip}/login", data=body, method="POST")
+        req.add_header("Content-Type", "application/x-www-form-urlencoded")
+        with self.opener.open(req, timeout=10):
+            pass
+
+    def get(self, path: str) -> tuple[int, str]:
+        try:
+            with self.opener.open(f"http://{self.ip}{path}", timeout=10) as r:
+                return r.status, r.read().decode(errors="replace")
+        except urllib.error.HTTPError as e:
+            return e.code, e.read().decode(errors="replace")
+
+    def post_form(self, path: str, fields: dict[str, str]) -> tuple[int, str]:
+        body = urllib.parse.urlencode(fields).encode()
+        req = urllib.request.Request(f"http://{self.ip}{path}", data=body, method="POST")
+        req.add_header("Content-Type", "application/x-www-form-urlencoded")
+        try:
+            with self.opener.open(req, timeout=15) as r:
+                return r.status, r.read().decode(errors="replace")
+        except urllib.error.HTTPError as e:
+            return e.code, e.read().decode(errors="replace")
+
+    def get_json(self, path: str) -> tuple[int, dict]:
+        status, text = self.get(path)
+        try:
+            return status, json.loads(text)
+        except json.JSONDecodeError:
+            return status, {}
+
+    def post_json(self, path: str, payload: dict) -> tuple[int, str]:
+        data = json.dumps(payload).encode()
+        req = urllib.request.Request(f"http://{self.ip}{path}", data=data, method="POST")
+        req.add_header("Content-Type", "application/json")
+        try:
+            with self.opener.open(req, timeout=15) as r:
+                return r.status, r.read().decode(errors="replace")
+        except urllib.error.HTTPError as e:
+            return e.code, e.read().decode(errors="replace")
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+
+
+class Report:
+    def __init__(self) -> None:
+        self.rows: list[tuple[str, bool, str]] = []
+
+    def check(self, name: str, ok: bool, detail: str = "") -> bool:
+        self.rows.append((name, ok, detail))
+        print(f"  [{'PASS' if ok else 'FAIL'}] {name}{f' – {detail}' if detail else ''}", flush=True)
+        return ok
+
+    def skip(self, name: str, why: str) -> None:
+        self.rows.append((name, True, f"SKIPPED: {why}"))
+        print(f"  [SKIP] {name} – {why}", flush=True)
+
+    def failed(self) -> list[str]:
+        return [n for n, ok, _ in self.rows if not ok]
+
+
+# --------------------------------------------------------------------------- #
+# Probes
+# --------------------------------------------------------------------------- #
+
+
+def netdev_exists(ssh_base: list[str], host: str, name: str) -> bool:
+    result = ssh(ssh_base, host, f"ip -o link show {name} 2>/dev/null | wc -l")
+    return result.stdout.strip() not in ("", "0")
+
+
+def iface_address(ssh_base: list[str], host: str, name: str) -> str:
+    result = ssh(ssh_base, host, f"ip -4 -o addr show {name} 2>/dev/null | awk '{{print $4}}'")
+    return result.stdout.strip()
+
+
+def capture_psn(
+    ssh_base: list[str],
+    host: str,
+    nic: str,
+    mcast: str,
+    seconds: int = CAPTURE_SECONDS,
+) -> str:
+    """Return tcpdump's link-level output for PSN traffic on ``nic``.
+
+    ``-e`` prints the ethernet header, which is what carries the 802.1Q tag –
+    without it a tagged and an untagged frame look identical.
+    """
+    cmd = f"sudo timeout {seconds + 2} tcpdump -l -n -e -c 40 -i {nic} host {mcast} 2>/dev/null || true"
+    result = ssh(ssh_base, host, cmd, timeout=seconds + 20)
+    return result.stdout
+
+
+def set_psn_pin(web: Web, iface: str) -> tuple[int, str]:
+    return web.post_json("/api/config/interface_assignment", {"psn_source_iface": iface})
+
+
+def read_psn_pin(web: Web) -> str:
+    _status, data = web.get_json("/api/config/interface_assignment")
+    return str(data.get("psn_source_iface", ""))
+
+
+# --------------------------------------------------------------------------- #
+# Phases
+# --------------------------------------------------------------------------- #
+
+
+def phase_vlan_lifecycle(rep: Report, web: Web, ssh_base: list[str], args, vlan_name: str) -> bool:
+    print("\n[1] VLAN lifecycle")
+    status, body = web.post_form(
+        "/section/network/vlan/create",
+        {"vlan_parent": args.parent, "vlan_id": str(args.vlan_id)},
+    )
+    if not rep.check("create returns 200", status == 200, f"HTTP {status}"):
+        return False
+    if not rep.check(
+        "create reported success",
+        "Created" in body or vlan_name in body,
+        "banner did not confirm creation",
+    ):
+        print(f"      body excerpt: {body[:400]}")
+        return False
+    time.sleep(SETTLE_SECONDS)
+    return rep.check(
+        f"{vlan_name} exists as a netdev on the DUT",
+        netdev_exists(ssh_base, args.dut, vlan_name),
+        "ip link does not show it",
+    )
+
+
+def phase_no_extra_plumbing(rep: Report, web: Web, vlan_name: str) -> None:
+    print("\n[2] A VLAN is an ordinary netdev (no extra plumbing)")
+    _status, card = web.get("/section/network/edit")
+    rep.check(
+        "VLAN appears in the Network Settings list",
+        vlan_name in card,
+        "not in the interface list",
+    )
+    _status, picker = web.get("/network/interfaces/by_name")
+    rep.check(
+        "VLAN is offered as a plane pin",
+        f'value="{vlan_name}"' in picker,
+        "not offered in the interface picker",
+    )
+
+
+def phase_guards(rep: Report, web: Web, args, vlan_name: str) -> None:
+    print("\n[3] Delete guards")
+    _status, body = web.post_form("/section/network/vlan/delete", {"iface": args.parent})
+    rep.check(
+        "deleting a non-VLAN adapter is refused",
+        "is not a VLAN" in body,
+        "the parent NIC was not protected",
+    )
+    _status, body = web.post_form("/section/network/vlan/delete", {"iface": "definitely-not-real"})
+    rep.check(
+        "deleting an unknown adapter is refused",
+        "is not a VLAN" in body,
+        "an unknown name was not rejected",
+    )
+    # The session guard only fires when the browser arrived over the interface
+    # being deleted, which needs the request to come in on the VLAN itself.
+    _status, card = web.get("/section/network/edit")
+    if "This session" in card and vlan_name in card.split("This session")[0][-200:]:
+        _status, body = web.post_form("/section/network/vlan/delete", {"iface": vlan_name})
+        rep.check(
+            "deleting this session's own adapter is refused",
+            "This session is connected over" in body,
+            "the session guard did not fire",
+        )
+    else:
+        rep.skip(
+            "deleting this session's own adapter is refused",
+            "this run did not arrive over the VLAN; re-run with --dut set to the VLAN address",
+        )
+
+
+def phase_traffic_separation(rep: Report, web: Web, ssh_base: list[str], args, vlan_name: str) -> None:
+    print("\n[4] Traffic separation")
+    if not iface_address(ssh_base, args.dut, vlan_name):
+        rep.skip(
+            "PSN leaves tagged on the parent NIC",
+            f"{vlan_name} has no address; give it one in Network Settings first",
+        )
+        rep.skip("PSN does not leak to the other NIC", "no address on the VLAN")
+        return
+
+    status, _body = set_psn_pin(web, vlan_name)
+    if not rep.check("PSN pin accepted", status == 200, f"HTTP {status}"):
+        return
+    time.sleep(SETTLE_SECONDS)
+
+    tagged = capture_psn(ssh_base, args.dut, args.parent, args.psn_mcast)
+    rep.check(
+        "PSN leaves tagged on the parent NIC",
+        f"vlan {args.vlan_id}" in tagged,
+        f"no 802.1Q tag {args.vlan_id} seen on {args.parent}",
+    )
+    if args.other_nic:
+        leaked = capture_psn(ssh_base, args.dut, args.other_nic, args.psn_mcast)
+        rep.check(
+            "PSN does not leak to the other NIC",
+            args.psn_mcast not in leaked,
+            f"PSN frames seen on {args.other_nic} – the pin is not holding",
+        )
+    else:
+        rep.skip("PSN does not leak to the other NIC", "no --other-nic given")
+
+
+def phase_fail_closed(rep: Report, ssh_base: list[str], args, vlan_name: str) -> None:
+    print("\n[5] Fail closed when the pinned interface goes dark")
+    if not iface_address(ssh_base, args.dut, vlan_name):
+        rep.skip("PSN stops rather than moving interface", "the VLAN had no address to lose")
+        return
+    ssh(ssh_base, args.dut, f"sudo nmcli con down {vlan_name} >/dev/null 2>&1 || true")
+    time.sleep(SETTLE_SECONDS)
+    try:
+        nics = [args.parent] + ([args.other_nic] if args.other_nic else [])
+        seen_on = [nic for nic in nics if args.psn_mcast in capture_psn(ssh_base, args.dut, nic, args.psn_mcast)]
+        rep.check(
+            "PSN stops rather than moving interface",
+            not seen_on,
+            f"PSN reappeared on {', '.join(seen_on)} after its pinned interface went down",
+        )
+    finally:
+        ssh(ssh_base, args.dut, f"sudo nmcli con up {vlan_name} >/dev/null 2>&1 || true")
+
+
+def phase_companion(rep: Report, args, vlan_name: str) -> None:
+    print("\n[6] End-to-end delivery at the companion station")
+    if not args.companion:
+        rep.skip("companion receives PSN on the tagged network", "no --companion given")
+        return
+    try:
+        web_b = Web(args.companion, args.pin)
+        status, data = web_b.get_json("/api/info")
+        rep.check(
+            "companion web UI reachable",
+            status == 200 and bool(data),
+            f"HTTP {status}",
+        )
+    except OSError as exc:
+        rep.check("companion web UI reachable", False, str(exc))
+        return
+    rep.skip(
+        "companion receives PSN on the tagged network",
+        "requires the companion on the same tagged VLAN; verify its viewer markers by eye",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Entry point
+# --------------------------------------------------------------------------- #
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--dut", required=True, help="device under test IP")
+    p.add_argument("--companion", default="", help="second station IP (optional)")
+    p.add_argument("--parent", default="eth0", help="physical NIC on the trunk port")
+    p.add_argument("--other-nic", default="", help="a second NIC PSN must NOT appear on")
+    p.add_argument("--vlan-id", type=int, default=10, help="802.1Q tag to create (1-4094)")
+    p.add_argument("--psn-mcast", default="236.10.10.10", help="PSN multicast group")
+    p.add_argument("--ssh-user", default="openfollow")
+    p.add_argument("--ssh-key", default="~/.ssh/id_rsa")
+    p.add_argument("--pin", default="", help="web PIN, if the station has one")
+    args = p.parse_args()
+
+    if not 1 <= args.vlan_id <= 4094:
+        print("--vlan-id must be between 1 and 4094", file=sys.stderr)
+        return 2
+
+    vlan_name = f"{args.parent}.{args.vlan_id}"
+    ssh_base = build_ssh_base(args.ssh_user, args.ssh_key)
+    rep = Report()
+
+    print(f"DUT {args.dut} – creating {vlan_name} on {args.parent}")
+    probe = ssh(ssh_base, args.dut, "true")
+    if probe.returncode != 0:
+        print(f"SSH to {args.dut} failed: {probe.stderr.strip()}", file=sys.stderr)
+        return 2
+    if netdev_exists(ssh_base, args.dut, vlan_name):
+        print(f"{vlan_name} already exists – choose a free --vlan-id so cleanup can't remove a real one.")
+        return 2
+
+    web = Web(args.dut, args.pin)
+    original_pin = read_psn_pin(web)
+    print(f"Original PSN pin: {original_pin or '(auto-detect)'}")
+
+    created = False
+    try:
+        created = phase_vlan_lifecycle(rep, web, ssh_base, args, vlan_name)
+        if created:
+            phase_no_extra_plumbing(rep, web, vlan_name)
+            phase_guards(rep, web, args, vlan_name)
+            phase_traffic_separation(rep, web, ssh_base, args, vlan_name)
+            phase_fail_closed(rep, ssh_base, args, vlan_name)
+            phase_companion(rep, args, vlan_name)
+    finally:
+        print("\n[cleanup]")
+        status, _body = set_psn_pin(web, original_pin)
+        print(f"  PSN pin restored to {original_pin or '(auto-detect)'} (HTTP {status})")
+        if created:
+            status, _body = web.post_form("/section/network/vlan/delete", {"iface": vlan_name})
+            gone = not netdev_exists(ssh_base, args.dut, vlan_name)
+            print(f"  {vlan_name} deleted (HTTP {status}), netdev gone: {gone}")
+            if not gone:
+                print(f"  WARNING: {vlan_name} still present – remove it with: sudo nmcli con delete {vlan_name}")
+
+    failures = rep.failed()
+    print(f"\n{'FAIL' if failures else 'PASS'} – {len(rep.rows) - len(failures)}/{len(rep.rows)} checks passed")
+    for name in failures:
+        print(f"  failed: {name}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hw_validation/vlan_tag_probe.py
+++ b/scripts/hw_validation/vlan_tag_probe.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""Report which 802.1Q tag (if any) a station's traffic leaves an interface with.
+
+Runs **on the device**, as root, with no dependencies – an OpenFollow station
+ships neither ``tcpdump`` nor a pip toolchain, and the offline-runtime contract
+means a validation step cannot assume an uplink to install one.
+
+Tagging is done by the **host**, not the switch: sending via ``eth0.10`` makes
+the kernel add the VLAN header before the frame reaches ``eth0``. So capturing
+on the parent proves the pin is honoured even on an access port, where the
+switch would drop the frame downstream. Only end-to-end delivery to another
+station needs a trunk.
+
+Exit code is 0 when at least one matching frame was seen, 1 when none were –
+so "PSN stopped" and "PSN is flowing" are both assertable from a shell.
+
+    sudo /opt/openfollow/venv/bin/python vlan_tag_probe.py --iface eth0 \\
+        --dst 236.10.10.10 --seconds 6
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import struct
+import sys
+import time
+
+_ETH_P_ALL = 0x0003
+_ETH_P_IP = 0x0800
+_ETH_P_8021Q = 0x8100
+_IPPROTO_UDP = 17
+
+
+def _parse(frame: bytes) -> dict[str, object] | None:
+    """Decode one ethernet frame into ``{vlan, src, dst, sport, dport}``.
+
+    Returns ``None`` for anything that is not IPv4/UDP – including ARP, IPv6
+    and the truncated reads a raw socket can hand back.
+    """
+    if len(frame) < 14:
+        return None
+    ethertype = struct.unpack("!H", frame[12:14])[0]
+    vlan: int | None = None
+    offset = 14
+    if ethertype == _ETH_P_8021Q:
+        if len(frame) < 18:
+            return None
+        # The low 12 bits of the TCI are the VLAN ID; the top 4 are priority
+        # and the drop-eligible bit, which are not part of the identity.
+        vlan = struct.unpack("!H", frame[14:16])[0] & 0x0FFF
+        ethertype = struct.unpack("!H", frame[16:18])[0]
+        offset = 18
+    if ethertype != _ETH_P_IP or len(frame) < offset + 20:
+        return None
+    ihl = (frame[offset] & 0x0F) * 4
+    if frame[offset + 9] != _IPPROTO_UDP or len(frame) < offset + ihl + 8:
+        return None
+    src = socket.inet_ntoa(frame[offset + 12 : offset + 16])
+    dst = socket.inet_ntoa(frame[offset + 16 : offset + 20])
+    sport, dport = struct.unpack("!HH", frame[offset + ihl : offset + ihl + 4])
+    return {"vlan": vlan, "src": src, "dst": dst, "sport": sport, "dport": dport}
+
+
+def capture(iface: str, dst: str, seconds: float, limit: int) -> list[dict[str, object]]:
+    sock = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(_ETH_P_ALL))
+    try:
+        sock.bind((iface, 0))
+        sock.settimeout(0.5)
+        deadline = time.monotonic() + seconds
+        seen: list[dict[str, object]] = []
+        while time.monotonic() < deadline and len(seen) < limit:
+            try:
+                frame = sock.recv(65535)
+            except TimeoutError:
+                continue
+            parsed = _parse(frame)
+            if parsed is not None and (not dst or parsed["dst"] == dst):
+                seen.append(parsed)
+        return seen
+    finally:
+        sock.close()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--iface", required=True, help="interface to capture on (the PARENT, not the VLAN)")
+    p.add_argument("--dst", default="", help="only report frames to this IPv4 destination")
+    p.add_argument("--seconds", type=float, default=6.0)
+    p.add_argument("--limit", type=int, default=40)
+    p.add_argument("--json", action="store_true", help="emit the frame list as JSON")
+    args = p.parse_args()
+
+    try:
+        seen = capture(args.iface, args.dst, args.seconds, args.limit)
+    except PermissionError:
+        print("Raw capture needs root.", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"Capture on {args.iface} failed: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(seen))
+    else:
+        tags = sorted({("untagged" if f["vlan"] is None else f"vlan {f['vlan']}") for f in seen})
+        print(f"frames={len(seen)} tags={', '.join(tags) if tags else '(none)'}")
+        for f in seen[:5]:
+            tag = "untagged" if f["vlan"] is None else f"vlan {f['vlan']}"
+            print(f"  {tag:<10} {f['src']}:{f['sport']} -> {f['dst']}:{f['dport']}")
+    return 0 if seen else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hw_validation/vlan_tag_probe.py
+++ b/scripts/hw_validation/vlan_tag_probe.py
@@ -30,6 +30,18 @@ import sys
 import time
 
 _ETH_P_ALL = 0x0003
+# The kernel lifts an 802.1Q tag out of the frame on the RECEIVE path and hands
+# it over as socket metadata instead, so reading the ethernet header alone finds
+# a tag on egress and nothing on ingress. That asymmetry is why a capture at the
+# receiving station used to report every delivered frame as untagged. Asking for
+# PACKET_AUXDATA gets the tag back (it is what tcpdump reads to print "vlan 10").
+# socket.SOL_PACKET is not exposed by CPython's socket module.
+_SOL_PACKET = 263
+_PACKET_AUXDATA = 8
+_TP_STATUS_VLAN_VALID = 1 << 4
+# struct tpacket_auxdata: 3x u32 then 4x u16.
+_AUXDATA_FMT = "IIIHHHH"
+_AUXDATA_LEN = struct.calcsize(_AUXDATA_FMT)
 _ETH_P_IP = 0x0800
 _ETH_P_8021Q = 0x8100
 _IPPROTO_UDP = 17
@@ -65,21 +77,38 @@ def _parse(frame: bytes) -> dict[str, object] | None:
     return {"vlan": vlan, "src": src, "dst": dst, "sport": sport, "dport": dport}
 
 
+def _auxdata_vlan(ancillary: list[tuple[int, int, bytes]]) -> int | None:
+    """The VLAN id the kernel stripped on ingress, or ``None`` if it stripped none."""
+    for level, cmsg_type, data in ancillary:
+        if level == _SOL_PACKET and cmsg_type == _PACKET_AUXDATA and len(data) >= _AUXDATA_LEN:
+            status, _len, _snap, _mac, _net, tci, _tpid = struct.unpack(_AUXDATA_FMT, data[:_AUXDATA_LEN])
+            if status & _TP_STATUS_VLAN_VALID:
+                return tci & 0x0FFF
+    return None
+
+
 def capture(iface: str, dst: str, seconds: float, limit: int) -> list[dict[str, object]]:
     sock = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(_ETH_P_ALL))
     try:
         sock.bind((iface, 0))
+        try:
+            sock.setsockopt(_SOL_PACKET, _PACKET_AUXDATA, 1)
+        except OSError:  # pragma: no cover - older kernel; egress tags still read
+            pass
         sock.settimeout(0.5)
         deadline = time.monotonic() + seconds
         seen: list[dict[str, object]] = []
         while time.monotonic() < deadline and len(seen) < limit:
             try:
-                frame = sock.recv(65535)
+                frame, ancillary, _flags, _addr = sock.recvmsg(65535, socket.CMSG_SPACE(_AUXDATA_LEN))
             except TimeoutError:
                 continue
             parsed = _parse(frame)
-            if parsed is not None and (not dst or parsed["dst"] == dst):
-                seen.append(parsed)
+            if parsed is None or (dst and parsed["dst"] != dst):
+                continue
+            if parsed["vlan"] is None:
+                parsed["vlan"] = _auxdata_vlan(ancillary)
+            seen.append(parsed)
         return seen
     finally:
         sock.close()

--- a/tests/test_network_adapter_dhcpcd.py
+++ b/tests/test_network_adapter_dhcpcd.py
@@ -9,7 +9,7 @@ import subprocess
 
 import pytest
 
-from openfollow.network.adapter import Ipv4Config, Ipv4Method
+from openfollow.network.adapter import VLAN_UNSUPPORTED_MESSAGE, Ipv4Config, Ipv4Method
 from openfollow.network.dhcpcd_adapter import DhcpcdAdapter
 from tests._fake_broker import FakeBroker, make_failure, make_nonzero
 
@@ -1296,3 +1296,25 @@ class TestMessagesFitTheOnScreenBanner:
         assert self._SECOND_SENTENCE.search("Could not update the file. Nothing was changed.")
         assert not self._SECOND_SENTENCE.search("Could not update /etc/dhcpcd.conf; nothing was changed.")
         assert not self._SECOND_SENTENCE.search("Saved; eth0 is at 192.168.1.5 now.")
+
+class TestVlansUnsupported:
+    """dhcpcd configures addresses on links; it does not create them. The Pi
+    image masks systemd-networkd, so NetworkManager owns link creation."""
+
+    def test_reports_unsupported(self, broker: FakeBroker) -> None:
+        assert DhcpcdAdapter(broker=broker).supports_vlans() is False
+
+    def test_lists_nothing(self, broker: FakeBroker) -> None:
+        assert DhcpcdAdapter(broker=broker).list_vlans() == []
+
+    def test_create_refuses(self, broker: FakeBroker) -> None:
+        result = DhcpcdAdapter(broker=broker).create_vlan("eth0", 10)
+        assert result.ok is False
+        assert result.message == VLAN_UNSUPPORTED_MESSAGE
+        assert broker.calls == []
+
+    def test_delete_refuses(self, broker: FakeBroker) -> None:
+        result = DhcpcdAdapter(broker=broker).delete_vlan("eth0.10")
+        assert result.ok is False
+        assert result.message == VLAN_UNSUPPORTED_MESSAGE
+        assert broker.calls == []

--- a/tests/test_network_adapter_dhcpcd.py
+++ b/tests/test_network_adapter_dhcpcd.py
@@ -1297,6 +1297,7 @@ class TestMessagesFitTheOnScreenBanner:
         assert not self._SECOND_SENTENCE.search("Could not update /etc/dhcpcd.conf; nothing was changed.")
         assert not self._SECOND_SENTENCE.search("Saved; eth0 is at 192.168.1.5 now.")
 
+
 class TestVlansUnsupported:
     """dhcpcd configures addresses on links; it does not create them. The Pi
     image masks systemd-networkd, so NetworkManager owns link creation."""

--- a/tests/test_network_adapter_nm.py
+++ b/tests/test_network_adapter_nm.py
@@ -1156,6 +1156,65 @@ class TestConnectionForActiveLoopFallthrough:
         assert a._connection_for("eth0") is None
 
 
+class TestConnectionLookupSurvivesAColonInTheName:
+    """A colon in a profile name must not hide the profile.
+
+    ``nmcli -t`` escapes it as ``\\:``, and cutting at the first colon puts the
+    device column in the remainder where it can never match - so the profile is
+    invisible to every lookup and ``apply_ipv4`` answers "No NetworkManager
+    connection profile bound to eth0" for an interface that has one. That is
+    the same failure the actionable-message work exists to remove, reached by a
+    different route.
+    """
+
+    def test_active_pass_finds_a_colon_named_profile(self, adapter) -> None:
+        a, _captured, responses = adapter
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"],
+            stdout="Wired connection\\: office:eth0\n",
+        )
+        assert a._connection_for("eth0") == "Wired connection: office"
+
+    def test_fallback_pass_finds_a_colon_named_profile(self, adapter) -> None:
+        a, _captured, responses = adapter
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"],
+            stdout="",
+        )
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show"],
+            stdout="Wired connection\\: office:eth0\n",
+        )
+        assert a._connection_for("eth0") == "Wired connection: office"
+
+    def test_apply_reaches_the_profile_instead_of_reporting_none(self, adapter) -> None:
+        """The operator-visible half: the apply succeeds rather than claiming
+        the interface has no profile."""
+        a, captured, responses = adapter
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"],
+            stdout="Wired connection\\: office:eth0\n",
+        )
+        result = a.apply_ipv4("eth0", Ipv4Config(method=Ipv4Method.DHCP))
+        assert result.ok is True, result.message
+        modify = next(c for c in captured if c[:3] == ["nmcli", "connection", "modify"])
+        assert "Wired connection: office" in modify
+
+    def test_a_short_row_is_ignored(self, adapter) -> None:
+        a, _captured, responses = adapter
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"],
+            stdout="truncated\n",
+        )
+        _set(responses, ["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show"], stdout="")
+        assert a._connection_for("eth0") is None
+
+
 class TestVlans:
     _CONNECTIONS = ["nmcli", "-t", "-f", "NAME,UUID,TYPE,DEVICE", "connection", "show"]
 

--- a/tests/test_network_adapter_nm.py
+++ b/tests/test_network_adapter_nm.py
@@ -8,8 +8,9 @@ import subprocess
 
 import pytest
 
-from openfollow.network.adapter import Ipv4Config, Ipv4Method
+from openfollow.network.adapter import Ipv4Config, Ipv4Method, VlanInterface
 from openfollow.network.nm_adapter import NetworkManagerAdapter
+from openfollow.privilege.capabilities import NETWORK_NM_CON_ADD, NETWORK_NM_CON_DELETE
 from tests._fake_broker import FakeBroker, make_failure
 
 pytestmark = pytest.mark.unit
@@ -1153,3 +1154,182 @@ class TestConnectionForActiveLoopFallthrough:
             stdout="Profile-A:other0\nProfile-B:other1\n",
         )
         assert a._connection_for("eth0") is None
+
+
+class TestVlans:
+    _CONNECTIONS = ["nmcli", "-t", "-f", "NAME,UUID,TYPE,DEVICE", "connection", "show"]
+
+    def _prime(self, responses, stdout: str) -> None:
+        _set(responses, self._CONNECTIONS, stdout=stdout)
+
+    def test_backend_supports_vlans(self, adapter) -> None:
+        a, _captured, _responses = adapter
+        assert a.supports_vlans() is True
+
+    def test_lists_vlans_with_parent_and_id(self, adapter) -> None:
+        a, _captured, responses = adapter
+        self._prime(
+            responses,
+            "Wired connection 1:uuid-eth0:802-3-ethernet:eth0\nvlan10:uuid-v10:vlan:eth0.10\n",
+        )
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "vlan.parent,vlan.id", "connection", "show", "id", "vlan10"],
+            stdout="vlan.parent:eth0\nvlan.id:10\n",
+        )
+        assert a.list_vlans() == [VlanInterface(name="eth0.10", parent="eth0", vlan_id=10)]
+
+    def test_resolves_a_uuid_parent_back_to_an_interface(self, adapter) -> None:
+        """nmcli stores ``vlan.parent`` as either an interface name or the
+        parent profile's UUID. A raw UUID in the parent column would render
+        as gibberish in the interface list."""
+        a, _captured, responses = adapter
+        self._prime(
+            responses,
+            "Wired connection 1:uuid-eth0:802-3-ethernet:eth0\nvlan10:uuid-v10:vlan:eth0.10\n",
+        )
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "vlan.parent,vlan.id", "connection", "show", "id", "vlan10"],
+            stdout="vlan.parent:uuid-eth0\nvlan.id:10\n",
+        )
+        assert a.list_vlans() == [VlanInterface(name="eth0.10", parent="eth0", vlan_id=10)]
+
+    def test_skips_a_profile_with_an_unreadable_id(self, adapter) -> None:
+        a, _captured, responses = adapter
+        self._prime(responses, "vlan10:uuid-v10:vlan:eth0.10\n")
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "vlan.parent,vlan.id", "connection", "show", "id", "vlan10"],
+            stdout="vlan.parent:eth0\nvlan.id:not-a-number\n",
+        )
+        assert a.list_vlans() == []
+
+    def test_skips_a_profile_with_no_device(self, adapter) -> None:
+        a, _captured, responses = adapter
+        self._prime(responses, "vlan10:uuid-v10:vlan:\n")
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "vlan.parent,vlan.id", "connection", "show", "id", "vlan10"],
+            stdout="vlan.parent:eth0\nvlan.id:10\n",
+        )
+        assert a.list_vlans() == []
+
+    def test_ignores_non_vlan_profiles(self, adapter) -> None:
+        a, _captured, responses = adapter
+        self._prime(responses, "Wired connection 1:uuid-eth0:802-3-ethernet:eth0\n")
+        assert a.list_vlans() == []
+
+    def test_create_issues_the_add_argv(self, adapter) -> None:
+        a, captured, _responses = adapter
+        result = a.create_vlan("eth0", 10)
+        assert result.ok is True
+        assert [
+            "nmcli",
+            "connection",
+            "add",
+            "type",
+            "vlan",
+            "con-name",
+            "eth0.10",
+            "ifname",
+            "eth0.10",
+            "dev",
+            "eth0",
+            "id",
+            "10",
+        ] in captured
+
+    def test_create_uses_the_add_capability(self, adapter) -> None:
+        a, _captured, _responses = adapter
+        a.create_vlan("eth0", 10)
+        assert a._broker.calls[-1].capability is NETWORK_NM_CON_ADD
+
+    def test_create_reports_a_broker_failure(self, adapter) -> None:
+        a, _captured, _responses = adapter
+        a._broker.exceptions.append(make_failure("parent device not found"))
+        result = a.create_vlan("eth0", 10)
+        assert result.ok is False
+        assert "parent device not found" in result.message
+
+    def test_delete_issues_the_delete_argv_for_the_bound_profile(self, adapter) -> None:
+        a, captured, responses = adapter
+        self._prime(responses, "vlan10:uuid-v10:vlan:eth0.10\n")
+        result = a.delete_vlan("eth0.10")
+        assert result.ok is True
+        assert ["nmcli", "connection", "delete", "id", "vlan10"] in captured
+
+    def test_delete_uses_the_delete_capability(self, adapter) -> None:
+        a, _captured, responses = adapter
+        self._prime(responses, "vlan10:uuid-v10:vlan:eth0.10\n")
+        a.delete_vlan("eth0.10")
+        assert a._broker.calls[-1].capability is NETWORK_NM_CON_DELETE
+
+    def test_delete_refuses_a_non_vlan_interface(self, adapter) -> None:
+        """``con delete`` is a wildcarded grant, so this is the check that
+        keeps it off a physical NIC's profile."""
+        a, captured, responses = adapter
+        self._prime(responses, "Wired connection 1:uuid-eth0:802-3-ethernet:eth0\n")
+        result = a.delete_vlan("eth0")
+        assert result.ok is False
+        assert "not a VLAN" in result.message
+        assert not any("delete" in argv for argv in captured)
+
+    def test_delete_reports_a_broker_failure(self, adapter) -> None:
+        a, _captured, responses = adapter
+        self._prime(responses, "vlan10:uuid-v10:vlan:eth0.10\n")
+        a._broker.exceptions.append(make_failure("profile is in use"))
+        result = a.delete_vlan("eth0.10")
+        assert result.ok is False
+        assert "profile is in use" in result.message
+
+    def test_profile_list_survives_an_nmcli_failure(self, adapter) -> None:
+        a, _captured, _responses = adapter
+
+        def _boom(argv, *, check=True):
+            raise RuntimeError("nmcli exploded")
+
+        a._run = _boom
+        assert a.list_vlans() == []
+        assert a.delete_vlan("eth0.10").ok is False
+
+    def test_profile_list_skips_short_rows(self, adapter) -> None:
+        a, _captured, responses = adapter
+        self._prime(responses, "truncated:row\n\nvlan10:uuid-v10:vlan:eth0.10\n")
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "vlan.parent,vlan.id", "connection", "show", "id", "vlan10"],
+            stdout="vlan.parent:eth0\nvlan.id:10\n",
+        )
+        assert a.list_vlans() == [VlanInterface(name="eth0.10", parent="eth0", vlan_id=10)]
+
+    def test_skips_a_profile_whose_detail_read_fails(self, adapter) -> None:
+        a, _captured, responses = adapter
+        self._prime(responses, "vlan10:uuid-v10:vlan:eth0.10\n")
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "vlan.parent,vlan.id", "connection", "show", "id", "vlan10"],
+            stdout="",
+            returncode=1,
+        )
+
+        original = a._run
+
+        def _run(argv, *, check=True):
+            result = original(argv, check=False)
+            if check and result.returncode != 0:
+                raise RuntimeError("nmcli failed")
+            return result
+
+        a._run = _run
+        assert a.list_vlans() == []
+
+    def test_skips_a_profile_with_no_parent(self, adapter) -> None:
+        a, _captured, responses = adapter
+        self._prime(responses, "vlan10:uuid-v10:vlan:eth0.10\n")
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "vlan.parent,vlan.id", "connection", "show", "id", "vlan10"],
+            stdout="vlan.parent:\nvlan.id:10\n",
+        )
+        assert a.list_vlans() == []

--- a/tests/test_network_adapter_nm.py
+++ b/tests/test_network_adapter_nm.py
@@ -1259,6 +1259,19 @@ class TestVlans:
         assert result.ok is True
         assert ["nmcli", "connection", "delete", "id", "vlan10"] in captured
 
+    def test_delete_targets_the_matching_profile_not_the_first(self, adapter) -> None:
+        """With several VLANs on one parent, deleting the wrong profile tears
+        down a different network than the operator asked for."""
+        a, captured, responses = adapter
+        self._prime(
+            responses,
+            "vlan10:uuid-v10:vlan:eth0.10\nvlan20:uuid-v20:vlan:eth0.20\n",
+        )
+        result = a.delete_vlan("eth0.20")
+        assert result.ok is True
+        assert ["nmcli", "connection", "delete", "id", "vlan20"] in captured
+        assert ["nmcli", "connection", "delete", "id", "vlan10"] not in captured
+
     def test_delete_uses_the_delete_capability(self, adapter) -> None:
         a, _captured, responses = adapter
         self._prime(responses, "vlan10:uuid-v10:vlan:eth0.10\n")

--- a/tests/test_network_adapter_nm.py
+++ b/tests/test_network_adapter_nm.py
@@ -1215,6 +1215,34 @@ class TestVlans:
         )
         assert a.list_vlans() == []
 
+    def test_a_colon_in_a_profile_name_does_not_shift_the_columns(self, adapter) -> None:
+        """nmcli -t escapes a literal ':' in a value as '\\:'.
+
+        Splitting on every colon shifts each field after a colon-bearing name,
+        so an unrelated profile called "Wired connection: office" poisons the
+        UUID->device map that resolves a VLAN's parent - and a VLAN whose own
+        name contains one drops out of the list entirely, which makes it
+        undeletable from the UI.
+        """
+        a, _captured, responses = adapter
+        self._prime(
+            responses,
+            "Wired connection\\: office:uuid-eth0:802-3-ethernet:eth0\nvlan\\: ten:uuid-v10:vlan:eth0.10\n",
+        )
+        _set(
+            responses,
+            ["nmcli", "-t", "-f", "vlan.parent,vlan.id", "connection", "show", "id", "vlan: ten"],
+            stdout="vlan.parent:uuid-eth0\nvlan.id:10\n",
+        )
+        assert a.list_vlans() == [VlanInterface(name="eth0.10", parent="eth0", vlan_id=10)]
+
+    def test_a_colon_named_vlan_is_still_deletable(self, adapter) -> None:
+        a, captured, responses = adapter
+        self._prime(responses, "vlan\\: ten:uuid-v10:vlan:eth0.10\n")
+        result = a.delete_vlan("eth0.10")
+        assert result.ok is True
+        assert ["nmcli", "connection", "delete", "id", "vlan: ten"] in captured
+
     def test_ignores_non_vlan_profiles(self, adapter) -> None:
         a, _captured, responses = adapter
         self._prime(responses, "Wired connection 1:uuid-eth0:802-3-ethernet:eth0\n")

--- a/tests/test_network_adapter_psutil.py
+++ b/tests/test_network_adapter_psutil.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 import pytest
 
 import openfollow.network.psutil_adapter as psutil_adapter
-from openfollow.network.adapter import Ipv4Config, Ipv4Method
+from openfollow.network.adapter import VLAN_UNSUPPORTED_MESSAGE, Ipv4Config, Ipv4Method
 from openfollow.network.psutil_adapter import PsutilReadOnlyAdapter
 
 pytestmark = pytest.mark.unit
@@ -295,3 +295,23 @@ class TestGetStateInnerErrors:
         state = PsutilReadOnlyAdapter().get_state("eth0")
         assert state is not None
         assert state.ipv4.address is None
+
+
+class TestVlansUnsupported:
+    """psutil reads interfaces, it does not create links."""
+
+    def test_reports_unsupported(self) -> None:
+        assert PsutilReadOnlyAdapter().supports_vlans() is False
+
+    def test_lists_nothing(self) -> None:
+        assert PsutilReadOnlyAdapter().list_vlans() == []
+
+    def test_create_refuses(self) -> None:
+        result = PsutilReadOnlyAdapter().create_vlan("eth0", 10)
+        assert result.ok is False
+        assert result.message == VLAN_UNSUPPORTED_MESSAGE
+
+    def test_delete_refuses(self) -> None:
+        result = PsutilReadOnlyAdapter().delete_vlan("eth0.10")
+        assert result.ok is False
+        assert result.message == VLAN_UNSUPPORTED_MESSAGE

--- a/tests/test_network_validate.py
+++ b/tests/test_network_validate.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 OpenFollow Project
-"""Tests for the IPv4 validation helpers: parse_ipv4/prefix, prefix<->mask, DNS list, router-subnet, validate_apply."""
+"""Tests for the IPv4 validation helpers: parsing, masks, DNS list, router-subnet, validate_apply, VLAN create."""
 
 from __future__ import annotations
 
@@ -12,9 +12,12 @@ from openfollow.network.validate import (
     parse_dns_list,
     parse_ipv4,
     parse_prefix,
+    parse_vlan_id,
     prefix_to_mask,
     router_in_subnet,
     validate_apply,
+    validate_vlan_create,
+    vlan_interface_name,
 )
 
 pytestmark = pytest.mark.unit
@@ -247,3 +250,84 @@ class TestValidateApply:
         # because prefix is out of range.
         assert any("Subnet prefix" in e for e in errors)
         assert not any("not inside the subnet" in e for e in errors)
+
+
+class TestVlanValidation:
+    """VLAN create is the one path that can name a link into existence, so
+    every rejection here is what stops a bad name reaching ``nmcli con add``."""
+
+    _IFACES = ("lo", "eth0", "eth0.10", "wlan0")
+    _VLANS = ("eth0.10",)
+
+    def _errors(self, parent: str, vlan_id: object) -> list[str]:
+        return validate_vlan_create(
+            parent,
+            vlan_id,  # type: ignore[arg-type]
+            interfaces=self._IFACES,
+            vlan_names=self._VLANS,
+        )
+
+    def test_accepts_a_new_vlan_on_a_physical_parent(self) -> None:
+        assert self._errors("eth0", 20) == []
+
+    @pytest.mark.parametrize("vlan_id", [0, 4095, -1, 4096, 100000])
+    def test_rejects_reserved_and_out_of_range_ids(self, vlan_id: int) -> None:
+        assert any("VLAN ID" in e for e in self._errors("eth0", vlan_id))
+
+    @pytest.mark.parametrize("vlan_id", [1, 4094])
+    def test_accepts_the_boundary_ids(self, vlan_id: int) -> None:
+        assert self._errors("eth0", vlan_id) == []
+
+    @pytest.mark.parametrize("vlan_id", ["abc", None, "", True, 12.5, "1e3"])
+    def test_rejects_non_integer_ids(self, vlan_id: object) -> None:
+        assert any("VLAN ID" in e for e in self._errors("eth0", vlan_id))
+
+    def test_accepts_a_digit_string_id(self) -> None:
+        assert self._errors("eth0", "20") == []
+
+    def test_rejects_a_vlan_parent(self) -> None:
+        assert any("stacked" in e for e in self._errors("eth0.10", 20))
+
+    def test_rejects_loopback_parent(self) -> None:
+        assert any("loopback" in e for e in self._errors("lo", 20))
+
+    def test_rejects_unknown_parent(self) -> None:
+        assert any("not a network interface" in e for e in self._errors("eth9", 20))
+
+    def test_rejects_blank_parent(self) -> None:
+        assert any("Choose a parent" in e for e in self._errors("   ", 20))
+
+    def test_rejects_a_duplicate_derived_name(self) -> None:
+        assert any("already exists" in e for e in self._errors("eth0", 10))
+
+    def test_rejects_a_name_over_ifnamsiz(self) -> None:
+        errors = validate_vlan_create(
+            "verylongifname",
+            4094,
+            interfaces=("verylongifname",),
+        )
+        assert any("longer than" in e for e in errors)
+
+    def test_blank_parent_does_not_also_report_a_name_error(self) -> None:
+        """The derived-name checks need a parent to derive from; reporting
+        'the interface name .20 is too long' on top of 'choose a parent'
+        would be noise."""
+        errors = self._errors("", 20)
+        assert errors == ["Choose a parent interface."]
+
+
+class TestVlanInterfaceName:
+    def test_derives_dot_notation(self) -> None:
+        assert vlan_interface_name("eth0", 10) == "eth0.10"
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        assert vlan_interface_name("  eth0  ", 10) == "eth0.10"
+
+
+class TestParseVlanId:
+    @pytest.mark.parametrize(("value", "expected"), [("10", 10), (10, 10), (" 10 ", 10)])
+    def test_accepts_valid(self, value: object, expected: int) -> None:
+        assert parse_vlan_id(value) == expected  # type: ignore[arg-type]
+
+    def test_rejects_bool_which_is_an_int_subclass(self) -> None:
+        assert parse_vlan_id(True) is None

--- a/tests/test_services_startup.py
+++ b/tests/test_services_startup.py
@@ -1180,6 +1180,7 @@ def test_the_outage_flag_clears_after_one_recovery(monkeypatch) -> None:
     assert sync.reopens == 1
     assert server.reopens == 1
 
+
 # VLAN providers / handlers
 # --------------------------------------------------------------------------- #
 

--- a/tests/test_services_startup.py
+++ b/tests/test_services_startup.py
@@ -536,6 +536,11 @@ class _FakeWritableAdapter:
         self._state = state
         self.applied: list = []
         self.renewed: list = []
+        self.vlans: list = []
+        self.vlans_created: list = []
+        self.vlans_deleted: list = []
+        self.vlan_support = True
+        self.vlan_list_raises = False
 
     def list_interfaces(self):
         return list(self._ifaces)
@@ -556,6 +561,26 @@ class _FakeWritableAdapter:
         from openfollow.network.adapter import ApplyResult
 
         self.renewed.append(iface)
+        return ApplyResult(ok=True)
+
+    def supports_vlans(self) -> bool:
+        return self.vlan_support
+
+    def list_vlans(self):
+        if self.vlan_list_raises:
+            raise RuntimeError("nmcli exploded")
+        return list(self.vlans)
+
+    def create_vlan(self, parent, vlan_id):
+        from openfollow.network.adapter import ApplyResult
+
+        self.vlans_created.append((parent, vlan_id))
+        return ApplyResult(ok=True)
+
+    def delete_vlan(self, name):
+        from openfollow.network.adapter import ApplyResult
+
+        self.vlans_deleted.append(name)
         return ApplyResult(ok=True)
 
 
@@ -1154,3 +1179,86 @@ def test_the_outage_flag_clears_after_one_recovery(monkeypatch) -> None:
     services._follow_station_ip()
     assert sync.reopens == 1
     assert server.reopens == 1
+
+# VLAN providers / handlers
+# --------------------------------------------------------------------------- #
+
+
+def test_vlan_provider_reports_unsupported_without_adapter(monkeypatch) -> None:
+    services = _build_services_with_psutil_backend(monkeypatch)
+    services._network_adapter = None
+    assert services._network_vlan_provider() == {"supported": False, "vlans": []}
+
+
+def test_vlan_provider_reports_unsupported_on_a_read_only_backend(monkeypatch) -> None:
+    """The psutil backend reads interfaces; it cannot create links."""
+    services = _build_services_with_psutil_backend(monkeypatch)
+    assert services._network_vlan_provider() == {"supported": False, "vlans": []}
+
+
+def test_vlan_provider_lists_the_backend_vlans(monkeypatch) -> None:
+    from openfollow.network.adapter import VlanInterface
+
+    services = _build_services_with_psutil_backend(monkeypatch)
+    fake = _FakeWritableAdapter([_iface()], None)
+    fake.vlans = [VlanInterface(name="eth0.10", parent="eth0", vlan_id=10)]
+    services._network_adapter = fake
+    assert services._network_vlan_provider() == {
+        "supported": True,
+        "vlans": [{"name": "eth0.10", "parent": "eth0", "vlan_id": 10}],
+    }
+
+
+def test_vlan_provider_survives_a_backend_failure(monkeypatch) -> None:
+    """Still reports supported – the backend does own links, this read just
+    failed – so the card keeps the controls rather than pretending the
+    station cannot do VLANs at all."""
+    services = _build_services_with_psutil_backend(monkeypatch)
+    fake = _FakeWritableAdapter([_iface()], None)
+    fake.vlan_list_raises = True
+    services._network_adapter = fake
+    assert services._network_vlan_provider() == {"supported": True, "vlans": []}
+
+
+def test_vlan_create_calls_the_adapter(monkeypatch) -> None:
+    services = _build_services_with_psutil_backend(monkeypatch)
+    fake = _FakeWritableAdapter([_iface()], None)
+    services._network_adapter = fake
+    result = services._handle_network_vlan_create("eth0", 10)
+    assert result.ok is True
+    assert fake.vlans_created == [("eth0", 10)]
+
+
+def test_vlan_create_refused_on_a_read_only_host(monkeypatch) -> None:
+    services = _build_services_with_psutil_backend(monkeypatch)
+    result = services._handle_network_vlan_create("eth0", 10)
+    assert result.ok is False and "Read-only" in result.message
+
+
+def test_vlan_create_refused_without_adapter(monkeypatch) -> None:
+    services = _build_services_with_psutil_backend(monkeypatch)
+    services._network_adapter = None
+    result = services._handle_network_vlan_create("eth0", 10)
+    assert result.ok is False and "No network adapter" in result.message
+
+
+def test_vlan_delete_calls_the_adapter(monkeypatch) -> None:
+    services = _build_services_with_psutil_backend(monkeypatch)
+    fake = _FakeWritableAdapter([_iface()], None)
+    services._network_adapter = fake
+    result = services._handle_network_vlan_delete("eth0.10")
+    assert result.ok is True
+    assert fake.vlans_deleted == ["eth0.10"]
+
+
+def test_vlan_delete_refused_on_a_read_only_host(monkeypatch) -> None:
+    services = _build_services_with_psutil_backend(monkeypatch)
+    result = services._handle_network_vlan_delete("eth0.10")
+    assert result.ok is False and "Read-only" in result.message
+
+
+def test_vlan_delete_refused_without_adapter(monkeypatch) -> None:
+    services = _build_services_with_psutil_backend(monkeypatch)
+    services._network_adapter = None
+    result = services._handle_network_vlan_delete("eth0.10")
+    assert result.ok is False and "No network adapter" in result.message

--- a/tests/test_web_network_write.py
+++ b/tests/test_web_network_write.py
@@ -985,6 +985,7 @@ def test_a_pending_apply_still_shows_its_warnings(net_server) -> None:
     assert "take effect when eth0 has a link" in body
     assert "rebind refused" in body, "the pending banner dropped its warnings"
 
+
 # --------------------------------------------------------------------------- #
 # VLAN create / delete
 # --------------------------------------------------------------------------- #

--- a/tests/test_web_network_write.py
+++ b/tests/test_web_network_write.py
@@ -76,6 +76,12 @@ class FakeNetwork:
         self.apply_result = ApplyResult(ok=True)
         self.renew_result = ApplyResult(ok=True)
         self.provide_rows = True
+        self.supports_vlans = True
+        self.vlans: list[dict] = []
+        self.vlans_created: list[tuple[str, int]] = []
+        self.vlans_deleted: list[str] = []
+        self.vlan_create_result = ApplyResult(ok=True, message="Created.")
+        self.vlan_delete_result = ApplyResult(ok=True, message="Deleted.")
 
     def config_provider(self, iface: str | None = None) -> dict | None:
         if not self.interfaces:
@@ -128,6 +134,17 @@ class FakeNetwork:
     def renew_handler(self, iface: str) -> ApplyResult:
         self.renewed.append(iface)
         return self.renew_result
+
+    def vlan_provider(self) -> dict:
+        return {"supported": self.supports_vlans, "vlans": list(self.vlans)}
+
+    def vlan_create_handler(self, parent: str, vlan_id: int) -> ApplyResult:
+        self.vlans_created.append((parent, vlan_id))
+        return self.vlan_create_result
+
+    def vlan_delete_handler(self, name: str) -> ApplyResult:
+        self.vlans_deleted.append(name)
+        return self.vlan_delete_result
 
 
 def _find_free_tcp_port() -> int:
@@ -202,6 +219,9 @@ def net_server(tmp_path, monkeypatch):
         network_interfaces_provider=fake.interfaces_provider,
         network_apply_handler=fake.apply_handler,
         network_renew_handler=fake.renew_handler,
+        network_vlan_provider=fake.vlan_provider,
+        network_vlan_create_handler=fake.vlan_create_handler,
+        network_vlan_delete_handler=fake.vlan_delete_handler,
     )
     server.start()
     assert _wait_for_port(port)
@@ -964,3 +984,231 @@ def test_a_pending_apply_still_shows_its_warnings(net_server) -> None:
     assert status == 200
     assert "take effect when eth0 has a link" in body
     assert "rebind refused" in body, "the pending banner dropped its warnings"
+
+# --------------------------------------------------------------------------- #
+# VLAN create / delete
+# --------------------------------------------------------------------------- #
+
+
+def test_add_vlan_control_only_in_edit_mode(net_server) -> None:
+    """Creating a link is a write, so it follows the same Edit-mode gate as
+    every other write on this card."""
+    _fake, base = net_server
+    _status, view = _get(base, "/section/network/status")
+    assert "+ Add VLAN" not in view
+    _status, edit = _get(base, "/section/network/edit")
+    assert "+ Add VLAN" in edit
+
+
+def test_add_vlan_control_absent_on_a_backend_without_vlans(net_server) -> None:
+    fake, base = net_server
+    fake.supports_vlans = False
+    _status, body = _get(base, "/section/network/edit")
+    assert "+ Add VLAN" not in body
+    assert "/section/network/vlan/create" not in body
+
+
+def test_vlan_rows_carry_their_tag(net_server) -> None:
+    fake, base = net_server
+    fake.interfaces = ["eth0", "eth0.10"]
+    fake.vlans = [{"name": "eth0.10", "parent": "eth0", "vlan_id": 10}]
+    _status, body = _get(base, "/section/network/edit")
+    assert "VLAN 10" in body
+
+
+def test_a_vlan_is_not_offered_as_a_parent(net_server) -> None:
+    """QinQ is out of scope, so a VLAN can't parent another one."""
+    fake, base = net_server
+    fake.interfaces = ["eth0", "eth0.10"]
+    fake.vlans = [{"name": "eth0.10", "parent": "eth0", "vlan_id": 10}]
+    _status, body = _get(base, "/section/network/edit")
+    parent_block = body.split('name="vlan_parent"', 1)[1].split("</select>", 1)[0]
+    assert "eth0" in parent_block
+    assert "eth0.10" not in parent_block
+
+
+def test_create_passes_parent_and_id_to_the_adapter(net_server) -> None:
+    fake, base = net_server
+    status, _body = _post(base, "/section/network/vlan/create", {"vlan_parent": "eth0", "vlan_id": "10"})
+    assert status == 200
+    assert fake.vlans_created == [("eth0", 10)]
+
+
+def test_create_rejects_a_reserved_id_without_calling_the_adapter(net_server) -> None:
+    fake, base = net_server
+    status, body = _post(base, "/section/network/vlan/create", {"vlan_parent": "eth0", "vlan_id": "4095"})
+    assert status == 200
+    assert "VLAN ID must be" in body
+    assert fake.vlans_created == []
+
+
+def test_create_rejects_an_unknown_parent_without_calling_the_adapter(net_server) -> None:
+    fake, base = net_server
+    status, body = _post(base, "/section/network/vlan/create", {"vlan_parent": "eth9", "vlan_id": "10"})
+    assert status == 200
+    assert "not a network interface" in body
+    assert fake.vlans_created == []
+
+
+def test_create_rejects_a_duplicate_name_without_calling_the_adapter(net_server) -> None:
+    fake, base = net_server
+    fake.interfaces = ["eth0", "eth0.10"]
+    fake.vlans = [{"name": "eth0.10", "parent": "eth0", "vlan_id": 10}]
+    status, body = _post(base, "/section/network/vlan/create", {"vlan_parent": "eth0", "vlan_id": "10"})
+    assert status == 200
+    assert "already exists" in body
+    assert fake.vlans_created == []
+
+
+def test_create_refused_on_a_backend_without_vlans(net_server) -> None:
+    fake, base = net_server
+    fake.supports_vlans = False
+    status, body = _post(base, "/section/network/vlan/create", {"vlan_parent": "eth0", "vlan_id": "10"})
+    assert status == 200
+    assert "cannot create VLAN interfaces" in body
+    assert fake.vlans_created == []
+
+
+def test_create_surfaces_an_adapter_failure(net_server) -> None:
+    fake, base = net_server
+    fake.vlan_create_result = ApplyResult(ok=False, message="parent device not found")
+    status, body = _post(base, "/section/network/vlan/create", {"vlan_parent": "eth0", "vlan_id": "10"})
+    assert status == 200
+    assert "parent device not found" in body
+
+
+def test_delete_passes_the_interface_to_the_adapter(net_server) -> None:
+    fake, base = net_server
+    fake.interfaces = ["eth0", "eth0.10"]
+    fake.vlans = [{"name": "eth0.10", "parent": "eth0", "vlan_id": 10}]
+    status, _body = _post(base, "/section/network/vlan/delete", {"iface": "eth0.10"})
+    assert status == 200
+    assert fake.vlans_deleted == ["eth0.10"]
+
+
+def test_delete_refuses_a_non_vlan_interface(net_server) -> None:
+    """The delete grant is a wildcarded ``nmcli con delete``, so the app layer
+    is what keeps it off a physical NIC's profile."""
+    fake, base = net_server
+    status, body = _post(base, "/section/network/vlan/delete", {"iface": "eth0"})
+    assert status == 200
+    assert "is not a VLAN" in body
+    assert fake.vlans_deleted == []
+
+
+def test_delete_refuses_an_unknown_interface(net_server) -> None:
+    fake, base = net_server
+    status, body = _post(base, "/section/network/vlan/delete", {"iface": "eth9.10"})
+    assert status == 200
+    assert "is not a VLAN" in body
+    assert fake.vlans_deleted == []
+
+
+def test_delete_refused_on_a_backend_without_vlans(net_server) -> None:
+    fake, base = net_server
+    fake.supports_vlans = False
+    status, body = _post(base, "/section/network/vlan/delete", {"iface": "eth0.10"})
+    assert status == 200
+    assert "cannot create VLAN interfaces" in body
+    assert fake.vlans_deleted == []
+
+
+def test_delete_surfaces_an_adapter_failure(net_server) -> None:
+    fake, base = net_server
+    fake.interfaces = ["eth0", "eth0.10"]
+    fake.vlans = [{"name": "eth0.10", "parent": "eth0", "vlan_id": 10}]
+    fake.vlan_delete_result = ApplyResult(ok=False, message="profile is in use")
+    status, body = _post(base, "/section/network/vlan/delete", {"iface": "eth0.10"})
+    assert status == 200
+    assert "profile is in use" in body
+
+
+def test_delete_control_only_renders_for_a_vlan_row(net_server) -> None:
+    """The control lives inside the open editor so it can only ever be aimed
+    at the interface named in that editor's header."""
+    fake, base = net_server
+    fake.interfaces = ["eth0", "eth0.10"]
+    fake.vlans = [{"name": "eth0.10", "parent": "eth0", "vlan_id": 10}]
+    _status, physical = _get(base, "/section/network/edit/eth0")
+    assert "Delete VLAN" not in physical
+    _status, vlan = _get(base, "/section/network/edit/eth0.10")
+    assert "Delete VLAN" in vlan
+
+
+def test_delete_refuses_the_interface_serving_this_request(net_server, monkeypatch) -> None:
+    """Deleting the interface the browser arrived on cuts the operator's own
+    session, and the page they would need to undo it is the one that just
+    became unreachable. The test server binds loopback, where
+    ``request_local_iface`` correctly reports no interface, so that single
+    seam is patched to stand in for a real NIC connection."""
+    import openfollow.web.routes as routes_module
+
+    fake, base = net_server
+    fake.interfaces = ["eth0", "eth0.10"]
+    fake.vlans = [{"name": "eth0.10", "parent": "eth0", "vlan_id": 10}]
+    monkeypatch.setattr(routes_module, "request_local_iface", lambda _environ: "eth0.10")
+    status, body = _post(base, "/section/network/vlan/delete", {"iface": "eth0.10"})
+    assert status == 200
+    assert "This session is connected over eth0.10" in body
+    assert fake.vlans_deleted == []
+
+
+def test_delete_allows_a_vlan_this_request_did_not_arrive_on(net_server, monkeypatch) -> None:
+    import openfollow.web.routes as routes_module
+
+    fake, base = net_server
+    fake.interfaces = ["eth0", "eth0.10", "eth0.20"]
+    fake.vlans = [
+        {"name": "eth0.10", "parent": "eth0", "vlan_id": 10},
+        {"name": "eth0.20", "parent": "eth0", "vlan_id": 20},
+    ]
+    monkeypatch.setattr(routes_module, "request_local_iface", lambda _environ: "eth0.10")
+    status, _body = _post(base, "/section/network/vlan/delete", {"iface": "eth0.20"})
+    assert status == 200
+    assert fake.vlans_deleted == ["eth0.20"]
+
+
+def test_get_network_vlans_without_provider_reports_unsupported(tmp_path) -> None:
+    srv = _make_server(tmp_path)
+    assert srv.get_network_vlans() == {"supported": False, "vlans": []}
+
+
+def test_get_network_vlans_swallows_provider_error(tmp_path) -> None:
+    """A failed read must not leave the card offering controls whose backend
+    just proved it can't answer."""
+
+    def _boom():
+        raise RuntimeError("provider down")
+
+    srv = _make_server(tmp_path, network_vlan_provider=_boom)
+    assert srv.get_network_vlans() == {"supported": False, "vlans": []}
+
+
+def test_create_network_vlan_without_handler_is_unavailable(tmp_path) -> None:
+    srv = _make_server(tmp_path)
+    result = srv.create_network_vlan("eth0", 10)
+    assert result.ok is False and "not available" in result.message
+
+
+def test_create_network_vlan_swallows_handler_error(tmp_path) -> None:
+    def _boom(parent, vlan_id):
+        raise RuntimeError("kaboom")
+
+    srv = _make_server(tmp_path, network_vlan_create_handler=_boom)
+    result = srv.create_network_vlan("eth0", 10)
+    assert result.ok is False and "kaboom" in result.message
+
+
+def test_delete_network_vlan_without_handler_is_unavailable(tmp_path) -> None:
+    srv = _make_server(tmp_path)
+    result = srv.delete_network_vlan("eth0.10")
+    assert result.ok is False and "not available" in result.message
+
+
+def test_delete_network_vlan_swallows_handler_error(tmp_path) -> None:
+    def _boom(name):
+        raise RuntimeError("kaboom")
+
+    srv = _make_server(tmp_path, network_vlan_delete_handler=_boom)
+    result = srv.delete_network_vlan("eth0.10")
+    assert result.ok is False and "kaboom" in result.message

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -6362,3 +6362,29 @@ def test_section_broadcast_receive_does_not_carry_or_clobber_speeds(tmp_path, mo
         assert reloaded.marker_move_speeds == {5: 1.0}
     finally:
         server.stop()
+
+
+def test_vlan_subinterface_is_offered_as_a_plane_pin(live_server, monkeypatch) -> None:
+    """A VLAN needs no plumbing beyond creating the link: once eth0.10 exists
+    it is an ordinary netdev, so it reaches the interface pickers through the
+    same psutil enumeration every other adapter uses. This is the claim the
+    VLAN work rests on – if it breaks, tagged VLANs stop being assignable
+    while every other test still passes."""
+    import socket as _socket
+    from types import SimpleNamespace
+
+    from openfollow import net_utils as net_utils_mod
+
+    monkeypatch.setattr(
+        net_utils_mod.psutil,
+        "net_if_addrs",
+        lambda: {
+            "eth0": [SimpleNamespace(family=_socket.AF_INET, address="192.168.178.59")],
+            "eth0.10": [SimpleNamespace(family=_socket.AF_INET, address="10.20.0.5")],
+        },
+    )
+    _, base = live_server
+    status, body = _get(base, "/network/interfaces/by_name")
+    assert status == 200
+    assert 'value="eth0.10"' in body
+    assert "eth0.10 – 10.20.0.5" in body

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -6365,25 +6365,35 @@ def test_section_broadcast_receive_does_not_carry_or_clobber_speeds(tmp_path, mo
 
 
 def test_vlan_subinterface_is_offered_as_a_plane_pin(live_server, monkeypatch) -> None:
-    """A VLAN needs no plumbing beyond creating the link: once eth0.10 exists
-    it is an ordinary netdev, so it reaches the interface pickers through the
-    same psutil enumeration every other adapter uses. This is the claim the
-    VLAN work rests on – if it breaks, tagged VLANs stop being assignable
-    while every other test still passes."""
+    """A VLAN needs no plumbing beyond creating the link and addressing it.
+
+    Once eth0.10 has an IPv4 it is an ordinary netdev and reaches the interface
+    pickers through the same psutil enumeration every other adapter uses - the
+    claim the VLAN work rests on. The unaddressed half is asserted too: the
+    pickers list interfaces that HAVE an address, so a freshly created VLAN is
+    deliberately not selectable until Configure gives it one. Hardware
+    validation found that ordering, which an addressed-only test hides.
+    """
     import socket as _socket
     from types import SimpleNamespace
 
     from openfollow import net_utils as net_utils_mod
 
-    monkeypatch.setattr(
-        net_utils_mod.psutil,
-        "net_if_addrs",
-        lambda: {
-            "eth0": [SimpleNamespace(family=_socket.AF_INET, address="192.168.178.59")],
-            "eth0.10": [SimpleNamespace(family=_socket.AF_INET, address="10.20.0.5")],
-        },
-    )
+    def _addrs(vlan_address: str | None):
+        rows = {"eth0": [SimpleNamespace(family=_socket.AF_INET, address="192.168.178.59")]}
+        # An unaddressed VLAN still exists as a netdev; psutil reports it with
+        # no AF_INET entry, which is exactly the state right after Create.
+        rows["eth0.10"] = [SimpleNamespace(family=_socket.AF_INET, address=vlan_address)] if vlan_address else []
+        return rows
+
     _, base = live_server
+
+    monkeypatch.setattr(net_utils_mod.psutil, "net_if_addrs", lambda: _addrs(None))
+    status, body = _get(base, "/network/interfaces/by_name")
+    assert status == 200
+    assert 'value="eth0.10"' not in body
+
+    monkeypatch.setattr(net_utils_mod.psutil, "net_if_addrs", lambda: _addrs("10.20.0.5"))
     status, body = _get(base, "/network/interfaces/by_name")
     assert status == 200
     assert 'value="eth0.10"' in body


### PR DESCRIPTION
PR 3 of the stacked work for #50, on top of #65 and #66 which are now on `main`.

## Why this is likely how the feature gets used

Many venues deliver **one** Ethernet run carrying tagged 802.1Q VLANs rather
than a separate cable per network. Pinning planes by interface name already
makes those sub-interfaces assignable for free - `eth0.10` is just another
interface name. What was missing was any way to *create* them without an SSH
session, which put the most likely deployment shape behind a terminal.

## Assignment needed no work at all

A VLAN sub-interface is an ordinary netdev. Once `eth0.10` exists,
`psutil.net_if_addrs()` reports it, `list_iface_ipv4()` returns it,
`/network/interfaces/by_name` offers it, and every Interface Assignment row can
pin to it - with zero changes to anything #65 or #66 shipped. Addressing it runs
through the existing `apply_ipv4` path unchanged, including the link-local
fallback from #66, which matters because a tagged lighting VLAN frequently has
no DHCP server.

That claim is the thing worth breaking, so it has its own regression test:
a VLAN name flowing through `list_iface_ipv4` to a pinnable dropdown entry. If
tagged VLANs ever stop being assignable, that test goes red while everything
else still passes.

**All the new work is creating and removing the links.**

## Guards live in the app layer, not sudo

`nmcli con add` / `con delete` have to be wildcarded because the profile name is
operator-influenced. The narrowing is therefore in the route:

- refuse to delete anything that is not a VLAN, so `con delete` can never be
  aimed at a physical NIC's profile;
- refuse to delete the interface the request arrived on. The page an operator
  would need to undo that deletion is the page it just made unreachable.

Both yield an actionable message rather than a bare sudo failure, and the threat
model here is a web user holding the PIN rather than someone with shell access.
`Delete VLAN` also lives *inside* the open editor, so the UI can only ever aim it
at the interface named in that editor's header.

## One bug found while writing the tests

`parse_vlan_id` accepted a float and a bool. `int(12.5)` is `12`, and `bool` is
an `int` subclass, so either would have quietly created a VLAN on a different tag
than the one submitted - stage traffic on the wrong network. Both are now
rejected outright rather than coerced, mirroring the Unicode-digit guard
`parse_prefix` already had.

## Scope

- No QinQ: a VLAN cannot parent another VLAN. Loopback is not offered either.
- NetworkManager only. psutil reads interfaces, dhcpcd configures addresses on
  links rather than creating them, and the Pi image masks `systemd-networkd`. The
  trait defaults to unsupported so a backend has to opt in rather than inherit a
  broken implementation; on a non-NM stack the card renders exactly as #65 left it.
- `ApplyResult.pending` is on #68, not `main`, so the saved-but-not-activated case
  reports through `partial_failures` for now. Small follow-up if #68 lands.

## Verification

`make ci-remote` green: lint, mypy, bandit, 1044 tests, coverage 100%, build clean.
No Pi was reachable, so it ran on the Mac.

The three guards were mutation-checked - removing each one turns its test red -
because reviews on this stack have repeatedly turned up tests that passed no
matter what the code did.

**No hardware validation yet.** `scripts/hw_validation/multi_interface_two_station.py`
is here for it: it creates a VLAN from the web UI, asserts it becomes a pinnable
netdev, exercises both delete guards, then checks the two things no fake-socket
test can reach - that PSN leaves *tagged* on the pinned NIC and never appears on
another, and that it **stops** rather than relocating when its interface goes
down. Checks it cannot run report as skipped rather than passing, so a run
without a trunk port can't be mistaken for a clean result.