### PR TITLE
feat(net): name USB network adapters after their MAC

### DIFF
--- a/openfollow/web/help/general-interface-assignment.md
+++ b/openfollow/web/help/general-interface-assignment.md
@@ -26,6 +26,16 @@ The **address** is allowed to change. If the interface is on DHCP and comes back
 
 **PSN in / out** and **Discovery / marker sync** always follow the station interface and are shown read-only. They carry this station's identity on the network – the address other stations and consoles see it at – so splitting them from the station default would mean the box advertised one address and answered on another.
 
+## USB Ethernet adapters
+
+A USB adapter is named after its own hardware address, so it appears as something like `enx88a29edf04e3` rather than `eth1`. The name is long, but it belongs to that one physical adapter and stays the same wherever it is plugged in and whatever else is fitted.
+
+That matters because a plain `eth1` is handed out in the order adapters are found at boot, not by which adapter it is. With two fitted, `eth1` and `eth2` can trade places after a restart, and since a pin stores the name, the function would carry on sending to a name that now means the other adapter. Nothing looks wrong in that state, which is why the naming is worth the ugliness.
+
+Replacing a failed adapter gives you a new name, so re-pick the affected rows. A row pinned to an adapter that is no longer present stops and says so rather than moving to another one.
+
+A newly plugged adapter keeps whatever name it already had until it is unplugged and back in, or the station restarts.
+
 ## Saving
 
 Save applies immediately to the running station. PSN, OTP, and the other data planes rebind their sockets in place – no restart, and no interruption to anything on an interface you didn't change.

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -309,6 +309,11 @@ install -m 0644 "$DEBIAN_DIR/nm-wait-online-timeout.conf" \
 install -d -m 0755 "$STAGE/etc/NetworkManager/conf.d"
 install -m 0644 "$DEBIAN_DIR/nm-dhcp-fallback.conf" \
   "$STAGE/etc/NetworkManager/conf.d/10-openfollow-dhcp-fallback.conf"
+# Stable names for USB network adapters, so a pin cannot follow probe order onto
+# the wrong NIC (see the .link header).
+install -d -m 0755 "$STAGE/etc/systemd/network"
+install -m 0644 "$DEBIAN_DIR/usb-net-by-mac.link" \
+  "$STAGE/etc/systemd/network/72-openfollow-usb-net-by-mac.link"
 install -m 0644 "$DEBIAN_DIR/copyright"                          "$DOC_DIR/copyright"
 
 # --- control + maintainer scripts --------------------------------------------
@@ -324,6 +329,7 @@ done
 # conffile means an operator who tuned the DHCP timeout keeps that value across
 # an upgrade instead of having it silently replaced.
 printf '%s\n' /etc/NetworkManager/conf.d/10-openfollow-dhcp-fallback.conf \
+                /etc/systemd/network/72-openfollow-usb-net-by-mac.link \
   > "$STAGE/DEBIAN/conffiles"
 
 # --- build --------------------------------------------------------------------

--- a/packaging/debian/usb-net-by-mac.link
+++ b/packaging/debian/usb-net-by-mac.link
@@ -1,0 +1,21 @@
+# Name a USB network adapter after its MAC so the name cannot move.
+#
+# Kernel ethN names are handed out in probe order, not by device identity, so a
+# station with two adapters fitted can swap eth1 and eth2 across a reboot. Every
+# network plane here pins an interface by NAME, and both names still resolve
+# after a swap - so the pin binds cleanly to the wrong adapter and stage data
+# leaves on the wrong network with nothing to show for it. It is the one case
+# the fail-closed rule cannot catch, because nothing is down.
+#
+# Matched by driver rather than by USB path: on Pi 3 and Zero the ONBOARD NIC is
+# USB-attached (smsc95xx / lan78xx), so a path match would rename eth0 there and
+# dangle every pin an operator already has. Neither driver is listed below, and
+# no Pi's onboard NIC uses one that is.
+#
+# Naming applies when the device appears, so an adapter already plugged in keeps
+# its old name until the next replug or reboot.
+[Match]
+Driver=r8152 ax88179_178a asix ax88172a aqc111 cdc_ether cdc_ncm cdc_eem rndis_host smsc75xx sr9700 sr9800 dm9601 mcs7830 pegasus
+
+[Link]
+NamePolicy=mac

--- a/packaging/image/layer/openfollow.yaml
+++ b/packaging/image/layer/openfollow.yaml
@@ -97,6 +97,23 @@ mmdebstrap:
       ipv4.link-local=4
       NMFALLBACK
 
