### PR TITLE
fix(catalog): chunk marker-catalog beacons so large catalogs still sync

### DIFF
--- a/openfollow/configuration.py
+++ b/openfollow/configuration.py
@@ -2270,7 +2270,10 @@ class AppConfig:
         # startup ``init_psn`` / ``init_otp`` broadcast the same value.
         if not isinstance(self.psn_system_name, str):
             self.psn_system_name = _DEFAULT_PSN_SYSTEM_NAME
-        self.psn_system_name = self.psn_system_name.strip() or _DEFAULT_PSN_SYSTEM_NAME
+        # Cap to match the ``psn_system_name`` FieldRule: a hand-edited TOML
+        # must not bypass the bound the web form enforces, and the value sizes
+        # the marker-catalog beacon envelope.
+        self.psn_system_name = self.psn_system_name.strip()[:64] or _DEFAULT_PSN_SYSTEM_NAME
         # Normalise the Media Gallery selection: a hand-edited non-string (or a
         # blank) must never reach ``media_store.resolve`` / ``re.match`` – which
         # raise ``TypeError`` on a non-string and would crash pipeline build and

--- a/openfollow/marker_catalog/catalog.py
+++ b/openfollow/marker_catalog/catalog.py
@@ -45,17 +45,20 @@ _DEFAULT_COLOR = "#ffffff"
 _MAX_VERSION = 2**63 - 1
 # Cap the origin (a station id, normally a ~36-char UUID).
 _ORIGIN_MAX_LEN = 128
+# Cap the display name. A bounded name is what lets the sync layer guarantee
+# every entry fits inside one sub-MTU beacon chunk.
+_NAME_MAX_LEN = 64
 
 
-def _sanitize_origin(value: object) -> str:
-    """Coerce origin to a printable, length-capped station id.
+def _sanitize_text(value: object, max_len: int) -> str:
+    """Coerce ``value`` to a printable, length-capped string.
 
     Single choke point shared by the dataclass, the loader, and the sync
     receiver so disk and wire enforce the same contract.
     """
     if not isinstance(value, str):
         return ""
-    return "".join(ch for ch in value if ch.isprintable())[:_ORIGIN_MAX_LEN]
+    return "".join(ch for ch in value if ch.isprintable())[:max_len]
 
 
 @dataclass
@@ -81,8 +84,7 @@ class MarkerEntry:
             raise ValueError("MarkerEntry.id must be int")
         if self.id < 1:
             raise ValueError("MarkerEntry.id must be >= 1")
-        if not isinstance(self.name, str):
-            self.name = ""
+        self.name = _sanitize_text(self.name, _NAME_MAX_LEN)
         self.color = _coerce_hex_color(self.color, _DEFAULT_COLOR)
         try:
             self.updated_at = float(self.updated_at)
@@ -100,7 +102,7 @@ class MarkerEntry:
             self.version = 0
         elif self.version > _MAX_VERSION:
             self.version = _MAX_VERSION
-        self.origin = _sanitize_origin(self.origin)
+        self.origin = _sanitize_text(self.origin, _ORIGIN_MAX_LEN)
 
 
 def _entry_rank(entry: MarkerEntry) -> tuple[int, float, str]:

--- a/openfollow/marker_catalog/catalog.py
+++ b/openfollow/marker_catalog/catalog.py
@@ -327,6 +327,14 @@ def load_catalog(path: str) -> MarkerCatalog:
         except ValueError:
             logger.warning("markers.toml: dropping invalid entry %r", raw)
             continue
+        raw_name = raw.get("name")
+        if isinstance(raw_name, str) and entry.name != raw_name:
+            logger.warning(
+                "markers.toml: marker %d name shortened to %d characters (was %d).",
+                entry.id,
+                len(entry.name),
+                len(raw_name),
+            )
         catalog._entries[entry.id] = entry
     # Resume the logical clock above every persisted version so edits after a
     # restart keep out-ranking what's on disk (and what peers still hold).

--- a/openfollow/marker_catalog/sync.py
+++ b/openfollow/marker_catalog/sync.py
@@ -191,7 +191,7 @@ def _fit_envelope(
     *,
     kind: str,
     station_id: str,
-    station_name: str,
+    station_name: object,
     controlled_ids: list[int],
     viewer_ids: list[int],
 ) -> tuple[str, list[int], list[int], bool]:
@@ -205,10 +205,13 @@ def _fit_envelope(
     catalog from syncing. Returns the fitted parts and whether anything was cut.
     """
     limit = _MAX_TX_PACKET - _MIN_ENTRY_BUDGET
+    # The name comes from a caller-supplied provider, so it is sanitised rather
+    # than trusted: a non-string return degrades to "" instead of raising out of
+    # the send loop, which only recovers from OSError.
     name = _sanitize_text(station_name, _STATION_NAME_MAX_LEN)
     controlled = list(controlled_ids)
     viewer = list(viewer_ids)