+    # 2a2. Name USB network adapters after their MAC. Kernel ethN names follow
+    #      probe order, not device identity, so two adapters can swap across a
+    #      reboot - and because a plane pins an interface by name and both names
+    #      still resolve, the swap moves stage data onto the wrong network with
+    #      nothing down to notice. Matched by driver, not USB path: the onboard
+    #      NIC is USB-attached on Pi 3 / Zero and must keep the name eth0.
+    - |-
+      set -eu
+      mkdir -p "$1/etc/systemd/network"
+      cat > "$1/etc/systemd/network/72-openfollow-usb-net-by-mac.link" <<'USBNETLINK'
+      [Match]
+      Driver=r8152 ax88179_178a asix ax88172a aqc111 cdc_ether cdc_ncm cdc_eem rndis_host smsc75xx sr9700 sr9800 dm9601 mcs7830 pegasus
+
+      [Link]
+      NamePolicy=mac
+      USBNETLINK
+
     # 2b. Enable lingering for openfollow so /run/user/<uid> exists at boot before
     #     login – the Cage kiosk session needs XDG_RUNTIME_DIR. The deb postinst
     #     tries `loginctl enable-linger` but that no-ops in a chroot (no logind);

--- a/scripts/ansible/install-raspberry-pi.yml
+++ b/scripts/ansible/install-raspberry-pi.yml
@@ -451,6 +451,26 @@
       notify:
         - reload networkmanager
 
+    # Kernel ethN names follow probe order, not device identity, so two USB
+    # adapters can swap across a reboot. A plane pins an interface by name and
+    # both names still resolve after a swap, so it would bind the wrong adapter
+    # with nothing down to notice. Matched by driver, not USB path: the onboard
+    # NIC is USB-attached on Pi 3 / Zero and has to keep the name eth0.
+    - name: Name USB network adapters after their MAC so a pin cannot move
+      ansible.builtin.copy:
+        dest: /etc/systemd/network/72-openfollow-usb-net-by-mac.link
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          [Match]
+          Driver=r8152 ax88179_178a asix ax88172a aqc111 cdc_ether cdc_ncm cdc_eem rndis_host smsc75xx sr9700 sr9800 dm9601 mcs7830 pegasus
+
+          [Link]
+          NamePolicy=mac
+      notify:
+        - reload udev
+
     - name: Mask getty on tty1
       ansible.builtin.systemd:
         name: getty@tty1.service

--- a/tests/test_usb_nic_naming_provisioning.py
+++ b/tests/test_usb_nic_naming_provisioning.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""Provisioning contract for stable USB network adapter names.
+
+Kernel ``ethN`` names are handed out in probe order, not by device identity, so
+a station with two USB adapters can swap ``eth1`` and ``eth2`` across a reboot.
+Every network plane pins an interface by *name*, and after a swap both names
+still resolve - so the pin binds cleanly to the wrong adapter and stage data
+leaves on the wrong network. It is the one case the fail-closed rule cannot
+catch, because nothing is down. Naming an adapter after its MAC removes the
+ordering entirely, and like the DHCP fallback it is provisioning: nothing in the
+running app may rewrite an operator's network configuration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import openfollow
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(openfollow.__file__).resolve().parent.parent
+_LINK_NAME = "72-openfollow-usb-net-by-mac.link"
+
+_SOURCES = {
+    "image layer": _REPO_ROOT / "packaging" / "image" / "layer" / "openfollow.yaml",
+    "ansible playbook": _REPO_ROOT / "scripts" / "ansible" / "install-raspberry-pi.yml",
+    "deb link file": _REPO_ROOT / "packaging" / "debian" / "usb-net-by-mac.link",
+    "deb build script": _REPO_ROOT / "packaging" / "build-deb.sh",
+}
+
+# Routes carrying the rule itself; the build script only installs it.
+_BLOCK_SOURCES = ("image layer", "ansible playbook", "deb link file")
+_INSTALLING_SOURCES = ("image layer", "ansible playbook", "deb build script")
+
+# The onboard NIC is USB-attached on Pi 3 and Zero. Matching those drivers would
+# rename eth0 on those boards and dangle every pin an operator already has.
+_ONBOARD_USB_DRIVERS = ("smsc95xx", "lan78xx")
+
+
+def _read(name: str) -> str:
+    path = _SOURCES[name]
+    if not path.is_file():
+        pytest.skip(f"no checkout {path.name} (wheel install)")
+    return path.read_text(encoding="utf-8")
+
+
+def _matched_drivers(name: str) -> set[str]:
+    """The drivers the rule actually matches.
+
+    Read off the ``Driver=`` line rather than the file, because the comment
+    above it names the onboard drivers precisely to say they are excluded - a
+    substring search over the whole text cannot tell the two apart.
+    """
+    for line in _read(name).splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Driver="):
+            return set(stripped.removeprefix("Driver=").split())
+    return set()
+
+
+@pytest.mark.parametrize("name", sorted(_INSTALLING_SOURCES))
+def test_every_install_route_ships_the_link_file(name: str) -> None:
+    """A route that skips it leaves that install method exposed to the reorder
+    while the others are safe - the hardest kind of gap to notice, because it
+    only shows up as data on the wrong network."""
+    assert _LINK_NAME in _read(name)
+
+
+@pytest.mark.parametrize("name", sorted(_BLOCK_SOURCES))
+def test_routes_name_adapters_by_mac(name: str) -> None:
+    assert "NamePolicy=mac" in _read(name)
+
+
+@pytest.mark.parametrize("name", sorted(_BLOCK_SOURCES))
+def test_matched_by_driver_not_by_usb_path(name: str) -> None:
+    """A ``Path=*-usb-*`` match would also catch the onboard NIC on the boards
+    where it hangs off USB. Driver matching is what keeps eth0 called eth0."""
+    assert _matched_drivers(name)
+    assert "Path=*-usb-*" not in _read(name)
+
+
+@pytest.mark.parametrize("name", sorted(_BLOCK_SOURCES))
+@pytest.mark.parametrize("driver", _ONBOARD_USB_DRIVERS)
+def test_onboard_usb_nic_drivers_are_never_matched(name: str, driver: str) -> None:
+    """Renaming the onboard NIC would break every existing ``eth0`` pin on a
+    Pi 3 / Zero, and the operator would meet it as a plane that stopped."""
+    assert driver not in _matched_drivers(name)
+
+
+@pytest.mark.parametrize("name", sorted(_BLOCK_SOURCES))
+def test_the_usual_adapter_chipsets_are_covered(name: str) -> None:
+    """The drivers behind the adapters an operator is likely to buy. One that is
+    missing gets ordering-dependent names back without any signal."""
+    matched = _matched_drivers(name)
+    for driver in ("r8152", "ax88179_178a", "asix", "cdc_ether"):
+        assert driver in matched
+
+
+def test_deb_declares_the_link_file_as_a_conffile() -> None:
+    """An operator who adjusted the match list keeps it across an upgrade."""
+    text = _read("deb build script")
+    assert "DEBIAN/conffiles" in text
+    assert f"/etc/systemd/network/{_LINK_NAME}" in text
+
+
+def test_nothing_renames_an_interface_at_runtime() -> None:
+    """The app must never rewrite a station's network configuration while it is
+    running. Stable naming is provisioning, and only provisioning."""
+    for module in ("network/nm_adapter.py", "network/adapter.py", "network/dhcpcd_adapter.py", "services.py"):
+        text = (_REPO_ROOT / "openfollow" / module).read_text(encoding="utf-8")
+        assert "NamePolicy" not in text
+        assert _LINK_NAME not in text