-    trimmed = len(name) != len(station_name)
+    trimmed = name != station_name
 
     def envelope_len() -> int:
         return len(

--- a/openfollow/marker_catalog/sync.py
+++ b/openfollow/marker_catalog/sync.py
@@ -20,9 +20,11 @@ this station + bright-fox") – it's never applied as a remote write.
 
 from __future__ import annotations
 
+import bisect
 import errno
 import json
 import logging
+import math
 import socket
 import threading
 import time
@@ -58,10 +60,11 @@ _MAX_RX_PACKET = 60 * 1024
 _MAX_TX_PACKET = 1400
 # ``json.dumps`` writes ", " between array items.
 _JSON_ITEM_SEPARATOR_LEN = 2
-# Bound the per-heartbeat burst. The full-catalog resend is the amplification
-# vector: tombstones are never collected, and any peer can insert entries we
-# then rebroadcast. Chunks past the cap ride the next heartbeat instead.
+# Chunks per heartbeat; the rest ride the following beats.
 _MAX_HEARTBEAT_CHUNKS = 8
+# Bytes the envelope must leave for entries, so a large selection can never
+# squeeze the catalog out of its own beacon.
+_MIN_ENTRY_BUDGET = 400
 _CHUNK_LOG_INTERVAL = 30.0
 
 _TRANSIENT_SEND_ERRNOS: frozenset[int] = frozenset(
@@ -155,11 +158,12 @@ def _chunk_entries(
 ) -> tuple[list[list[MarkerEntry]], list[int]]:
     """Split ``entries`` into groups whose JSON array body fits ``budget`` bytes.
 
-    ``budget`` is the room the beacon shell leaves for the array contents: each
-    entry's serialised size plus the separator between items. Also returns the
-    ids of entries too large to fit a group on their own - unreachable while
-    :class:`MarkerEntry` bounds ``name`` and ``origin``, but kept so one
-    outsized entry can never stall the rest of the catalog.
+    ``budget`` is the room the beacon envelope leaves for the array contents:
+    each entry's serialised size plus the separator between items. Also returns
+    the ids of entries too large to fit a group on their own: ``MarkerEntry``
+    bounds ``name`` and ``origin`` in code points, but ``json.dumps`` escapes
+    non-ASCII to 6-12 bytes apiece, so a bounded entry can still outgrow a whole
+    datagram. Reporting them keeps one outsized entry from stalling the rest.
     """
     chunks: list[list[MarkerEntry]] = []
     skipped: list[int] = []
@@ -181,6 +185,54 @@ def _chunk_entries(
     if current:
         chunks.append(current)
     return chunks, skipped
+
+
+def _fit_envelope(
+    *,
+    kind: str,
+    station_id: str,
+    station_name: str,
+    controlled_ids: list[int],
+    viewer_ids: list[int],
+) -> tuple[str, list[int], list[int], bool]:
+    """Shrink the beacon envelope until it leaves ``_MIN_ENTRY_BUDGET`` for entries.
+
+    The envelope is as unbounded as the entry array was: a station viewing every
+    marker on the LAN serialises hundreds of ids, which would otherwise crowd the
+    catalog out of its own beacon or push the empty-entries shell past the cap and
+    drop the beacon outright. Selection is display-only, so trimming ids (then the
+    station name) degrades a peer's "controlled by" list rather than stopping the
+    catalog from syncing. Returns the fitted parts and whether anything was cut.
+    """
+    limit = _MAX_TX_PACKET - _MIN_ENTRY_BUDGET
+    name = _sanitize_text(station_name, _STATION_NAME_MAX_LEN)
+    controlled = list(controlled_ids)
+    viewer = list(viewer_ids)
+    trimmed = len(name) != len(station_name)
+
+    def envelope_len() -> int:
+        return len(
+            _build_beacon(
+                kind=kind,
+                station_id=station_id,
+                station_name=name,
+                controlled_ids=controlled,
+                viewer_ids=viewer,
+                entries=[],
+            )
+        )
+
+    # One pop per iteration, but only for selections far larger than any real
+    # station's - a typical envelope clears the limit on the first check.
+    while envelope_len() > limit:
+        if viewer or controlled:
+            (viewer if len(viewer) >= len(controlled) else controlled).pop()
+        elif name:
+            name = name[: len(name) * 3 // 4]
+        else:
+            break  # station_id alone busts the limit; caller drops the beacon
+        trimmed = True
+    return name, controlled, viewer, trimmed
 
 
 def _parse_beacon(data: bytes) -> dict[str, object] | None:
@@ -249,11 +301,12 @@ class MarkerCatalogSync:
         # below _PEER_CAP_LOG_INTERVAL at boot, which 0.0 would suppress for ~30s
         # during a startup flood. Mirrors web.discovery.
         self._peer_cap_log_ts = float("-inf")
-        # Send-thread only – rotating window start when the catalog needs more
-        # than ``_MAX_HEARTBEAT_CHUNKS`` datagrams.
-        self._heartbeat_chunk_offset = 0
+        # Send-thread only. Highest id sent by the last heartbeat; the next one
+        # resumes above it when the catalog needs more than one burst.
+        self._heartbeat_cursor_id = 0
         self._rotation_log_ts = float("-inf")
         self._unchunkable_log_ts = float("-inf")
+        self._envelope_log_ts = float("-inf")
 
     # -- Public API ----------------------------------------------------------
 
@@ -326,7 +379,7 @@ class MarkerCatalogSync:
                 "rotating the window so every entry still reaches peers within %.0fs.",
                 total_chunks,
                 _MAX_HEARTBEAT_CHUNKS,
-                (total_chunks / _MAX_HEARTBEAT_CHUNKS) * HEARTBEAT_INTERVAL,
+                math.ceil(total_chunks / _MAX_HEARTBEAT_CHUNKS) * HEARTBEAT_INTERVAL,
             )
             self._rotation_log_ts = now
 
@@ -341,6 +394,17 @@ class MarkerCatalogSync:
                 ", ".join(str(i) for i in ids[:10]),
             )
             self._unchunkable_log_ts = now
+
+    def _note_envelope_trim(self) -> None:
+        """Log that the selection had to be cut to leave room for entries."""
+        now = time.monotonic()
+        if (now - self._envelope_log_ts) >= _CHUNK_LOG_INTERVAL:
+            logger.warning(
+                "MarkerCatalogSync: selection too large for a %d-byte beacon; "
+                "trimming the ids peers display so the catalog still syncs.",
+                _MAX_TX_PACKET,
+            )
+            self._envelope_log_ts = now
 
     # -- Send path ------------------------------------------------------------
 
@@ -435,9 +499,10 @@ class MarkerCatalogSync:
     ) -> None:
         """Emit ``entries`` as one or more sub-MTU beacons.
 
-        A mid-burst ``OSError`` propagates to the caller (which rebuilds the
-        socket and backs off); the undelivered chunks simply ride the next
-        heartbeat.
+        A mid-burst ``OSError`` propagates to the caller, which rebuilds the
+        socket and backs off. Undelivered heartbeat chunks are retried from the
+        same cursor next beat; a failed delta is lost until a heartbeat happens
+        to carry those ids, which is why the cursor only advances on success.
         """
         try:
             station_name = self._station_name_provider()
@@ -447,8 +512,15 @@ class MarkerCatalogSync:
             controlled, viewer = self._selection_provider()
         except Exception:
             controlled, viewer = [], []
-        controlled_ids = list(controlled)
-        viewer_ids = list(viewer)
+        station_name, controlled_ids, viewer_ids, trimmed = _fit_envelope(
+            kind=kind,
+            station_id=self._station_id,
+            station_name=station_name,
+            controlled_ids=list(controlled),
+            viewer_ids=list(viewer),
+        )
+        if trimmed:
+            self._note_envelope_trim()
 
         def build(chunk: list[MarkerEntry]) -> bytes:
             return _build_beacon(
@@ -462,8 +534,8 @@ class MarkerCatalogSync:
 
         shell = build([])
         if len(shell) > _MAX_TX_PACKET:
-            # Nothing to split: the envelope alone busts the cap. Truncating
-            # JSON would only wire-poison peers with an unparseable packet.
+            # Irreducible envelope – only a station_id past the cap gets here.
+            # Truncating JSON would wire-poison peers with an unparseable packet.
             logger.error(
                 "MarkerCatalogSync: %s envelope alone is %d bytes, over the %d-byte cap; dropping beacon.",
                 kind,
@@ -472,30 +544,36 @@ class MarkerCatalogSync:
             )
             return
 
-        chunks, skipped = _chunk_entries(entries, _MAX_TX_PACKET - len(shell))
+        ordered = self._heartbeat_order(entries) if kind == "heartbeat" else entries
+        chunks, skipped = _chunk_entries(ordered, _MAX_TX_PACKET - len(shell))
         if skipped:
             self._note_unchunkable(skipped)
         if kind == "heartbeat" and len(chunks) > _MAX_HEARTBEAT_CHUNKS:
-            chunks = self._rotate_heartbeat_chunks(chunks)
+            self._note_chunk_rotation(len(chunks))
+            chunks = chunks[:_MAX_HEARTBEAT_CHUNKS]
         if not chunks:
             # No entries (or none sendable) – the selection still has to reach peers.
             chunks = [[]]
         for chunk in chunks:
             sock.sendto(build(chunk), (CATALOG_MCAST_GROUP, CATALOG_PORT))
+        if kind == "heartbeat" and chunks[-1]:
+            # Only after the whole burst lands, so a mid-burst failure retries
+            # these entries next beat instead of skipping past them.
+            self._heartbeat_cursor_id = chunks[-1][-1].id
 
-    def _rotate_heartbeat_chunks(
-        self,
-        chunks: list[list[MarkerEntry]],
-    ) -> list[list[MarkerEntry]]:
-        """Take a ``_MAX_HEARTBEAT_CHUNKS``-wide window, advancing it each
-        heartbeat so entries past the cap still reach peers within a few cycles.
+    def _heartbeat_order(self, entries: list[MarkerEntry]) -> list[MarkerEntry]:
+        """Rotate ``entries`` to resume above the last id the previous beat sent.
+
+        Keyed on the id rather than a chunk index so that adding or removing
+        markers between beats reshuffles chunk boundaries without starving the
+        entries the window was about to reach.
         """
-        total = len(chunks)
-        start = self._heartbeat_chunk_offset % total
-        window = [chunks[(start + i) % total] for i in range(_MAX_HEARTBEAT_CHUNKS)]
-        self._heartbeat_chunk_offset = (start + _MAX_HEARTBEAT_CHUNKS) % total
-        self._note_chunk_rotation(total)
-        return window
+        if not entries:
+            return entries
+        start = bisect.bisect_right([e.id for e in entries], self._heartbeat_cursor_id)
+        if start >= len(entries):
+            return entries  # cursor past the end: wrap to the start
+        return entries[start:] + entries[:start]
 
     def _handle_send_error(
         self,
@@ -610,11 +688,11 @@ class MarkerCatalogSync:
             if self._catalog.merge_entry(entry):
                 changed.append(entry.id)
         # Rate ceiling: on_change fires synchronously on the recv thread once
-        # per heartbeat that merges any change, so a peer toggling updated_at
-        # every heartbeat couples inbound multicast to the callback's cost
-        # (the app persists, fsync + atomic rename). Writes are serialized and
-        # atomic; a persistence consumer that wants to decouple should debounce
-        # on its side (the send path already debounces deltas).
+        # per *datagram* that merges any change - so up to _MAX_HEARTBEAT_CHUNKS
+        # times per peer heartbeat while a station converges on a large catalog,
+        # each costing the app a persist (fsync + atomic rename). Writes are
+        # serialized and atomic; a persistence consumer that wants to decouple
+        # should debounce on its side (the send path already debounces deltas).
         if changed and self._on_change is not None:
             try:
                 self._on_change(changed)

--- a/openfollow/marker_catalog/sync.py
+++ b/openfollow/marker_catalog/sync.py
@@ -9,6 +9,11 @@ the full catalog plus its own selection (controlled / viewer ids);
 on local catalog edit, a smaller "delta" beacon is queued and
 flushed after a short debounce.
 
+A catalog too large for one sub-MTU datagram is split across several
+beacons. Entries merge independently and idempotently on the receiver,
+so every chunk is a complete beacon in its own right - there is no
+sequencing and no reassembly.
+
 Selection is broadcast purely for UI display ("controlled by:
 this station + bright-fox") – it's never applied as a remote write.
 """
@@ -24,7 +29,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
-from openfollow.marker_catalog.catalog import MarkerCatalog, MarkerEntry
+from openfollow.marker_catalog.catalog import MarkerCatalog, MarkerEntry, _sanitize_text
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +54,15 @@ _SEND_ERROR_BACKOFF = HEARTBEAT_INTERVAL
 
 # Reject packets larger than 60KB to prevent receive buffer exhaustion.
 _MAX_RX_PACKET = 60 * 1024
+# Stay under a typical MTU so a beacon is never IP-fragmented on multicast.
 _MAX_TX_PACKET = 1400
+# ``json.dumps`` writes ", " between array items.
+_JSON_ITEM_SEPARATOR_LEN = 2
+# Bound the per-heartbeat burst. The full-catalog resend is the amplification
+# vector: tombstones are never collected, and any peer can insert entries we
+# then rebroadcast. Chunks past the cap ride the next heartbeat instead.
+_MAX_HEARTBEAT_CHUNKS = 8
+_CHUNK_LOG_INTERVAL = 30.0
 
 _TRANSIENT_SEND_ERRNOS: frozenset[int] = frozenset(
     {
@@ -136,6 +149,40 @@ def _build_beacon(
     return json.dumps(payload).encode("utf-8")
 
 
+def _chunk_entries(
+    entries: list[MarkerEntry],
+    budget: int,
+) -> tuple[list[list[MarkerEntry]], list[int]]:
+    """Split ``entries`` into groups whose JSON array body fits ``budget`` bytes.
+
+    ``budget`` is the room the beacon shell leaves for the array contents: each
+    entry's serialised size plus the separator between items. Also returns the
+    ids of entries too large to fit a group on their own - unreachable while
+    :class:`MarkerEntry` bounds ``name`` and ``origin``, but kept so one
+    outsized entry can never stall the rest of the catalog.
+    """
+    chunks: list[list[MarkerEntry]] = []
+    skipped: list[int] = []
+    current: list[MarkerEntry] = []
+    used = 0
+    for entry in entries:
+        size = len(json.dumps(_entry_to_dict(entry)).encode("utf-8"))
+        if size > budget:
+            skipped.append(entry.id)
+            continue
+        extra = size if not current else size + _JSON_ITEM_SEPARATOR_LEN
+        if used + extra > budget:
+            chunks.append(current)
+            current = [entry]
+            used = size
+            continue
+        current.append(entry)
+        used += extra
+    if current:
+        chunks.append(current)
+    return chunks, skipped
+
+
 def _parse_beacon(data: bytes) -> dict[str, object] | None:
     """Parse an untrusted datagram. Returns ``None`` on any malformed input."""
     if len(data) > _MAX_RX_PACKET:
@@ -162,20 +209,6 @@ def _coerce_id_list(value: object) -> list[int]:
             continue
         out.append(v)
     return out
-
-
-def _sanitize_text(value: object, max_len: int) -> str:
-    """Coerce ``value`` to a printable, length-capped string.
-
-    Mirrors :func:`web.discovery._sanitize_beacon_text`: non-string input
-    becomes ``""``, control characters are dropped (so an untrusted station_id
-    / station_name can't inject terminal escapes or newlines into the web UI),
-    and the result is capped at ``max_len`` to bound per-entry memory.
-    """
-    if not isinstance(value, str):
-        return ""
-    cleaned = "".join(ch for ch in value if ch.isprintable())
-    return cleaned[:max_len]
 
 
 class MarkerCatalogSync:
@@ -216,6 +249,11 @@ class MarkerCatalogSync:
         # below _PEER_CAP_LOG_INTERVAL at boot, which 0.0 would suppress for ~30s
         # during a startup flood. Mirrors web.discovery.
         self._peer_cap_log_ts = float("-inf")
+        # Send-thread only – rotating window start when the catalog needs more
+        # than ``_MAX_HEARTBEAT_CHUNKS`` datagrams.
+        self._heartbeat_chunk_offset = 0
+        self._rotation_log_ts = float("-inf")
+        self._unchunkable_log_ts = float("-inf")
 
     # -- Public API ----------------------------------------------------------
 
@@ -278,6 +316,31 @@ class MarkerCatalogSync:
                 MAX_PEER_SELECTIONS,
             )
             self._peer_cap_log_ts = now
+
+    def _note_chunk_rotation(self, total_chunks: int) -> None:
+        """Log that the catalog outgrew one heartbeat's chunk budget."""
+        now = time.monotonic()
+        if (now - self._rotation_log_ts) >= _CHUNK_LOG_INTERVAL:
+            logger.warning(
+                "MarkerCatalogSync: catalog needs %d beacons but a heartbeat sends %d; "
+                "rotating the window so every entry still reaches peers within %.0fs.",
+                total_chunks,
+                _MAX_HEARTBEAT_CHUNKS,
+                (total_chunks / _MAX_HEARTBEAT_CHUNKS) * HEARTBEAT_INTERVAL,
+            )
+            self._rotation_log_ts = now
+
+    def _note_unchunkable(self, ids: list[int]) -> None:
+        """Log entries too large to fit a beacon of their own."""
+        now = time.monotonic()
+        if (now - self._unchunkable_log_ts) >= _CHUNK_LOG_INTERVAL:
+            logger.error(
+                "MarkerCatalogSync: %d entr(y/ies) too large for a %d-byte beacon; not sent to peers (ids: %s).",
+                len(ids),
+                _MAX_TX_PACKET,
+                ", ".join(str(i) for i in ids[:10]),
+            )
+            self._unchunkable_log_ts = now
 
     # -- Send path ------------------------------------------------------------
 
@@ -370,6 +433,12 @@ class MarkerCatalogSync:
         kind: str,
         entries: list[MarkerEntry],
     ) -> None:
+        """Emit ``entries`` as one or more sub-MTU beacons.
+
+        A mid-burst ``OSError`` propagates to the caller (which rebuilds the
+        socket and backs off); the undelivered chunks simply ride the next
+        heartbeat.
+        """
         try:
             station_name = self._station_name_provider()
         except Exception:
@@ -378,40 +447,55 @@ class MarkerCatalogSync:
             controlled, viewer = self._selection_provider()
         except Exception:
             controlled, viewer = [], []
-        data = _build_beacon(
-            kind=kind,
-            station_id=self._station_id,
-            station_name=station_name,
-            controlled_ids=list(controlled),
-            viewer_ids=list(viewer),
-            entries=entries,
-        )
-        if len(data) > _MAX_TX_PACKET:
-            # Don't truncate JSON; send selection-only beacon instead.
-            fallback = _build_beacon(
+        controlled_ids = list(controlled)
+        viewer_ids = list(viewer)
+
+        def build(chunk: list[MarkerEntry]) -> bytes:
+            return _build_beacon(
                 kind=kind,
                 station_id=self._station_id,
                 station_name=station_name,
-                controlled_ids=list(controlled),
-                viewer_ids=list(viewer),
-                entries=[],
+                controlled_ids=controlled_ids,
+                viewer_ids=viewer_ids,
+                entries=chunk,
             )
+
+        shell = build([])
+        if len(shell) > _MAX_TX_PACKET:
+            # Nothing to split: the envelope alone busts the cap. Truncating
+            # JSON would only wire-poison peers with an unparseable packet.
             logger.error(
-                "MarkerCatalogSync: %s payload %d bytes exceeds %d-byte cap; "
-                "sending selection-only beacon (chunked entry beacons deferred).",
+                "MarkerCatalogSync: %s envelope alone is %d bytes, over the %d-byte cap; dropping beacon.",
                 kind,
-                len(data),
+                len(shell),
                 _MAX_TX_PACKET,
             )
-            if len(fallback) > _MAX_TX_PACKET:
-                # Selection-only shell still too big; drop beacon.
-                logger.error(
-                    "MarkerCatalogSync: selection-only fallback also %d bytes; dropping beacon.",
-                    len(fallback),
-                )
-                return
-            data = fallback
-        sock.sendto(data, (CATALOG_MCAST_GROUP, CATALOG_PORT))
+            return
+
+        chunks, skipped = _chunk_entries(entries, _MAX_TX_PACKET - len(shell))
+        if skipped:
+            self._note_unchunkable(skipped)
+        if kind == "heartbeat" and len(chunks) > _MAX_HEARTBEAT_CHUNKS:
+            chunks = self._rotate_heartbeat_chunks(chunks)
+        if not chunks:
+            # No entries (or none sendable) – the selection still has to reach peers.
+            chunks = [[]]
+        for chunk in chunks:
+            sock.sendto(build(chunk), (CATALOG_MCAST_GROUP, CATALOG_PORT))
+
+    def _rotate_heartbeat_chunks(
+        self,
+        chunks: list[list[MarkerEntry]],
+    ) -> list[list[MarkerEntry]]:
+        """Take a ``_MAX_HEARTBEAT_CHUNKS``-wide window, advancing it each
+        heartbeat so entries past the cap still reach peers within a few cycles.
+        """
+        total = len(chunks)
+        start = self._heartbeat_chunk_offset % total
+        window = [chunks[(start + i) % total] for i in range(_MAX_HEARTBEAT_CHUNKS)]
+        self._heartbeat_chunk_offset = (start + _MAX_HEARTBEAT_CHUNKS) % total
+        self._note_chunk_rotation(total)
+        return window
 
     def _handle_send_error(
         self,

--- a/openfollow/web/help/marker-control-visibility.md
+++ b/openfollow/web/help/marker-control-visibility.md
@@ -4,10 +4,10 @@ Defines which markers exist in the show and how this station drives and displays
 
 ## Shared catalog
 
-A live table of every marker, synced to all stations within a few seconds of saving. Each row:
+A live table of every marker, synced to all stations within a few seconds of saving. Very large catalogs (roughly 55 markers and up) sync in batches, so the last of them can take a few heartbeats longer to appear on every station. Each row:
 
 - **ID** – numeric identifier (integer ≥ 1) that receivers see on PSN, OSC, OTP, and RTTrPM. Match your console's numbering.
-- **Name** – a human-readable label for the interface; not sent on the PSN wire.
+- **Name** – a human-readable label for the interface, up to 64 characters; longer names are shortened when saved. Not sent on the PSN wire.
 - **Color** – the marker's swatch on the Operator Screen and web UI; click it to open the picker. The add-row suggests the first unused palette colour.
 - **Controlled by / Viewed by** – read-only: which stations currently claim control or view. A ⚠ and red row highlight flag a control conflict (more than one station controlling the same marker); resolve it in each station's selection table.
 - **Save** / **Delete** (per row) – commit a row's name/colour, or remove the marker from all stations (after a confirmation prompt).

--- a/openfollow/web/templates/partials/marker.tpl
+++ b/openfollow/web/templates/partials/marker.tpl
@@ -332,7 +332,7 @@
         // polls as diff renderer reuses row node).
         tr.innerHTML =
             '<td data-cell="id"></td>' +
-            '<td><input type="text" data-field="name"></td>' +
+            '<td><input type="text" data-field="name" maxlength="64"></td>' +
             '<td><button type="button" class="color-swatch-trigger" data-field="color" ' +
                 'data-color-picker="full" aria-label="Marker colour"></button></td>' +
             '<td class="cell-soft" data-cell="controlled-by"></td>' +
@@ -411,7 +411,7 @@
         // Add-row status span reports duplicate / success / error.
         tr.innerHTML =
             '<td><input type="number" min="1" id="new-marker-id" style="width: 4rem;"></td>' +
-            '<td><input type="text" id="new-marker-name"></td>' +
+            '<td><input type="text" id="new-marker-name" maxlength="64"></td>' +
             '<td><button type="button" class="color-swatch-trigger" id="new-marker-color" ' +
                 'data-color-picker="full" aria-label="New marker colour"></button></td>' +
             '<td colspan="2"><span id="add-marker-feedback" class="add-feedback" aria-live="polite"></span></td>' +

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1994,6 +1994,13 @@ def test_app_config_normalises_psn_system_name(
     assert cfg.psn_system_name == expected
 
 
+def test_app_config_caps_psn_system_name_at_the_field_rule_bound() -> None:
+    """A hand-edited config.toml must not bypass the 64-char bound the web form
+    enforces: the name also sizes the marker-catalog beacon envelope."""
+    cfg = AppConfig(psn_system_name="S" * 300)
+    assert cfg.psn_system_name == "S" * 64
+
+
 @pytest.mark.parametrize("bad_fps", [True, False, None, "60", 3.14])
 def test_rttrpm_output_config_rejects_non_int_fps_and_clamps_to_one(bad_fps: object) -> None:
     # TOML loaders occasionally hand through unexpected types (a bool that

--- a/tests/test_marker_catalog.py
+++ b/tests/test_marker_catalog.py
@@ -533,6 +533,66 @@ class TestMarkerEntryVersion:
         assert len(entry.origin) <= 128
 
 
+class TestMarkerEntryNameBounds:
+    """A bounded name is what lets the sync layer fit any entry in one beacon."""
+
+    def test_name_length_capped(self) -> None:
+        entry = MarkerEntry(id=1, name="F" * 500, color="#ff0000", updated_at=0.0)
+        assert len(entry.name) == 64
+        assert entry.name == "F" * 64
+
+    def test_name_under_the_cap_is_untouched(self) -> None:
+        entry = MarkerEntry(id=1, name="Follow Spot 1 – Küche 🎭", color="#ff0000", updated_at=0.0)
+        assert entry.name == "Follow Spot 1 – Küche 🎭"
+
+    def test_control_characters_stripped_from_name(self) -> None:
+        # A peer-supplied name lands in the web UI and the HUD; escapes and
+        # newlines must not survive the wire.
+        entry = MarkerEntry(id=1, name="Fol\x1b[31mlow\n1", color="#ff0000", updated_at=0.0)
+        assert entry.name == "Fol[31mlow1"
+
+    def test_bounded_entry_fits_a_single_beacon(self) -> None:
+        """The invariant the chunker relies on: a maximally-sized entry still
+        serialises small enough to be sent on its own."""
+        from openfollow.marker_catalog.sync import _MAX_TX_PACKET, _build_beacon
+
+        entry = MarkerEntry(
+            id=999999,
+            name="F" * 100,
+            color="#ff0000",
+            updated_at=1755900000.123456,
+            version=2**63 - 1,
+            origin="o" * 200,
+        )
+        data = _build_beacon(
+            kind="heartbeat",
+            station_id="c" * 32,
+            station_name="OpenFollow bright-weasel",
+            controlled_ids=[],
+            viewer_ids=[],
+            entries=[entry],
+        )
+        assert len(data) <= _MAX_TX_PACKET
+
+    def test_load_caps_name_from_disk(self, tmp_path) -> None:
+        # A hand-edited markers.toml goes through the same cap as the wire path.
+        path = tmp_path / "markers.toml"
+        path.write_text(
+            '[[marker]]\nid = 1\nname = "' + "N" * 300 + '"\ncolor = "#ffffff"\nupdated_at = 1.0\n',
+            encoding="utf-8",
+        )
+        cat = load_catalog(str(path))
+        entry = cat.get_any(1)
+        assert entry is not None
+        assert entry.name == "N" * 64
+
+    def test_upsert_caps_name(self) -> None:
+        cat = MarkerCatalog()
+        entry = cat.upsert(1, "N" * 300, "#ff0000")
+        assert entry.name == "N" * 64
+        assert cat.get(1).name == "N" * 64
+
+
 class TestLogicalClockConflictResolution:
     """The clock-skew bug: a fresh local edit must win over a stale remote even
     when the remote carries a larger (clock-ahead) wall-clock ``updated_at``."""

--- a/tests/test_marker_catalog.py
+++ b/tests/test_marker_catalog.py
@@ -586,6 +586,29 @@ class TestMarkerEntryNameBounds:
         assert entry is not None
         assert entry.name == "N" * 64
 
+    def test_load_warns_when_it_shortens_a_name(self, tmp_path, caplog) -> None:
+        """An upgrade that shortens an existing name must say so - the next
+        save rewrites markers.toml, and the peer still holding the long name
+        has the same version, so the two stations never reconverge on it."""
+        path = tmp_path / "markers.toml"
+        path.write_text(
+            '[[marker]]\nid = 1\nname = "' + "N" * 100 + '"\ncolor = "#ffffff"\nupdated_at = 1.0\n',
+            encoding="utf-8",
+        )
+        with caplog.at_level("WARNING", logger="openfollow.marker_catalog.catalog"):
+            load_catalog(str(path))
+        assert any("name shortened to 64 characters (was 100)" in r.message for r in caplog.records)
+
+    def test_load_stays_quiet_for_a_name_within_the_cap(self, tmp_path, caplog) -> None:
+        path = tmp_path / "markers.toml"
+        path.write_text(
+            '[[marker]]\nid = 1\nname = "Follow Spot"\ncolor = "#ffffff"\nupdated_at = 1.0\n',
+            encoding="utf-8",
+        )
+        with caplog.at_level("WARNING", logger="openfollow.marker_catalog.catalog"):
+            load_catalog(str(path))
+        assert not [r for r in caplog.records if "shortened" in r.message]
+
     def test_upsert_caps_name(self) -> None:
         cat = MarkerCatalog()
         entry = cat.upsert(1, "N" * 300, "#ff0000")

--- a/tests/test_marker_sync.py
+++ b/tests/test_marker_sync.py
@@ -21,6 +21,8 @@ import pytest
 import openfollow.marker_catalog.sync as marker_sync
 from openfollow.marker_catalog.catalog import MarkerCatalog, MarkerEntry
 from openfollow.marker_catalog.sync import (
+    _MAX_HEARTBEAT_CHUNKS,
+    _MAX_TX_PACKET,
     CATALOG_MCAST_GROUP,
     CATALOG_PORT,
     DELTA_DEBOUNCE,
@@ -28,6 +30,7 @@ from openfollow.marker_catalog.sync import (
     MarkerCatalogSync,
     PeerSelection,
     _build_beacon,
+    _chunk_entries,
     _coerce_id_list,
     _entry_from_dict,
     _parse_beacon,
@@ -461,25 +464,6 @@ class TestSendPacket:
         assert decoded["controlled_ids"] == []
         assert decoded["viewer_ids"] == []
 
-    def test_oversized_payload_falls_back_to_selection_only(self) -> None:
-        """An oversized entries payload triggers a selection-only beacon
-        (no entries) instead of a byte-truncated invalid-JSON packet
-        that every peer would reject."""
-        sync = self._sync()
-        # Build a synthetic entry set large enough to exceed _MAX_TX_PACKET
-        # (60 KiB) on the wire – each entry name is ~600 bytes.
-        big_entries = [MarkerEntry(id=i, name="x" * 600, color="#ff0000", updated_at=0.0) for i in range(1, 200)]
-        sock = MagicMock()
-        sync._send_packet(sock, kind="heartbeat", entries=big_entries)
-        assert sock.sendto.call_count == 1
-        data, _ = sock.sendto.call_args[0]
-        decoded = _parse_beacon(data)
-        assert decoded is not None
-        # Fallback drops entries but keeps selection / station_id.
-        assert decoded["entries"] == []
-        assert decoded["station_id"] == "station-A"
-        assert decoded["controlled_ids"] == [1, 2]
-
     def test_oversized_fallback_also_too_large_drops_beacon(self) -> None:
         """Pathological case: even the empty-entries shell is bigger
         than the cap (e.g. astronomically long station name). Drop the
@@ -490,6 +474,238 @@ class TestSendPacket:
         # Entries don't matter – even the empty shell is oversize.
         sync._send_packet(sock, kind="heartbeat", entries=[])
         assert sock.sendto.call_count == 0
+
+
+def _catalog_entries(n: int, *, name: str = "Follow") -> list[MarkerEntry]:
+    """A realistic catalog: 32-hex origin (a station UUID) on every entry."""
+    return [
+        MarkerEntry(
+            id=i,
+            name=f"{name} {i}",
+            color="#ff0000",
+            updated_at=1755900000.123456,
+            tombstone=False,
+            version=i,
+            origin="c" * 32,
+        )
+        for i in range(1, n + 1)
+    ]
+
+
+def _sent_ids(sock: MagicMock) -> set[int]:
+    ids: set[int] = set()
+    for call in sock.sendto.call_args_list:
+        decoded = _parse_beacon(call[0][0])
+        assert decoded is not None
+        raw_entries = decoded["entries"]
+        assert isinstance(raw_entries, list)
+        for raw in raw_entries:
+            entry = _entry_from_dict(raw)
+            assert entry is not None
+            ids.add(entry.id)
+    return ids
+
+
+class TestChunkEntries:
+    """Packing contract for the pure chunker."""
+
+    def test_no_entries_yields_no_chunks(self) -> None:
+        assert _chunk_entries([], 1000) == ([], [])
+
+    def test_everything_fitting_stays_one_chunk(self) -> None:
+        entries = _catalog_entries(3)
+        chunks, skipped = _chunk_entries(entries, 10_000)
+        assert skipped == []
+        assert [e.id for e in chunks[0]] == [1, 2, 3]
+        assert len(chunks) == 1
+
+    def test_splits_at_the_budget_boundary(self) -> None:
+        """Two entries that exactly fill the budget share a chunk; one byte
+        less of budget splits them."""
+        entries = _catalog_entries(2)
+        exact = sum(len(json.dumps(marker_sync._entry_to_dict(e)).encode()) for e in entries) + 2
+        chunks, _ = _chunk_entries(entries, exact)
+        assert len(chunks) == 1
+        chunks, _ = _chunk_entries(entries, exact - 1)
+        assert [[e.id for e in c] for c in chunks] == [[1], [2]]
+
+    def test_preserves_every_entry_in_order(self) -> None:
+        entries = _catalog_entries(40)
+        chunks, skipped = _chunk_entries(entries, 1200)
+        assert skipped == []
+        assert len(chunks) > 1
+        assert [e.id for c in chunks for e in c] == list(range(1, 41))
+
+    def test_entry_too_large_for_any_chunk_is_reported_not_dropped_silently(self) -> None:
+        """A budget below one entry's own size can't be satisfied by splitting;
+        the id is reported so the caller can log it, and its neighbours still pack."""
+        entries = _catalog_entries(3)
+        one = len(json.dumps(marker_sync._entry_to_dict(entries[1])).encode())
+        chunks, skipped = _chunk_entries(entries, one)
+        # Every entry here is the same size, so all three are individually
+        # sendable at this budget – one per chunk.
+        assert skipped == []
+        assert len(chunks) == 3
+        chunks, skipped = _chunk_entries(entries, one - 1)
+        assert chunks == []
+        assert skipped == [1, 2, 3]
+
+
+class TestChunkedBeacons:
+    """#80: a catalog larger than one datagram must still reach peers."""
+
+    def _sync(self, **kwargs):
+        return MarkerCatalogSync(
+            MarkerCatalog(),
+            station_id="c" * 32,
+            station_name_provider=kwargs.get("station_name_provider", lambda: "OpenFollow bright-weasel"),
+            selection_provider=kwargs.get("selection_provider", lambda: ([1, 2], [3])),
+        )
+
+    def test_eight_entries_still_reach_peers(self) -> None:
+        """The exact reproduction from the issue: eight entries overflow a
+        single beacon, and used to be replaced by an empty-entries fallback."""
+        sync = self._sync()
+        sock = MagicMock()
+        sync._send_packet(sock, kind="heartbeat", entries=_catalog_entries(8))
+        assert sock.sendto.call_count > 1
+        assert _sent_ids(sock) == set(range(1, 9))
+
+    @pytest.mark.parametrize("count", [8, 20, 40])
+    def test_every_datagram_stays_under_the_mtu_cap(self, count: int) -> None:
+        sync = self._sync()
+        sock = MagicMock()
+        sync._send_packet(sock, kind="heartbeat", entries=_catalog_entries(count))
+        sizes = [len(call[0][0]) for call in sock.sendto.call_args_list]
+        assert sizes and max(sizes) <= _MAX_TX_PACKET
+        assert _sent_ids(sock) == set(range(1, count + 1))
+
+    def test_each_datagram_carries_the_station_selection(self) -> None:
+        """Selection repeats in every chunk, so a dropped datagram costs
+        entries but never the 'controlled by' display."""
+        sync = self._sync()
+        sock = MagicMock()
+        sync._send_packet(sock, kind="heartbeat", entries=_catalog_entries(20))
+        for call in sock.sendto.call_args_list:
+            decoded = _parse_beacon(call[0][0])
+            assert decoded is not None
+            assert decoded["station_id"] == "c" * 32
+            assert decoded["controlled_ids"] == [1, 2]
+            assert decoded["viewer_ids"] == [3]
+            assert call[0][1] == (CATALOG_MCAST_GROUP, CATALOG_PORT)
+
+    def test_a_peer_converges_on_the_full_catalog_without_reassembly(self) -> None:
+        """Each chunk is a standalone beacon: merging them in any order
+        reproduces the sender's catalog, names and colours intact."""
+        sync = self._sync()
+        sock = MagicMock()
+        sync._send_packet(sock, kind="heartbeat", entries=_catalog_entries(40))
+        packets = [call[0][0] for call in sock.sendto.call_args_list]
+
+        received = MarkerCatalog()
+        peer = MarkerCatalogSync(
+            received,
+            station_id="peer-B",
+            station_name_provider=lambda: "peer",
+            selection_provider=lambda: ([], []),
+        )
+        for data in reversed(packets):
+            peer._handle_packet(data)
+        assert {e.id: e.name for e in received.live_entries()} == {i: f"Follow {i}" for i in range(1, 41)}
+        assert {e.color for e in received.live_entries()} == {"#ff0000"}
+
+    def test_heartbeat_burst_is_capped(self) -> None:
+        sync = self._sync()
+        sock = MagicMock()
+        sync._send_packet(sock, kind="heartbeat", entries=_catalog_entries(200))
+        assert sock.sendto.call_count == _MAX_HEARTBEAT_CHUNKS
+
+    def test_heartbeat_window_rotates_until_every_entry_is_sent(self) -> None:
+        """Past the burst cap the window advances each heartbeat, so a large
+        catalog still converges rather than silently truncating at the cap."""
+        sync = self._sync()
+        entries = _catalog_entries(200)
+        seen: set[int] = set()
+        for _ in range(20):
+            sock = MagicMock()
+            sync._send_packet(sock, kind="heartbeat", entries=entries)
+            seen |= _sent_ids(sock)
+            if seen == set(range(1, 201)):
+                break
+        assert seen == set(range(1, 201))
+
+    def test_delta_beacons_are_not_capped(self) -> None:
+        """Deltas carry only locally-edited ids, so they send in full rather
+        than deferring part of an operator's edit to the next heartbeat."""
+        sync = self._sync()
+        sock = MagicMock()
+        sync._send_packet(sock, kind="delta", entries=_catalog_entries(200))
+        assert sock.sendto.call_count > _MAX_HEARTBEAT_CHUNKS
+        assert _sent_ids(sock) == set(range(1, 201))
+
+    def test_unsendable_entries_still_leave_a_selection_beacon(self) -> None:
+        """A station name long enough to squeeze the entry budget to nothing:
+        no entry fits, but the selection beacon still goes out."""
+        sync = self._sync(station_name_provider=lambda: "x" * 1150)
+        sock = MagicMock()
+        sync._send_packet(sock, kind="heartbeat", entries=_catalog_entries(4))
+        assert sock.sendto.call_count == 1
+        decoded = _parse_beacon(sock.sendto.call_args[0][0])
+        assert decoded is not None
+        assert decoded["entries"] == []
+        assert decoded["controlled_ids"] == [1, 2]
+
+    def test_mid_burst_send_error_propagates_to_the_caller(self) -> None:
+        """The send loop owns socket rebuild + back-off; a failure partway
+        through a burst must reach it instead of being swallowed."""
+        sync = self._sync()
+        sock = MagicMock()
+        sock.sendto.side_effect = [None, OSError(errno.ENETDOWN, "down")]
+        with pytest.raises(OSError):
+            sync._send_packet(sock, kind="heartbeat", entries=_catalog_entries(40))
+
+
+class TestChunkNotices:
+    def _sync(self):
+        return MarkerCatalogSync(
+            MarkerCatalog(),
+            station_id="c" * 32,
+            station_name_provider=lambda: "OpenFollow bright-weasel",
+            selection_provider=lambda: ([], []),
+        )
+
+    def test_rotation_warning_is_throttled(self, caplog: pytest.LogCaptureFixture) -> None:
+        sync = self._sync()
+        with caplog.at_level("WARNING", logger="openfollow.marker_catalog.sync"):
+            sync._note_chunk_rotation(30)
+            sync._note_chunk_rotation(30)
+        assert sum("rotating the window" in r.message for r in caplog.records) == 1
+
+    def test_rotation_warning_fires_again_after_the_interval(self, caplog: pytest.LogCaptureFixture) -> None:
+        sync = self._sync()
+        with caplog.at_level("WARNING", logger="openfollow.marker_catalog.sync"):
+            sync._note_chunk_rotation(30)
+            sync._rotation_log_ts -= marker_sync._CHUNK_LOG_INTERVAL
+            sync._note_chunk_rotation(30)
+        assert sum("rotating the window" in r.message for r in caplog.records) == 2
+
+    def test_unchunkable_error_is_throttled(self, caplog: pytest.LogCaptureFixture) -> None:
+        sync = self._sync()
+        with caplog.at_level("ERROR", logger="openfollow.marker_catalog.sync"):
+            sync._note_unchunkable([1, 2])
+            sync._note_unchunkable([1, 2])
+        assert sum("too large for a" in r.message for r in caplog.records) == 1
+
+    def test_unchunkable_error_fires_again_after_the_interval(self, caplog: pytest.LogCaptureFixture) -> None:
+        sync = self._sync()
+        with caplog.at_level("ERROR", logger="openfollow.marker_catalog.sync"):
+            sync._note_unchunkable(list(range(1, 30)))
+            sync._unchunkable_log_ts -= marker_sync._CHUNK_LOG_INTERVAL
+            sync._note_unchunkable([7])
+        messages = [r.message for r in caplog.records if "too large for a" in r.message]
+        assert len(messages) == 2
+        # Only the first ten ids are named, so the line can't grow unbounded.
+        assert messages[0].endswith("(ids: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10).")
 
 
 class TestHandleSendError:
@@ -1219,6 +1435,17 @@ def test_entry_from_dict_sanitizes_origin() -> None:
     assert back is not None
     # Control chars (NUL, LF, ESC) dropped; printable remainder kept.
     assert back.origin == "stX"
+
+
+def test_entry_from_dict_caps_and_sanitizes_name() -> None:
+    """A peer-supplied name is bounded on intake, so no inbound entry can grow
+    past what one beacon chunk holds - or smuggle escapes into the UI."""
+    from openfollow.marker_catalog.sync import _entry_from_dict
+
+    back = _entry_from_dict({"id": 1, "name": "Spo\x1bt" + "z" * 300, "color": "#ffffff"})
+    assert back is not None
+    assert back.name == "Spot" + "z" * 60
+    assert len(back.name) == 64
 
 
 def test_entry_from_dict_caps_huge_version() -> None:

--- a/tests/test_marker_sync.py
+++ b/tests/test_marker_sync.py
@@ -464,14 +464,18 @@ class TestSendPacket:
         assert decoded["controlled_ids"] == []
         assert decoded["viewer_ids"] == []
 
-    def test_oversized_fallback_also_too_large_drops_beacon(self) -> None:
-        """Pathological case: even the empty-entries shell is bigger
-        than the cap (e.g. astronomically long station name). Drop the
-        beacon entirely rather than wire-poison peers with a truncated
-        invalid packet."""
-        sync = self._sync(station_name_provider=lambda: "x" * 70000)
+    def test_irreducible_envelope_drops_beacon(self) -> None:
+        """Pathological case: the envelope busts the cap even with the whole
+        selection and station name cut away (only a station_id past the cap
+        gets here). Drop the beacon rather than wire-poison peers with a
+        truncated invalid packet."""
+        sync = MarkerCatalogSync(
+            MarkerCatalog(),
+            station_id="x" * 70000,
+            station_name_provider=lambda: "OpenFollow X",
+            selection_provider=lambda: ([1, 2], [3]),
+        )
         sock = MagicMock()
-        # Entries don't matter – even the empty shell is oversize.
         sync._send_packet(sock, kind="heartbeat", entries=[])
         assert sock.sendto.call_count == 0
 
@@ -643,17 +647,36 @@ class TestChunkedBeacons:
         assert sock.sendto.call_count > _MAX_HEARTBEAT_CHUNKS
         assert _sent_ids(sock) == set(range(1, 201))
 
-    def test_unsendable_entries_still_leave_a_selection_beacon(self) -> None:
-        """A station name long enough to squeeze the entry budget to nothing:
-        no entry fits, but the selection beacon still goes out."""
+    def test_entries_that_cannot_be_serialised_small_enough_are_skipped(self) -> None:
+        """MarkerEntry bounds name/origin in code points, but json escapes
+        non-ASCII to up to 12 bytes apiece - so a bounded entry can still
+        outgrow a datagram. It is skipped; its neighbours still go out."""
+        sync = self._sync()
+        huge = MarkerEntry(id=7, name="M", color="#ff0000", updated_at=0.0, origin="\N{PERFORMING ARTS}" * 128)
+        sock = MagicMock()
+        sync._send_packet(sock, kind="heartbeat", entries=[*_catalog_entries(3), huge])
+        assert _sent_ids(sock) == {1, 2, 3}
+        assert all(len(call[0][0]) <= _MAX_TX_PACKET for call in sock.sendto.call_args_list)
+
+    def test_a_huge_station_name_does_not_starve_the_entries(self) -> None:
+        """The envelope is trimmed to fit rather than allowed to crowd the
+        catalog out of its own beacon."""
         sync = self._sync(station_name_provider=lambda: "x" * 1150)
         sock = MagicMock()
         sync._send_packet(sock, kind="heartbeat", entries=_catalog_entries(4))
-        assert sock.sendto.call_count == 1
-        decoded = _parse_beacon(sock.sendto.call_args[0][0])
-        assert decoded is not None
-        assert decoded["entries"] == []
-        assert decoded["controlled_ids"] == [1, 2]
+        assert _sent_ids(sock) == {1, 2, 3, 4}
+        assert all(len(call[0][0]) <= _MAX_TX_PACKET for call in sock.sendto.call_args_list)
+
+    def test_a_large_selection_does_not_drop_the_beacon(self) -> None:
+        """Regression: a station viewing every marker on the LAN serialises
+        hundreds of ids. That used to push the empty-entries envelope past the
+        cap and drop the beacon outright - the same silent failure as #80."""
+        sync = self._sync(selection_provider=lambda: (list(range(1, 151)), list(range(1, 151))))
+        sock = MagicMock()
+        sync._send_packet(sock, kind="heartbeat", entries=_catalog_entries(10))
+        assert sock.sendto.call_count > 0
+        assert _sent_ids(sock) == set(range(1, 11))
+        assert all(len(call[0][0]) <= _MAX_TX_PACKET for call in sock.sendto.call_args_list)
 
     def test_mid_burst_send_error_propagates_to_the_caller(self) -> None:
         """The send loop owns socket rebuild + back-off; a failure partway
@@ -663,6 +686,128 @@ class TestChunkedBeacons:
         sock.sendto.side_effect = [None, OSError(errno.ENETDOWN, "down")]
         with pytest.raises(OSError):
             sync._send_packet(sock, kind="heartbeat", entries=_catalog_entries(40))
+
+
+class TestEnvelopeFitting:
+    """The envelope must never crowd out the entries it wraps."""
+
+    def _fit(self, name: str, controlled: list[int], viewer: list[int]):
+        return marker_sync._fit_envelope(
+            kind="heartbeat",
+            station_id="c" * 32,
+            station_name=name,
+            controlled_ids=controlled,
+            viewer_ids=viewer,
+        )
+
+    def test_a_normal_envelope_is_left_alone(self) -> None:
+        name, controlled, viewer, trimmed = self._fit("OpenFollow bright-weasel", [1, 2], [3])
+        assert (name, controlled, viewer, trimmed) == ("OpenFollow bright-weasel", [1, 2], [3], False)
+
+    @pytest.mark.parametrize("count", [150, 400])
+    def test_a_huge_selection_is_trimmed_to_leave_room_for_entries(self, count: int) -> None:
+        name, controlled, viewer, trimmed = self._fit("station", list(range(1, count)), list(range(1, count)))
+        assert trimmed
+        shell = _build_beacon(
+            kind="heartbeat",
+            station_id="c" * 32,
+            station_name=name,
+            controlled_ids=controlled,
+            viewer_ids=viewer,
+            entries=[],
+        )
+        assert _MAX_TX_PACKET - len(shell) >= marker_sync._MIN_ENTRY_BUDGET
+
+    def test_both_id_lists_are_trimmed_evenly(self) -> None:
+        _, controlled, viewer, _ = self._fit("station", list(range(1, 200)), list(range(1, 200)))
+        assert abs(len(controlled) - len(viewer)) <= 1
+        assert controlled and viewer
+
+    def test_station_name_is_shortened_once_the_ids_are_gone(self) -> None:
+        name, controlled, viewer, trimmed = self._fit("\N{PERFORMING ARTS}" * 128, [], [])
+        assert trimmed
+        assert len(name) < 128
+        assert (controlled, viewer) == ([], [])
+
+    def test_an_irreducible_envelope_gives_up_rather_than_looping(self) -> None:
+        name, controlled, viewer, trimmed = marker_sync._fit_envelope(
+            kind="heartbeat",
+            station_id="x" * 5000,
+            station_name="station",
+            controlled_ids=[1],
+            viewer_ids=[2],
+        )
+        assert (name, controlled, viewer) == ("", [], [])
+        assert trimmed
+
+    def test_envelope_trim_warning_is_throttled(self, caplog: pytest.LogCaptureFixture) -> None:
+        sync = _make_sync()
+        with caplog.at_level("WARNING", logger="openfollow.marker_catalog.sync"):
+            sync._note_envelope_trim()
+            sync._note_envelope_trim()
+            sync._envelope_log_ts -= marker_sync._CHUNK_LOG_INTERVAL
+            sync._note_envelope_trim()
+        assert sum("selection too large" in r.message for r in caplog.records) == 2
+
+
+class TestHeartbeatCursor:
+    """Rotation resumes by marker id, so repacking can't starve an entry."""
+
+    def _sync(self):
+        return MarkerCatalogSync(
+            MarkerCatalog(),
+            station_id="c" * 32,
+            station_name_provider=lambda: "OpenFollow bright-weasel",
+            selection_provider=lambda: ([], []),
+        )
+
+    def test_order_is_untouched_from_a_fresh_cursor(self) -> None:
+        sync = self._sync()
+        entries = _catalog_entries(5)
+        assert [e.id for e in sync._heartbeat_order(entries)] == [1, 2, 3, 4, 5]
+
+    def test_order_resumes_above_the_cursor(self) -> None:
+        sync = self._sync()
+        sync._heartbeat_cursor_id = 3
+        assert [e.id for e in sync._heartbeat_order(_catalog_entries(5))] == [4, 5, 1, 2, 3]
+
+    def test_a_cursor_past_the_last_id_wraps_to_the_start(self) -> None:
+        sync = self._sync()
+        sync._heartbeat_cursor_id = 999
+        assert [e.id for e in sync._heartbeat_order(_catalog_entries(3))] == [1, 2, 3]
+
+    def test_an_empty_catalog_is_returned_unchanged(self) -> None:
+        assert self._sync()._heartbeat_order([]) == []
+
+    def test_cursor_survives_entries_being_removed_between_beats(self) -> None:
+        """A chunk-index window would re-derive an arbitrary slice when the
+        catalog repacks; an id cursor resumes where it actually left off."""
+        sync = self._sync()
+        sync._heartbeat_cursor_id = 60
+        shrunk = [e for e in _catalog_entries(100) if e.id % 2 == 0]
+        assert [e.id for e in sync._heartbeat_order(shrunk)][0] == 62
+
+    def test_cursor_does_not_advance_when_the_burst_fails(self) -> None:
+        """Otherwise a link flap mid-burst skips a whole window of entries
+        until the cursor wraps all the way round."""
+        sync = self._sync()
+        sock = MagicMock()
+        sock.sendto.side_effect = [None, OSError(errno.ENETDOWN, "down")]
+        with pytest.raises(OSError):
+            sync._send_packet(sock, kind="heartbeat", entries=_catalog_entries(200))
+        assert sync._heartbeat_cursor_id == 0
+
+    def test_cursor_advances_to_the_last_id_actually_sent(self) -> None:
+        sync = self._sync()
+        sock = MagicMock()
+        sync._send_packet(sock, kind="heartbeat", entries=_catalog_entries(200))
+        assert sync._heartbeat_cursor_id == max(_sent_ids(sock))
+
+    def test_a_delta_leaves_the_heartbeat_cursor_alone(self) -> None:
+        sync = self._sync()
+        sync._heartbeat_cursor_id = 42
+        sync._send_packet(MagicMock(), kind="delta", entries=_catalog_entries(3))
+        assert sync._heartbeat_cursor_id == 42
 
 
 class TestChunkNotices:
@@ -688,6 +833,18 @@ class TestChunkNotices:
             sync._rotation_log_ts -= marker_sync._CHUNK_LOG_INTERVAL
             sync._note_chunk_rotation(30)
         assert sum("rotating the window" in r.message for r in caplog.records) == 2
+
+    @pytest.mark.parametrize(("chunks", "seconds"), [(9, 10), (16, 10), (17, 15), (21, 15)])
+    def test_rotation_warning_rounds_convergence_up_to_whole_beats(
+        self, chunks: int, seconds: int, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Covering 9 chunks 8-at-a-time takes two beats, not 1.125 - the
+        operator-facing estimate must not undersell how long a big catalog
+        takes to reach every station."""
+        sync = self._sync()
+        with caplog.at_level("WARNING", logger="openfollow.marker_catalog.sync"):
+            sync._note_chunk_rotation(chunks)
+        assert f"within {seconds}s" in caplog.records[0].message
 
     def test_unchunkable_error_is_throttled(self, caplog: pytest.LogCaptureFixture) -> None:
         sync = self._sync()

--- a/tests/test_marker_sync.py
+++ b/tests/test_marker_sync.py
@@ -451,6 +451,19 @@ class TestSendPacket:
         assert decoded is not None
         assert decoded["station_name"] == ""
 
+    def test_station_name_provider_returning_non_string_falls_back_to_empty(self) -> None:
+        """A provider that returns a bad value rather than raising must degrade
+        the same way: the send loop only recovers from OSError, so a TypeError
+        here would kill the sender thread and stop the catalog syncing."""
+        sync = self._sync(station_name_provider=lambda: None)
+        sock = MagicMock()
+        sync._send_packet(sock, kind="heartbeat", entries=_catalog_entries(3))
+        data, _ = sock.sendto.call_args[0]
+        decoded = _parse_beacon(data)
+        assert decoded is not None
+        assert decoded["station_name"] == ""
+        assert _sent_ids(sock) == {1, 2, 3}
+
     def test_selection_provider_raises_falls_back_to_empty(self) -> None:
         def bad_provider():
             raise RuntimeError("provider boom")
@@ -691,7 +704,7 @@ class TestChunkedBeacons:
 class TestEnvelopeFitting:
     """The envelope must never crowd out the entries it wraps."""
 
-    def _fit(self, name: str, controlled: list[int], viewer: list[int]):
+    def _fit(self, name: object, controlled: list[int], viewer: list[int]):
         return marker_sync._fit_envelope(
             kind="heartbeat",
             station_id="c" * 32,
@@ -728,6 +741,14 @@ class TestEnvelopeFitting:
         assert trimmed
         assert len(name) < 128
         assert (controlled, viewer) == ([], [])
+
+    @pytest.mark.parametrize("name", [None, 42, ["OpenFollow"]])
+    def test_a_non_string_station_name_is_dropped_rather_than_raising(self, name: object) -> None:
+        """The station name is provider-supplied and reaches the fitter
+        unvalidated; a non-string must degrade to an empty name instead of
+        raising past the send loop, which only recovers from OSError."""
+        fitted, controlled, viewer, trimmed = self._fit(name, [1], [2])
+        assert (fitted, controlled, viewer, trimmed) == ("", [1], [2], True)
 
     def test_an_irreducible_envelope_gives_up_rather_than_looping(self) -> None:
         name, controlled, viewer, trimmed = marker_sync._fit_envelope(

--- a/tests/test_web_markers.py
+++ b/tests/test_web_markers.py
@@ -121,6 +121,22 @@ class TestCatalogEndpoints:
         assert catalog.get(1).name == "Spot 1"
         assert sync.delta_requests == [[1]]
 
+    def test_put_caps_an_overlong_name(self, live_server) -> None:
+        """An over-length name is truncated on save and the truncated value is
+        echoed back, so the UI can't show a name peers will never receive."""
+        _, base, _, catalog, _ = live_server
+        status, body = _request(
+            base,
+            "/api/markers/catalog/5",
+            method="PUT",
+            body={"name": "N" * 300, "color": "#ff0000"},
+        )
+        assert status == 200
+        entry = catalog.get(5)
+        assert entry is not None
+        assert entry.name == "N" * 64
+        assert json.loads(body)["entry"]["name"] == "N" * 64
+
     def test_put_id_zero_rejected(self, live_server) -> None:
         _, base, _, _, _ = live_server
         status, _ = _request(


### PR DESCRIPTION
Closes #80.

## The bug

A station's heartbeat carried the whole catalog in one datagram. Past 1400 bytes – **seven entries** – `_send_packet` replaced the payload with an empty-entries beacon, so marker names and colours stopped reaching every peer on the LAN permanently, with only a log line to show for it.

This was live on a test Pi: 720 errors in an hour, 1497-byte payloads, and the peer station sitting four entries short of the sender's eight.

```
192.168.178.66  OpenFollow bright-weasel   heartbeat   236B    0 entries []
192.168.178.59  OpenFollow eager-moose     heartbeat   783B    4 entries [1, 2, 3, 4]
```

## The fix

Entries merge independently and idempotently on the receiver (`merge_entry` per entry, LWW ordered per entry). So a catalog too large for one datagram can simply be split across several **complete** beacons – no sequence numbers, no reassembly buffer, no receiver change, no wire-format break, and an old peer still parses each chunk fine. That removes the complexity "chunking" normally implies.

`_chunk_entries` measures each entry once and greedily packs against the room the beacon envelope leaves, so packing is O(n) and the size arithmetic is exact rather than estimated.

### Two supporting bounds

**`MarkerEntry.name` is capped at 64.** It was unbounded on both the disk and wire paths (only `origin` was capped), so a single entry could exceed a whole beacon and be unchunkable by construction. It now goes through the same sanitiser as `origin` – which also stops a peer-supplied name carrying control characters into the web UI and the HUD.

**Heartbeats send at most 8 chunks, on a rotating window.** Tombstones are never collected and `merge_entry` inserts an entry for any id a peer announces, so the full-catalog resend is an amplification vector that the old 1400-byte ceiling happened to limit. Rotation keeps the burst bounded without reintroducing a silent ceiling – everything still converges, just across a few beats. Deltas carry only locally-edited ids and are not capped.

### Considered and rejected

- **Entry deltas instead of full heartbeats** (issue direction 2) – the full resend is what makes a freshly-joined station converge from cold; chunking keeps that property.
- **Interning `origin` per beacon** (direction 3) – raises the ceiling by ~20% without changing the shape of the problem, and breaks the wire format for no structural gain.

## Tests

New coverage for the chunker's packing contract, the sub-MTU invariant across 8/20/40 entries, a peer converging on the full catalog from chunks fed in reverse order (the proof that no reassembly is needed), the burst cap and its rotation, delta-vs-heartbeat capping, mid-burst `OSError` propagation, log throttling, and the name cap on the dataclass, disk, wire, and `PUT /api/markers/catalog/<id>` paths.

Each regression test was mutation-checked – reverting to the pre-fix fallback, freezing the rotation offset, removing the burst cap, removing the name cap, and dropping the JSON separator accounting each kill their intended test.

`make ci` green: 982 tests, 100% line + branch coverage, lint, mypy, bandit, build.

> [!NOTE]
> The gate ran locally. `make ci-remote` fell back to the Mac because neither test Pi carries a dev checkout (no `poetry`/`make` at `/home/openfollow/openfollow`) – they are packaged-venv deployment targets. The aarch64/trixie signal for this change comes from the hardware run below instead.

## Hardware verification

Both Pis on one LAN, branch overlaid on the packaged venv, observed from a third host joined to the multicast group.

| Case | Result |
|---|---|
| 8 entries (the reported ceiling) | 2 datagrams, 1327 B + 404 B, all 8 ids through |
| 48 entries, peer cold-started with an empty catalog | 8 datagrams/beat, max 1352 B, peer converged to all 48 with names + colours |
| 125 entries (past the burst cap) | rotating window, converged in 3 beats, max 1388 B |
| Rename via `PUT` on the peer | propagated back across a 125-entry catalog in under 6 s |
| 300-character name via `PUT` | truncated to 64, echoed truncated, propagated as 64 |

Rotation warning fired once per 30 s, not per 5 s tick. Zero `MarkerCatalogSync` errors on either station after the change. Both Pis have been restored to stock 0.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199CadtqopqvsKXYZLporta