### PR DESCRIPTION
Stacked on #72. Sibling of #67 / #68 / #70.

## The problem

Kernel `ethN` names are handed out in **probe order, not by device identity**. A station with two USB Ethernet adapters fitted can swap `eth1` and `eth2` across a reboot.

Every network plane in this project pins an interface **by name**. After a swap both names still resolve, so the pin binds cleanly to the *wrong* adapter and stage data leaves on the wrong network. This is the one case the fail-closed rule cannot catch: nothing is down, nothing errors, and the Interface Assignment panel shows a perfectly healthy row.

That is precisely the outcome the whole design exists to prevent - PSN quietly appearing on the office LAN is worse than PSN stopping.

## The fix

Name USB adapters after their MAC (`enx88a29edf04e3`), which belongs to one physical adapter and does not move. Ships as **provisioning** across all three install routes, never as a runtime rewrite of an operator's network configuration - same rule the DHCP fallback follows.

## Matched by driver, not by USB path

The stock `73-usb-net-by-mac.link` matches `Path=*-usb-*`. On **Pi 3 and Zero the onboard NIC is USB-attached** (`smsc95xx` / `lan78xx`), so that match would rename `eth0` on those boards and dangle every pin an operator already has. Matching on driver avoids it, and no Pi's onboard NIC uses a driver on the list.

Verified on a Pi 5: the onboard NIC reports `driver=macb` and `ID_PATH=platform-1f00100000.ethernet`, so the rule does not touch it.

## Trade-off

The pickers now show a long `enx…` name for USB adapters. The help drawer explains why that is the better trade, and that replacing a failed adapter means re-picking the rows that pinned it (a pin to an adapter that is gone stops and says so, which is correct).

Naming applies when a device appears, so an adapter already plugged in keeps its old name until a replug or restart.

## Not covered here

This closes the realistic case. It does not close the general one - an unusual driver, a hand-edited `config.toml`, or an adapter swapped for a different model still leave a pin pointing at a name whose hardware changed. Recording the MAC alongside the pin and failing closed on a mismatch is tracked separately.

## Testing

`tests/test_usb_nic_naming_provisioning.py` pins the contract: every install route ships the rule, all three agree on `NamePolicy=mac`, the match is by driver and never `Path=*-usb-*`, the onboard USB drivers are never in the match list, the usual adapter chipsets are, the deb declares it a conffile, and nothing in the app renames an interface at runtime.

The onboard-driver guard reads the `Driver=` line rather than the file text, because the comment above it names those drivers precisely to say they are excluded.

`make ci-remote` green, 100% coverage.

**Not hardware-verified:** no USB adapter on the bench. The reorder is inferred from `ethN` being probe-ordered; the driver/path facts above are measured on a Pi 5.