### PR TITLE
fix(psn): stamp per-tracker timestamp and status from a monotonic clock

### DIFF
--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -12,6 +12,7 @@ openfollow/              # Single unified package
 ├── net_utils.py         # Local IP/network helpers
 ├── window.py            # GTK native sink window wrapper
 ├── psn/                 # PSN protocol subpackage
+│   ├── clock.py         # Shared microsecond time base (headers + trackers)
 │   ├── marker.py       # Marker state
 │   ├── server.py        # PSN sender
 │   └── receiver.py      # PSN listener

--- a/openfollow/configuration.py
+++ b/openfollow/configuration.py
@@ -3049,12 +3049,17 @@ def apply_runtime_config_changes(app: OpenFollowApp, new_config: AppConfig) -> b
             # Capture old names up front so a rollback re-registers removed
             # markers with their original label.
             old_names = {tid: _marker_name_for_runtime(app, tid) for tid in to_remove}
+            # Seed the same default position startup registration uses: an
+            # unseeded marker broadcasts (0, 0, 0) and, having never taken a
+            # data write, reports itself invalid on the PSN wire.
+            _mk = app._config.marker
+            default_pos = (_mk.default_pos_x, _mk.default_pos_y, _mk.default_pos_z)
 
             def _apply_controlled() -> None:
                 for tid in to_remove:
                     server.remove_marker(tid)
                 for tid in to_add:
-                    server.add_marker(tid, _marker_name_for_runtime(app, tid))
+                    server.add_marker(tid, _marker_name_for_runtime(app, tid)).set_pos(*default_pos)
 
                 # Mirror marker changes to OTP output if active
                 if app._otp_server is not None:
@@ -3100,7 +3105,7 @@ def apply_runtime_config_changes(app: OpenFollowApp, new_config: AppConfig) -> b
                 for tid in to_add:
                     server.remove_marker(tid)
                 for tid in to_remove:
-                    server.add_marker(tid, old_names[tid])
+                    server.add_marker(tid, old_names[tid]).set_pos(*default_pos)
 
             _apply("controlled_marker_ids", _apply_controlled, on_failure=_restore_controlled)
         else:

--- a/openfollow/psn/clock.py
+++ b/openfollow/psn/clock.py
@@ -2,20 +2,16 @@
 # Copyright (C) 2026 OpenFollow Project
 """Shared time base for PSN packet headers and per-tracker timestamps.
 
-The PSN spec defines the header timestamp as the microseconds elapsed since the
-server started, and the reference implementation stamps trackers off that same
-clock (``set_timestamp( uint64_t timestamp_usec )``), so a receiver can compare
-the two. Monotonic rather than wall clock: the Pis have no RTC and sync their
-system time shortly after boot, which would otherwise step every timestamp we
-have already sent.
+Both fields are microseconds elapsed since this server started, off one clock,
+so a receiver can compare them.
 """
 
 from __future__ import annotations
 
 import time
 
-# Fixed at import, not at ``PsnServer.start()``: rebind() is a stop/start cycle,
-# and restarting the epoch there would send a receiver's clock backwards.
+# Import time, not ``PsnServer.start()``: rebind() is a stop/start cycle, and
+# restarting the epoch there would send a receiver's clock backwards.
 _EPOCH = time.monotonic()
 
 

--- a/openfollow/psn/clock.py
+++ b/openfollow/psn/clock.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""Shared time base for PSN packet headers and per-tracker timestamps.
+
+The PSN spec defines the header timestamp as the microseconds elapsed since the
+server started, and the reference implementation stamps trackers off that same
+clock (``set_timestamp( uint64_t timestamp_usec )``), so a receiver can compare
+the two. Monotonic rather than wall clock: the Pis have no RTC and sync their
+system time shortly after boot, which would otherwise step every timestamp we
+have already sent.
+"""
+
+from __future__ import annotations
+
+import time
+
+# Fixed at import, not at ``PsnServer.start()``: rebind() is a stop/start cycle,
+# and restarting the epoch there would send a receiver's clock backwards.
+_EPOCH = time.monotonic()
+
+
+def psn_timestamp_usec() -> int:
+    """Microseconds elapsed since this PSN server started."""
+    return int((time.monotonic() - _EPOCH) * 1_000_000)

--- a/openfollow/psn/clock.py
+++ b/openfollow/psn/clock.py
@@ -2,8 +2,9 @@
 # Copyright (C) 2026 OpenFollow Project
 """Shared time base for PSN packet headers and per-tracker timestamps.
 
-Both fields are microseconds elapsed since this server started, off one clock,
-so a receiver can compare them.
+Both fields are microseconds elapsed since this process started, off one clock,
+so a receiver can compare them. Process start is the spec's "server start": the
+epoch spans every ``PsnServer`` this process builds, not one instance's uptime.
 """
 
 from __future__ import annotations
@@ -16,5 +17,5 @@ _EPOCH = time.monotonic()
 
 
 def psn_timestamp_usec() -> int:
-    """Microseconds elapsed since this PSN server started."""
+    """Microseconds elapsed since this process started."""
     return int((time.monotonic() - _EPOCH) * 1_000_000)

--- a/openfollow/psn/marker.py
+++ b/openfollow/psn/marker.py
@@ -5,11 +5,18 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable
 
 import pypsn
 
+from openfollow.psn.clock import psn_timestamp_usec
+
 Vec3 = tuple[float, float, float]
 _ZERO: Vec3 = (0.0, 0.0, 0.0)
+# PSN_DATA_TRACKER_STATUS carries the tracker's validity as a float. A marker we
+# are actively driving is fully valid; 0.0 means "no data written yet".
+_VALID = 1.0
+_INVALID = 0.0
 
 
 class Marker:
@@ -21,6 +28,9 @@ class Marker:
     Thread-safety: Position/speed/orientation reads and writes are protected
     by an internal lock to prevent torn reads when background PSN threads
     read state while the main thread updates it.
+
+    Every data write stamps ``timestamp`` and marks the marker valid, so a
+    receiver can tell a marker that is still being updated from a stale one.
     """
 
     __slots__ = (
@@ -33,10 +43,17 @@ class Marker:
         "_trgtpos",
         "_status",
         "_timestamp",
+        "_clock",
         "_lock",
     )
 
-    def __init__(self, marker_id: int, name: str) -> None:
+    def __init__(
+        self,
+        marker_id: int,
+        name: str,
+        *,
+        clock: Callable[[], int] = psn_timestamp_usec,
+    ) -> None:
         # Marker id 0 reserved on PSN wire; validate early.
         if not isinstance(marker_id, int) or isinstance(marker_id, bool):
             raise ValueError("marker_id must be int")
@@ -49,8 +66,9 @@ class Marker:
         self._ori: Vec3 = _ZERO
         self._accel: Vec3 = _ZERO
         self._trgtpos: Vec3 = _ZERO
-        self._status: float = 0.0
+        self._status: float = _INVALID
         self._timestamp: int = 0
+        self._clock = clock
         self._lock = threading.Lock()
 
     @property
@@ -92,6 +110,7 @@ class Marker:
         """Set the marker position in PSN coordinates."""
         with self._lock:
             self._pos = (x, y, z)
+            self._stamp_locked()
 
     def set_name(self, name: str) -> None:
         """Update the marker name (used by live catalog rename)."""
@@ -102,6 +121,21 @@ class Marker:
         """Set the marker speed vector."""
         with self._lock:
             self._speed = (x, y, z)
+            self._stamp_locked()
+
+    def set_status(self, status: float) -> None:
+        """Set the tracker validity, clamped to the 0.0-1.0 range."""
+        with self._lock:
+            self._status = min(1.0, max(0.0, float(status)))
+
+    def _stamp_locked(self) -> None:
+        """Record the time of this data write. Caller holds ``_lock``.
+
+        ``set_name`` deliberately does not stamp - a rename is metadata, not
+        tracker data, and must not make a stale marker look fresh.
+        """
+        self._timestamp = self._clock()
+        self._status = _VALID
 
     def to_psn_marker(self) -> pypsn.PsnTracker:
         """Convert to pypsn.PsnTracker with all fields under lock."""

--- a/openfollow/psn/marker.py
+++ b/openfollow/psn/marker.py
@@ -124,18 +124,33 @@ class Marker:
             self._stamp_locked()
 
     def set_status(self, status: float) -> None:
-        """Set the tracker validity, clamped to the 0.0-1.0 range."""
+        """Set the tracker validity, clamped to the 0.0-1.0 range.
+
+        A non-numeric value falls back to the declared default rather than
+        raising: callers derive this from tracking confidence on the frame
+        path, where an exception would take the frame down.
+        """
+        try:
+            value = float(status)
+        except (TypeError, ValueError):
+            value = _INVALID
+        if value != value:  # NaN would reach struct.pack and ship a NaN status.
+            value = _INVALID
         with self._lock:
-            self._status = min(1.0, max(0.0, float(status)))
+            self._status = min(1.0, max(0.0, value))
 
     def _stamp_locked(self) -> None:
         """Record the time of this data write. Caller holds ``_lock``.
 
         ``set_name`` deliberately does not stamp - a rename is metadata, not
-        tracker data, and must not make a stale marker look fresh.
+        tracker data, and must not make a stale marker look fresh. The first
+        data write promotes an untouched marker to valid; an explicit
+        ``set_status`` afterwards stands, so a caller deriving validity from
+        tracking confidence is not overwritten on the next write.
         """
         self._timestamp = self._clock()
-        self._status = _VALID
+        if self._status == _INVALID:
+            self._status = _VALID
 
     def to_psn_marker(self) -> pypsn.PsnTracker:
         """Convert to pypsn.PsnTracker with all fields under lock."""

--- a/openfollow/psn/receiver.py
+++ b/openfollow/psn/receiver.py
@@ -153,8 +153,10 @@ class PsnReceiver:
                 # ``data.trackers`` and ``t.tracker_id`` are pypsn's
                 # wire-protocol-derived names; our domain layer
                 # translates them into Marker instances at this seam.
-                # One ``time.monotonic()`` per packet: all trackers in a packet
-                # arrive together, so a single read is cheaper and makes timing consistent.
+                # One read for the whole packet: all trackers in a packet arrive
+                # together, so they share an arrival time. Marker writes below
+                # stamp their own clock for the PSN tracker timestamp; that is a
+                # separate quantity from this arrival bookkeeping.
                 now = time.monotonic()
                 if now - self._last_evict_sweep >= _EVICT_SWEEP_INTERVAL_S:
                     self._last_evict_sweep = now

--- a/openfollow/psn/server.py
+++ b/openfollow/psn/server.py
@@ -12,11 +12,12 @@ import errno
 import logging
 import socket
 import threading
-import time
+from collections.abc import Callable
 
 import multicast_expert
 import pypsn
 
+from openfollow.psn.clock import psn_timestamp_usec
 from openfollow.psn.marker import Marker
 
 logger = logging.getLogger(__name__)
@@ -63,6 +64,7 @@ class PsnServer:
         source_ip: str = "",
         data_fps: float = 60.0,
         info_fps: float = 1.0,
+        clock: Callable[[], int] = psn_timestamp_usec,
     ) -> None:
         self._system_name = system_name
         self._target_ip = target_ip
@@ -71,6 +73,7 @@ class PsnServer:
         self._source_ip = source_ip.strip()
         self._data_fps = data_fps
         self._info_fps = info_fps
+        self._clock = clock
 
         self._markers: dict[int, Marker] = {}
         self._lock = threading.Lock()
@@ -86,7 +89,7 @@ class PsnServer:
 
     def add_marker(self, marker_id: int, name: str) -> Marker:
         """Register new marker (marker_id must be >= 1)."""
-        marker = Marker(marker_id, name)
+        marker = Marker(marker_id, name, clock=self._clock)
         with self._lock:
             self._markers[marker_id] = marker
         return marker
@@ -321,7 +324,7 @@ class PsnServer:
             frame_id = self._frame_id
             self._frame_id = (self._frame_id + 1) % 256
         info = pypsn.PsnInfo(
-            timestamp=int(time.time() * 1000),
+            timestamp=self._clock(),
             version_high=2,
             version_low=0,
             frame_id=frame_id,

--- a/openfollow/psn/server.py
+++ b/openfollow/psn/server.py
@@ -342,10 +342,11 @@ class PsnServer:
         if not markers:
             return
         # PSN spec uses "trackers" field name; internally called markers.
-        packet = pypsn.PsnDataPacket(
-            info=self._make_psn_info(),
-            trackers=[t.to_psn_marker() for t in markers],
-        )
+        # Snapshot the trackers before stamping the header: a marker written in
+        # between would otherwise carry a timestamp ahead of the header it ships
+        # in, which underflows a receiver computing age as unsigned.
+        trackers = [t.to_psn_marker() for t in markers]
+        packet = pypsn.PsnDataPacket(info=self._make_psn_info(), trackers=trackers)
         self._send(pypsn.prepare_psn_data_packet_bytes(packet))
 
     def _send_info_packet(self) -> None:

--- a/openfollow/runtime/services_marker_visuals.py
+++ b/openfollow/runtime/services_marker_visuals.py
@@ -364,7 +364,7 @@ def build_marker_visual_state(
     # gets the outbound speed write - not only the ones this station also views.
     # The write is what stamps the tracker's PSN timestamp, so driving it from
     # ``viewer_marker_ids`` would let a controlled-but-not-viewed marker go stale
-    # on the wire while still being transmitted at 60 fps.
+    # on the wire while it is still being transmitted.
     for tid in controlled_set:
         marker = app._server.get_marker(tid)
         if marker is not None:

--- a/openfollow/runtime/services_marker_visuals.py
+++ b/openfollow/runtime/services_marker_visuals.py
@@ -338,6 +338,16 @@ def build_initial_overlay_state(cfg: Any) -> OverlayState:
     return state
 
 
+def _broadcast_speed(app: Any, marker_id: int, marker_speeds: dict[int, float]) -> float:
+    """Effective speed magnitude a controlled marker sends on PSN.
+
+    ``marker_speeds`` only carries markers with a connected controller; the
+    accessor is the per-marker source of truth for everything else.
+    """
+    speed = marker_speeds.get(marker_id)
+    return speed if speed is not None else app.get_marker_move_speed(marker_id)
+
+
 def build_marker_visual_state(
     app: Any,
     *,
@@ -349,6 +359,16 @@ def build_marker_visual_state(
     """Build a complete OverlayState snapshot for atomic renderer swap."""
     controlled_set = set(app._controlled_ids)
     marker_speeds = app._input_manager.get_marker_gamepad_speeds() if app._input_manager is not None else {}
+
+    # Every controlled marker is broadcast on PSN, so every controlled marker
+    # gets the outbound speed write - not only the ones this station also views.
+    # The write is what stamps the tracker's PSN timestamp, so driving it from
+    # ``viewer_marker_ids`` would let a controlled-but-not-viewed marker go stale
+    # on the wire while still being transmitted at 60 fps.
+    for tid in controlled_set:
+        marker = app._server.get_marker(tid)
+        if marker is not None:
+            marker.set_speed(_broadcast_speed(app, tid, marker_speeds), 0.0, 0.0)
 
     # Fetch controller info once and build a reverse map so the per-marker
     # loop can stamp each marker card with its bound controller without an
@@ -507,9 +527,6 @@ def build_marker_visual_state(
         speed = marker_speeds.get(tid)
         if speed is None and tid in controlled_set:
             speed = app.get_marker_move_speed(tid)
-        if tid in controlled_set:
-            broadcast_speed = speed if speed is not None else app.get_marker_move_speed(tid)
-            marker.set_speed(broadcast_speed, 0.0, 0.0)
         if speed is None and tid not in controlled_set:
             vx, vy, vz = marker.speed
             speed = (vx * vx + vy * vy + vz * vz) ** 0.5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ vanish from both ``-m unit`` and ``-m "integration or smoke"`` selections.
 
 import os
 import warnings
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from pathlib import Path
 
 import pytest
@@ -152,3 +152,29 @@ def pytest_collection_modifyitems(
             UnmarkedTestWarning,
             stacklevel=1,
         )
+
+
+class PsnStepClock:
+    """Deterministic stand-in for the monotonic PSN clock (microseconds).
+
+    Shared by the PSN marker / timestamp suites so the tracker-stamp contract
+    is expressed in one place.
+    """
+
+    def __init__(self, now: int = 0) -> None:
+        self.now = now
+
+    def __call__(self) -> int:
+        return self.now
+
+
+def psn_packet_clock(first: float, rest: float) -> Callable[[], float]:
+    """Fake ``time.monotonic`` for a two-packet PsnReceiver test.
+
+    ``_on_packet`` reads the clock once for the packet's arrival time, so the
+    first read is packet one and every later read is packet two. It cannot
+    exhaust: marker writes on the same thread read the clock too, and starving
+    them would fail the test for the wrong reason.
+    """
+    seq = iter([first])
+    return lambda: next(seq, rest)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -131,6 +131,10 @@ class _DummyWebCommands:
 @dataclass
 class _DummyMarker:
     marker_id: int
+    pos: tuple[float, float, float] | None = None
+
+    def set_pos(self, x: float, y: float, z: float) -> None:
+        self.pos = (x, y, z)
 
 
 class _DummyPsnServer:
@@ -1639,6 +1643,41 @@ def test_apply_runtime_rewires_controlled_marker_ids() -> None:
     assert app._selected_id == 2
     assert app._psn_receiver.ignore_ids == {2}
     assert app._viewer_ids == [2]
+
+
+def test_apply_runtime_seeds_a_live_added_marker_with_the_default_position() -> None:
+    """Startup registration seeds the default position; the hot-reload add path
+    must match it. An unseeded marker broadcasts (0, 0, 0) and, never having
+    taken a data write, reports STATUS invalid on the PSN wire."""
+    app = _DummyApp(AppConfig(controlled_marker_ids=[1], viewer_marker_ids=[1]))
+    new_config = AppConfig(controlled_marker_ids=[1, 305], viewer_marker_ids=[1, 305])
+    new_config.marker.default_pos_x = 1.5
+    new_config.marker.default_pos_y = -2.0
+    new_config.marker.default_pos_z = 1.6
+
+    apply_runtime_config_changes(app, new_config)
+
+    assert app._server.markers[305].pos == (1.5, -2.0, 1.6)
+
+
+def test_apply_runtime_seeds_a_marker_restored_by_a_rolled_back_add() -> None:
+    """The rollback re-registers a removed marker; its position went with the
+    discarded Marker, so it needs the same seed the forward path gives."""
+    app = _app_with(controlled_marker_ids=[1, 2], viewer_marker_ids=[1, 2])
+    orig_add = app._server.add_marker
+
+    def _failing_add(tid, name):  # noqa: ANN001
+        if tid == 3:
+            raise RuntimeError("PSN add failed")
+        return orig_add(tid, name)
+
+    app._server.add_marker = _failing_add  # type: ignore[method-assign]
+    new_config = AppConfig(controlled_marker_ids=[1, 3], viewer_marker_ids=[1, 3])
+
+    apply_runtime_config_changes(app, new_config)
+
+    # Marker 2 is back after the rollback, seeded rather than left at the origin.
+    assert app._server.markers[2].pos == (0.0, 0.0, 1.6)
 
 
 def test_apply_runtime_filters_non_int_and_bool_marker_ids() -> None:

--- a/tests/test_psn_marker.py
+++ b/tests/test_psn_marker.py
@@ -102,3 +102,73 @@ def test_setters_use_lock_and_do_not_tear_reads() -> None:
     t.set_pos(40.0, 50.0, 60.0)
     # After a completed set_pos there is only one visible state.
     assert t.pos == (40.0, 50.0, 60.0)
+
+
+class _StepClock:
+    """Deterministic stand-in for the monotonic PSN clock."""
+
+    def __init__(self, now: int = 0) -> None:
+        self.now = now
+
+    def __call__(self) -> int:
+        return self.now
+
+
+class TestTrackerTimestampAndStatus:
+    """#85: every tracker shipped ``TIMESTAMP=0`` and ``STATUS=0.0`` forever.
+
+    The PSN spec defines the per-tracker timestamp as the time of that tracker's
+    last data update (microseconds, sharing the packet header's base) and status
+    as the tracker's validity, so a receiver can tell a live tracker from a
+    stale one.
+    """
+
+    def test_position_updates_advance_the_timestamp(self) -> None:
+        clock = _StepClock(1_000)
+        t = Marker(marker_id=1, name="T1", clock=clock)
+        t.set_pos(1.0, 0.0, 0.0)
+        first = t.timestamp
+        clock.now = 17_500
+        t.set_pos(2.0, 0.0, 0.0)
+        assert first == 1_000
+        assert t.timestamp == 17_500
+
+    def test_speed_updates_also_advance_the_timestamp(self) -> None:
+        """A controlled marker gets an unconditional per-frame speed write, so
+        a marker that is live but not moving still reads as fresh."""
+        clock = _StepClock(500)
+        t = Marker(marker_id=1, name="T1", clock=clock)
+        t.set_speed(2.0, 0.0, 0.0)
+        assert t.timestamp == 500
+
+    def test_rename_does_not_advance_the_timestamp(self) -> None:
+        """A rename is metadata, not tracker data - it must not make a stale
+        marker look freshly updated."""
+        clock = _StepClock(100)
+        t = Marker(marker_id=1, name="T1", clock=clock)
+        t.set_pos(1.0, 0.0, 0.0)
+        clock.now = 900
+        t.set_name("renamed")
+        assert t.timestamp == 100
+
+    def test_status_goes_valid_on_the_first_data_write(self) -> None:
+        t = Marker(marker_id=1, name="T1", clock=_StepClock(1))
+        assert t.status == 0.0  # nothing written yet
+        t.set_pos(1.0, 0.0, 0.0)
+        assert t.status == 1.0
+
+    @pytest.mark.parametrize(
+        ("given", "expected"),
+        [(0.0, 0.0), (0.5, 0.5), (1.0, 1.0), (7.5, 1.0), (-3.0, 0.0)],
+    )
+    def test_set_status_clamps_to_the_validity_range(self, given: float, expected: float) -> None:
+        t = Marker(marker_id=1, name="T1")
+        t.set_status(given)
+        assert t.status == expected
+
+    def test_to_psn_marker_carries_both_fields(self) -> None:
+        t = Marker(marker_id=9, name="T9", clock=_StepClock(4_242))
+        t.set_pos(1.0, 2.0, 3.0)
+        converted = t.to_psn_marker()
+        assert converted.timestamp == 4_242
+        assert converted.status == 1.0

--- a/tests/test_psn_marker.py
+++ b/tests/test_psn_marker.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import pypsn
 import pytest
+from conftest import PsnStepClock as _StepClock
 
 from openfollow.psn.marker import Marker
 
@@ -104,16 +105,6 @@ def test_setters_use_lock_and_do_not_tear_reads() -> None:
     assert t.pos == (40.0, 50.0, 60.0)
 
 
-class _StepClock:
-    """Deterministic stand-in for the monotonic PSN clock."""
-
-    def __init__(self, now: int = 0) -> None:
-        self.now = now
-
-    def __call__(self) -> int:
-        return self.now
-
-
 class TestTrackerTimestampAndStatus:
     """#85: every tracker shipped ``TIMESTAMP=0`` and ``STATUS=0.0`` forever.
 
@@ -165,6 +156,31 @@ class TestTrackerTimestampAndStatus:
         t = Marker(marker_id=1, name="T1")
         t.set_status(given)
         assert t.status == expected
+
+    def test_an_explicit_status_survives_later_data_writes(self) -> None:
+        """``set_status`` is the hook for deriving validity from tracking
+        confidence. A controlled marker takes a data write every frame, so a
+        stamp that reset the status would leave the hook useless."""
+        t = Marker(marker_id=1, name="T1", clock=_StepClock(1))
+        t.set_pos(1.0, 0.0, 0.0)
+        t.set_status(0.4)
+        t.set_pos(2.0, 0.0, 0.0)
+        t.set_speed(1.0, 0.0, 0.0)
+        assert t.status == pytest.approx(0.4)
+
+    @pytest.mark.parametrize("given", [None, "high", object()])
+    def test_a_non_numeric_status_falls_back_instead_of_raising(self, given: object) -> None:
+        """Confidence arrives from the detection path; an unexpected value must
+        not take the frame down."""
+        t = Marker(marker_id=1, name="T1")
+        t.set_status(given)  # type: ignore[arg-type]
+        assert t.status == 0.0
+
+    def test_a_nan_status_never_reaches_the_wire(self) -> None:
+        """``struct.pack`` would happily ship a NaN validity."""
+        t = Marker(marker_id=1, name="T1")
+        t.set_status(float("nan"))
+        assert t.status == 0.0
 
     def test_to_psn_marker_carries_both_fields(self) -> None:
         t = Marker(marker_id=9, name="T9", clock=_StepClock(4_242))

--- a/tests/test_psn_receiver.py
+++ b/tests/test_psn_receiver.py
@@ -18,6 +18,19 @@ from openfollow.psn.receiver import PsnReceiver
 pytestmark = pytest.mark.integration
 
 
+def _packet_clock(first: float, rest: float):
+    """Fake ``time.monotonic`` for a two-packet test.
+
+    The receiver reads the clock once per packet, at the top of ``_on_packet``,
+    so the first read is packet one's timestamp and every later read is packet
+    two's. Returning ``rest`` forever afterwards keeps the timeline stable when
+    something else on the thread reads the clock too - a marker stamping its own
+    data write, for instance - which an exhausting iterator could not.
+    """
+    seq = iter([first])
+    return lambda: next(seq, rest)
+
+
 @dataclass
 class _Vec:
     x: float
@@ -66,8 +79,7 @@ def test_receiver_ignores_ids_and_uses_protocol_speed(monkeypatch) -> None:
 
 def test_receiver_derives_speed_from_position_when_protocol_speed_is_zero(monkeypatch) -> None:
     monkeypatch.setattr(receiver_module.pypsn, "PsnDataPacket", _FakeDataPacket)
-    times = iter([1.0, 1.5])
-    monkeypatch.setattr(receiver_module.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(receiver_module.time, "monotonic", _packet_clock(1.0, 1.5))
 
     receiver = PsnReceiver()
     receiver._on_packet(_FakeDataPacket([_PacketTracker(5, _Vec(0.0, 0.0, 0.0), _Vec(0.0, 0.0, 0.0))]))
@@ -133,8 +145,9 @@ def test_receiver_evicts_stale_markers(monkeypatch) -> None:
     """#540: markers silent past the TTL are dropped from all three dicts so an
     enumerated tracker_id can't persist for the process lifetime."""
     monkeypatch.setattr(receiver_module.pypsn, "PsnDataPacket", _FakeDataPacket)
-    times = iter([0.0, 100.0])  # create at t=0, sweep+update at t=100 (> TTL + interval)
-    monkeypatch.setattr(receiver_module.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(
+        receiver_module.time, "monotonic", _packet_clock(0.0, 100.0)
+    )  # create at t=0, sweep+update at t=100 (> TTL + interval)
 
     receiver = PsnReceiver()
     receiver._on_packet(
@@ -159,8 +172,9 @@ def test_receiver_eviction_sweep_is_throttled(monkeypatch) -> None:
     """#540: the sweep runs at most every _EVICT_SWEEP_INTERVAL_S so a packet
     flood can't make it hot – a stale entry survives until the next sweep."""
     monkeypatch.setattr(receiver_module.pypsn, "PsnDataPacket", _FakeDataPacket)
-    times = iter([2.0, 3.0])  # both within the sweep interval of the 0.0 baseline
-    monkeypatch.setattr(receiver_module.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(
+        receiver_module.time, "monotonic", _packet_clock(2.0, 3.0)
+    )  # both within the sweep interval of the 0.0 baseline
 
     receiver = PsnReceiver()
     receiver._last_seen[99] = -1000.0  # very stale, but no sweep is due yet

--- a/tests/test_psn_receiver.py
+++ b/tests/test_psn_receiver.py
@@ -11,24 +11,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import pytest
+from conftest import psn_packet_clock as _packet_clock
 
 import openfollow.psn.receiver as receiver_module
 from openfollow.psn.receiver import PsnReceiver
 
 pytestmark = pytest.mark.integration
-
-
-def _packet_clock(first: float, rest: float):
-    """Fake ``time.monotonic`` for a two-packet test.
-
-    The receiver reads the clock once per packet, at the top of ``_on_packet``,
-    so the first read is packet one's timestamp and every later read is packet
-    two's. Returning ``rest`` forever afterwards keeps the timeline stable when
-    something else on the thread reads the clock too - a marker stamping its own
-    data write, for instance - which an exhausting iterator could not.
-    """
-    seq = iter([first])
-    return lambda: next(seq, rest)
 
 
 @dataclass

--- a/tests/test_psn_receiver_mutation.py
+++ b/tests/test_psn_receiver_mutation.py
@@ -35,24 +35,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import pytest
+from conftest import psn_packet_clock as _packet_clock
 
 import openfollow.psn.receiver as receiver_module
 from openfollow.psn.receiver import PsnReceiver
 
 pytestmark = pytest.mark.unit
-
-
-def _packet_clock(first: float, rest: float):
-    """Fake ``time.monotonic`` for a two-packet test.
-
-    The receiver reads the clock once per packet, at the top of ``_on_packet``,
-    so the first read is packet one's timestamp and every later read is packet
-    two's. Returning ``rest`` forever afterwards keeps the timeline stable when
-    something else on the thread reads the clock too - a marker stamping its own
-    data write, for instance - which an exhausting iterator could not.
-    """
-    seq = iter([first])
-    return lambda: next(seq, rest)
 
 
 @dataclass

--- a/tests/test_psn_receiver_mutation.py
+++ b/tests/test_psn_receiver_mutation.py
@@ -42,6 +42,19 @@ from openfollow.psn.receiver import PsnReceiver
 pytestmark = pytest.mark.unit
 
 
+def _packet_clock(first: float, rest: float):
+    """Fake ``time.monotonic`` for a two-packet test.
+
+    The receiver reads the clock once per packet, at the top of ``_on_packet``,
+    so the first read is packet one's timestamp and every later read is packet
+    two's. Returning ``rest`` forever afterwards keeps the timeline stable when
+    something else on the thread reads the clock too - a marker stamping its own
+    data write, for instance - which an exhausting iterator could not.
+    """
+    seq = iter([first])
+    return lambda: next(seq, rest)
+
+
 @dataclass
 class _Vec:
     x: float
@@ -170,8 +183,7 @@ class TestProtocolSpeedDispatch:
         speed) fires.
         """
         monkeypatch.setattr(receiver_module.pypsn, "PsnDataPacket", _FakeDataPacket)
-        times = iter([1.0, 1.1])
-        monkeypatch.setattr(receiver_module.time, "monotonic", lambda: next(times))
+        monkeypatch.setattr(receiver_module.time, "monotonic", _packet_clock(1.0, 1.1))
         recv = PsnReceiver()
         # Two packets with None speed → position delta used.
         recv._on_packet(
@@ -215,8 +227,7 @@ class TestPositionDerivedSpeedMath:
         identical, hiding the sign mutant.
         """
         monkeypatch.setattr(receiver_module.pypsn, "PsnDataPacket", _FakeDataPacket)
-        times = iter([1.0, 1.5])
-        monkeypatch.setattr(receiver_module.time, "monotonic", lambda: next(times))
+        monkeypatch.setattr(receiver_module.time, "monotonic", _packet_clock(1.0, 1.5))
         recv = PsnReceiver()
         # First packet at (10, 0, 0), second at (12, 0, 0) → dx = +2,
         # dt = 0.5 → vx = 4.0.  If subtraction mutates to addition we
@@ -249,8 +260,7 @@ class TestPositionDerivedSpeedMath:
         # block to fire; use 0.999.  prev = (1, 2, 3), new = (11, 7, 13)
         # → deltas (10, 5, 10).  Non-zero prev so additive mutants produce
         # different numbers; distinct deltas per axis so index swaps diverge.
-        times = iter([0.0, 0.999])
-        monkeypatch.setattr(receiver_module.time, "monotonic", lambda: next(times))
+        monkeypatch.setattr(receiver_module.time, "monotonic", _packet_clock(0.0, 0.999))
         recv = PsnReceiver()
         recv._on_packet(
             _FakeDataPacket(
@@ -292,8 +302,9 @@ class TestDtWindowGuard:
 
     def test_dt_just_below_upper_bound_still_derives(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(receiver_module.pypsn, "PsnDataPacket", _FakeDataPacket)
-        times = iter([0.0, 0.9])  # dt = 0.9, inside the (0.001, 1.0) window
-        monkeypatch.setattr(receiver_module.time, "monotonic", lambda: next(times))
+        monkeypatch.setattr(
+            receiver_module.time, "monotonic", _packet_clock(0.0, 0.9)
+        )  # dt = 0.9, inside the (0.001, 1.0) window
         recv = PsnReceiver()
         recv._on_packet(
             _FakeDataPacket(
@@ -319,8 +330,7 @@ class TestDtWindowGuard:
         this window.
         """
         monkeypatch.setattr(receiver_module.pypsn, "PsnDataPacket", _FakeDataPacket)
-        times = iter([0.0, 0.01])
-        monkeypatch.setattr(receiver_module.time, "monotonic", lambda: next(times))
+        monkeypatch.setattr(receiver_module.time, "monotonic", _packet_clock(0.0, 0.01))
         recv = PsnReceiver()
         recv._on_packet(
             _FakeDataPacket(
@@ -359,8 +369,7 @@ class TestPerPacketBookkeeping:
         timeout.
         """
         monkeypatch.setattr(receiver_module.pypsn, "PsnDataPacket", _FakeDataPacket)
-        times = iter([5.0, 5.1])
-        monkeypatch.setattr(receiver_module.time, "monotonic", lambda: next(times))
+        monkeypatch.setattr(receiver_module.time, "monotonic", _packet_clock(5.0, 5.1))
         recv = PsnReceiver()
         recv._on_packet(
             _FakeDataPacket(
@@ -377,8 +386,7 @@ class TestPerPacketBookkeeping:
         derivation uses ``prev_pos=None`` and skips the speed update.
         """
         monkeypatch.setattr(receiver_module.pypsn, "PsnDataPacket", _FakeDataPacket)
-        times = iter([0.0, 0.5])
-        monkeypatch.setattr(receiver_module.time, "monotonic", lambda: next(times))
+        monkeypatch.setattr(receiver_module.time, "monotonic", _packet_clock(0.0, 0.5))
         recv = PsnReceiver()
         recv._on_packet(
             _FakeDataPacket(

--- a/tests/test_psn_receiver_sockets.py
+++ b/tests/test_psn_receiver_sockets.py
@@ -29,6 +29,20 @@ from openfollow.psn.receiver import PsnReceiver, _RobustReceiver
 
 pytestmark = pytest.mark.unit
 
+
+def _packet_clock(first: float, rest: float):
+    """Fake ``time.monotonic`` for a two-packet test.
+
+    The receiver reads the clock once per packet, at the top of ``_on_packet``,
+    so the first read is packet one's timestamp and every later read is packet
+    two's. Returning ``rest`` forever afterwards keeps the timeline stable when
+    something else on the thread reads the clock too - a marker stamping its own
+    data write, for instance - which an exhausting iterator could not.
+    """
+    seq = iter([first])
+    return lambda: next(seq, rest)
+
+
 # --------------------------------------------------------------------------- #
 # Fakes
 # --------------------------------------------------------------------------- #
@@ -417,8 +431,7 @@ class TestOnPacketEdgeCases:
     def test_dt_outside_window_skips_speed_derivation(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(receiver_module.pypsn, "PsnDataPacket", _FakeDataPacket)
         # First packet at t=1, second at t=3 → dt=2.0, outside window.
-        times = iter([1.0, 3.0])
-        monkeypatch.setattr(receiver_module.time, "monotonic", lambda: next(times))
+        monkeypatch.setattr(receiver_module.time, "monotonic", _packet_clock(1.0, 3.0))
         recv = PsnReceiver()
         recv._on_packet(
             _FakeDataPacket(
@@ -446,8 +459,7 @@ class TestOnPacketEdgeCases:
         of snapping to zero between movement bursts.
         """
         monkeypatch.setattr(receiver_module.pypsn, "PsnDataPacket", _FakeDataPacket)
-        times = iter([1.0, 1.1])  # dt=0.1, inside the window
-        monkeypatch.setattr(receiver_module.time, "monotonic", lambda: next(times))
+        monkeypatch.setattr(receiver_module.time, "monotonic", _packet_clock(1.0, 1.1))  # dt=0.1, inside the window
         recv = PsnReceiver()
         recv._on_packet(
             _FakeDataPacket(

--- a/tests/test_psn_receiver_sockets.py
+++ b/tests/test_psn_receiver_sockets.py
@@ -23,24 +23,12 @@ from dataclasses import dataclass
 from typing import Any
 
 import pytest
+from conftest import psn_packet_clock as _packet_clock
 
 import openfollow.psn.receiver as receiver_module
 from openfollow.psn.receiver import PsnReceiver, _RobustReceiver
 
 pytestmark = pytest.mark.unit
-
-
-def _packet_clock(first: float, rest: float):
-    """Fake ``time.monotonic`` for a two-packet test.
-
-    The receiver reads the clock once per packet, at the top of ``_on_packet``,
-    so the first read is packet one's timestamp and every later read is packet
-    two's. Returning ``rest`` forever afterwards keeps the timeline stable when
-    something else on the thread reads the clock too - a marker stamping its own
-    data write, for instance - which an exhausting iterator could not.
-    """
-    seq = iter([first])
-    return lambda: next(seq, rest)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_psn_timestamps.py
+++ b/tests/test_psn_timestamps.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""#85: PSN timestamps and tracker validity, from the clock to the wire.
+
+The spec puts the packet header's timestamp in microseconds since the server
+started, and the reference implementation stamps trackers off the same clock, so
+these are checked together: a per-tracker timestamp is only meaningful if a
+receiver can compare it against the header it arrived in.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pypsn
+import pytest
+
+from openfollow.psn import clock as clock_module
+from openfollow.psn.marker import Marker
+from openfollow.psn.server import PsnServer
+
+pytestmark = pytest.mark.unit
+
+
+class _StepClock:
+    def __init__(self, now: int = 0) -> None:
+        self.now = now
+
+    def __call__(self) -> int:
+        return self.now
+
+
+def _decode(packet: pypsn.PsnDataPacket) -> pypsn.PsnDataPacket:
+    """Round-trip a packet through the real encoder and parser."""
+    parsed = pypsn.parse_psn_packet(pypsn.prepare_psn_data_packet_bytes(packet))
+    assert isinstance(parsed, pypsn.PsnDataPacket)
+    return parsed
+
+
+class TestMonotonicClock:
+    def test_reports_microseconds(self) -> None:
+        before = clock_module.psn_timestamp_usec()
+        time.sleep(0.02)
+        elapsed = clock_module.psn_timestamp_usec() - before
+        # 20 ms is 20_000 us; a wide upper bound keeps this off the flake list.
+        assert 10_000 < elapsed < 2_000_000
+
+    def test_starts_near_zero_not_at_the_unix_epoch(self) -> None:
+        """The spec counts from server start. Wall-clock microseconds would be
+        ~1.7e15 here, which is what the pre-fix header sent (in milliseconds)."""
+        assert clock_module.psn_timestamp_usec() < 60 * 60 * 1_000_000
+
+    def test_does_not_move_when_the_wall_clock_is_stepped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The Pis have no RTC and sync time shortly after boot. A wall-clock
+        timestamp would jump backwards mid-stream; a monotonic one cannot."""
+        monkeypatch.setattr(time, "time", lambda: 0.0)
+        stepped = clock_module.psn_timestamp_usec()
+        monkeypatch.setattr(time, "time", lambda: 10_000_000.0)
+        assert clock_module.psn_timestamp_usec() >= stepped
+
+
+class TestTrackerFieldsReachTheWire:
+    """The chunks were always emitted; they just always read zero."""
+
+    def test_timestamp_and_status_survive_encode_and_parse(self) -> None:
+        marker = Marker(301, "Marker 301", clock=_StepClock(123_456_789))
+        marker.set_pos(1.474, 2.672, 1.6)
+        packet = pypsn.PsnDataPacket(
+            info=pypsn.PsnInfo(
+                timestamp=123_456_789,
+                version_high=2,
+                version_low=0,
+                frame_id=0,
+                packet_count=1,
+            ),
+            trackers=[marker.to_psn_marker()],
+        )
+        tracker = _decode(packet).trackers[0]
+        assert tracker.tracker_id == 301
+        assert tracker.timestamp == 123_456_789
+        assert tracker.status == pytest.approx(1.0)
+
+    def test_a_never_updated_marker_stays_invalid_on_the_wire(self) -> None:
+        """Registered but never written: honestly reported as invalid rather
+        than claiming validity it does not have."""
+        packet = pypsn.PsnDataPacket(
+            info=pypsn.PsnInfo(timestamp=1, version_high=2, version_low=0, frame_id=0, packet_count=1),
+            trackers=[Marker(7, "T7").to_psn_marker()],
+        )
+        tracker = _decode(packet).trackers[0]
+        assert tracker.timestamp == 0
+        assert tracker.status == pytest.approx(0.0)
+
+
+class TestHeaderSharesTheTrackerClock:
+    def test_header_reads_the_injected_clock(self) -> None:
+        clock = _StepClock(555_000)
+        server = PsnServer(clock=clock)
+        assert server._make_psn_info().timestamp == 555_000
+
+    def test_header_and_tracker_stamps_share_one_time_base(self) -> None:
+        """A receiver compares the two to judge tracker freshness, so they must
+        come from the same clock - not one wall and one monotonic."""
+        clock = _StepClock(1_000)
+        server = PsnServer(clock=clock)
+        marker = server.add_marker(301, "Marker 301")
+        marker.set_pos(1.0, 2.0, 3.0)
+        clock.now = 4_000
+        info = server._make_psn_info()
+        assert marker.to_psn_marker().timestamp == 1_000
+        assert info.timestamp == 4_000
+        assert info.timestamp - marker.timestamp == 3_000
+
+    def test_header_advances_between_packets(self) -> None:
+        server = PsnServer()
+        first = server._make_psn_info().timestamp
+        time.sleep(0.01)
+        assert server._make_psn_info().timestamp > first

--- a/tests/test_psn_timestamps.py
+++ b/tests/test_psn_timestamps.py
@@ -14,20 +14,13 @@ import time
 
 import pypsn
 import pytest
+from conftest import PsnStepClock as _StepClock
 
 from openfollow.psn import clock as clock_module
 from openfollow.psn.marker import Marker
 from openfollow.psn.server import PsnServer
 
 pytestmark = pytest.mark.unit
-
-
-class _StepClock:
-    def __init__(self, now: int = 0) -> None:
-        self.now = now
-
-    def __call__(self) -> int:
-        return self.now
 
 
 def _decode(packet: pypsn.PsnDataPacket) -> pypsn.PsnDataPacket:
@@ -38,25 +31,32 @@ def _decode(packet: pypsn.PsnDataPacket) -> pypsn.PsnDataPacket:
 
 
 class TestMonotonicClock:
-    def test_reports_microseconds(self) -> None:
-        before = clock_module.psn_timestamp_usec()
-        time.sleep(0.02)
-        elapsed = clock_module.psn_timestamp_usec() - before
-        # 20 ms is 20_000 us; a wide upper bound keeps this off the flake list.
-        assert 10_000 < elapsed < 2_000_000
+    """The clock is pinned by driving ``time.monotonic`` - the function the
+    implementation actually reads - so a wall-clock implementation fails these
+    rather than passing them by coincidence."""
 
-    def test_starts_near_zero_not_at_the_unix_epoch(self) -> None:
+    def test_reports_microseconds_elapsed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(time, "monotonic", lambda: clock_module._EPOCH + 0.02)
+        assert clock_module.psn_timestamp_usec() == 20_000
+
+    def test_starts_at_zero_not_at_the_unix_epoch(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The spec counts from server start. Wall-clock microseconds would be
         ~1.7e15 here, which is what the pre-fix header sent (in milliseconds)."""
-        assert clock_module.psn_timestamp_usec() < 60 * 60 * 1_000_000
+        monkeypatch.setattr(time, "monotonic", lambda: clock_module._EPOCH)
+        assert clock_module.psn_timestamp_usec() == 0
 
-    def test_does_not_move_when_the_wall_clock_is_stepped(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """The Pis have no RTC and sync time shortly after boot. A wall-clock
-        timestamp would jump backwards mid-stream; a monotonic one cannot."""
+    @pytest.mark.parametrize("stepped_to", [10_000_000.0, -5_000.0])
+    def test_does_not_move_when_the_wall_clock_is_stepped(
+        self, monkeypatch: pytest.MonkeyPatch, stepped_to: float
+    ) -> None:
+        """The Pis have no RTC and sync time shortly after boot, stepping the
+        wall clock in either direction mid-stream. Holding ``time.monotonic``
+        still means a correct implementation cannot move at all."""
+        monkeypatch.setattr(time, "monotonic", lambda: clock_module._EPOCH + 1.0)
         monkeypatch.setattr(time, "time", lambda: 0.0)
-        stepped = clock_module.psn_timestamp_usec()
-        monkeypatch.setattr(time, "time", lambda: 10_000_000.0)
-        assert clock_module.psn_timestamp_usec() >= stepped
+        before = clock_module.psn_timestamp_usec()
+        monkeypatch.setattr(time, "time", lambda: stepped_to)
+        assert clock_module.psn_timestamp_usec() == before == 1_000_000
 
 
 class TestTrackerFieldsReachTheWire:
@@ -111,8 +111,36 @@ class TestHeaderSharesTheTrackerClock:
         assert info.timestamp == 4_000
         assert info.timestamp - marker.timestamp == 3_000
 
+    def test_a_write_during_the_snapshot_cannot_outrun_the_header(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The header and the trackers are read at different instants while the
+        GTK thread writes markers at 60-120 Hz. A tracker timestamp ahead of the
+        header it ships in underflows a receiver computing age as unsigned, so
+        the trackers must be snapshotted first."""
+        clock = _StepClock(1_000)
+        server = PsnServer(clock=clock, mcast_ip=None)
+        marker = server.add_marker(301, "Marker 301")
+        marker.set_pos(1.0, 2.0, 3.0)
+
+        sent: list[bytes] = []
+        monkeypatch.setattr(server, "_send", sent.append)
+        real_make = server._make_psn_info
+
+        def _make_then_write() -> pypsn.PsnInfo:
+            info = real_make()
+            clock.now += 5_000
+            marker.set_pos(9.0, 9.0, 9.0)  # a write lands between the two reads
+            return info
+
+        monkeypatch.setattr(server, "_make_psn_info", _make_then_write)
+        server._send_data_packet()
+
+        packet = pypsn.parse_psn_packet(sent[0])
+        assert isinstance(packet, pypsn.PsnDataPacket)
+        assert packet.trackers[0].timestamp <= packet.info.timestamp
+
     def test_header_advances_between_packets(self) -> None:
-        server = PsnServer()
+        clock = _StepClock(1_000)
+        server = PsnServer(clock=clock)
         first = server._make_psn_info().timestamp
-        time.sleep(0.01)
+        clock.now = 17_667
         assert server._make_psn_info().timestamp > first

--- a/tests/test_psn_timestamps.py
+++ b/tests/test_psn_timestamps.py
@@ -33,16 +33,31 @@ def _decode(packet: pypsn.PsnDataPacket) -> pypsn.PsnDataPacket:
 class TestMonotonicClock:
     """The clock is pinned by driving ``time.monotonic`` - the function the
     implementation actually reads - so a wall-clock implementation fails these
-    rather than passing them by coincidence."""
+    rather than passing them by coincidence.
 
-    def test_reports_microseconds_elapsed(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(time, "monotonic", lambda: clock_module._EPOCH + 0.02)
-        assert clock_module.psn_timestamp_usec() == 20_000
+    The epoch is pinned too, and elapsed times are binary fractions: reading the
+    real epoch would leave the assertion at the mercy of how a host's uptime
+    rounds, and ``(epoch + 0.02) - epoch`` truncates to 19_999 us on some.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _pinned_epoch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(clock_module, "_EPOCH", 1_000.0)
+
+    @pytest.mark.parametrize(
+        ("elapsed_s", "expected_usec"),
+        [(0.25, 250_000), (1.5, 1_500_000), (0.0, 0)],
+    )
+    def test_reports_microseconds_elapsed(
+        self, monkeypatch: pytest.MonkeyPatch, elapsed_s: float, expected_usec: int
+    ) -> None:
+        monkeypatch.setattr(time, "monotonic", lambda: 1_000.0 + elapsed_s)
+        assert clock_module.psn_timestamp_usec() == expected_usec
 
     def test_starts_at_zero_not_at_the_unix_epoch(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The spec counts from server start. Wall-clock microseconds would be
         ~1.7e15 here, which is what the pre-fix header sent (in milliseconds)."""
-        monkeypatch.setattr(time, "monotonic", lambda: clock_module._EPOCH)
+        monkeypatch.setattr(time, "monotonic", lambda: 1_000.0)
         assert clock_module.psn_timestamp_usec() == 0
 
     @pytest.mark.parametrize("stepped_to", [10_000_000.0, -5_000.0])
@@ -52,7 +67,7 @@ class TestMonotonicClock:
         """The Pis have no RTC and sync time shortly after boot, stepping the
         wall clock in either direction mid-stream. Holding ``time.monotonic``
         still means a correct implementation cannot move at all."""
-        monkeypatch.setattr(time, "monotonic", lambda: clock_module._EPOCH + 1.0)
+        monkeypatch.setattr(time, "monotonic", lambda: 1_001.0)
         monkeypatch.setattr(time, "time", lambda: 0.0)
         before = clock_module.psn_timestamp_usec()
         monkeypatch.setattr(time, "time", lambda: stepped_to)

--- a/tests/test_services_marker_visuals_remaining.py
+++ b/tests/test_services_marker_visuals_remaining.py
@@ -569,6 +569,39 @@ class TestSpeedDerivation:
         assert state.markers[0].speed == pytest.approx(5.5)
         assert app._server._markers[1].set_speed_calls == [(5.5, 0.0, 0.0)]
 
+    def test_controlled_marker_absent_from_viewer_ids_still_gets_its_speed_write(self, pool: OverlayStatePool) -> None:
+        """``controlled_marker_ids`` and ``viewer_marker_ids`` are edited
+        independently, and PSN broadcasts every controlled marker. The write is
+        what stamps the tracker's PSN timestamp, so a marker this station drives
+        without viewing must not go stale on the wire while it is transmitted."""
+        app = _build_app(
+            controlled=[1],
+            viewer=[],
+            server_markers={1: _FakeMarker(1)},
+        )
+        state = _build(app, pool)
+
+        assert state.markers == []  # not viewed: no card
+        assert app._server._markers[1].set_speed_calls == [(2.0, 0.0, 0.0)]
+
+    def test_speed_write_happens_once_per_frame_for_a_viewed_controlled_marker(self, pool: OverlayStatePool) -> None:
+        """Moving the write out of the viewer loop must not double-stamp a
+        marker that is both controlled and viewed."""
+        app = _build_app(
+            controlled=[1],
+            viewer=[1],
+            server_markers={1: _FakeMarker(1)},
+        )
+        _build(app, pool)
+        assert app._server._markers[1].set_speed_calls == [(2.0, 0.0, 0.0)]
+
+    def test_unregistered_controlled_marker_is_skipped(self, pool: OverlayStatePool) -> None:
+        """A controlled id the server has not registered yet (mid hot-reload)
+        must not raise on the frame path."""
+        app = _build_app(controlled=[1, 2], viewer=[], server_markers={1: _FakeMarker(1)})
+        _build(app, pool)
+        assert app._server._markers[1].set_speed_calls == [(2.0, 0.0, 0.0)]
+
     def test_viewer_without_gamepad_speed_uses_marker_velocity_norm(self, pool: OverlayStatePool) -> None:
         # Velocity (3, 4, 0) → ‖v‖ = 5.
         app = _build_app(


### PR DESCRIPTION
Closes #85.

Every tracker we transmitted carried `PSN_DATA_TRACKER_TIMESTAMP = 0` and
`PSN_DATA_TRACKER_STATUS = 0.0` permanently. Both chunks were on the wire, but
nothing ever wrote either field, so a receiver keying freshness off the tracker
timestamp saw a value that never advanced no matter how much the marker moved,
and a constant 0.0 validity reads as "invalid" to anything that checks it.

## Why the header changed too

The spec puts the packet header's timestamp in **microseconds elapsed since the
server started**, and the reference implementation stamps trackers off that same
clock (`set_timestamp( uint64_t timestamp_usec )`) so a receiver can compare the
two. Our header sent `int(time.time() * 1000)` – wrong unit *and* wrong origin.
Stamping only the tracker field would have propagated that error into a second
place, so both now read one monotonic microsecond clock fixed at import. The
monotonic base also survives the startup NTP step that made the header jump on
an RTC-less Pi.

## Behaviour

- `set_pos` and `set_speed` stamp the time and mark the marker valid.
- `set_name` deliberately does **not** stamp – a rename is metadata, and must not
  make a stale marker look freshly updated.
- Status keeps its `0.0` default and becomes `1.0` on the first data write, so a
  registered-but-never-written marker is honestly reported as invalid.
- `set_status` is added, clamped, as the hook for deriving validity from tracking
  confidence later.

## Tests

The receiver tests patched the global `time.monotonic` with two-element
iterators, which assumed exactly how many times the receiver reads the clock;
markers stamping their own writes exhausted them. They now use a packet-scoped
fake that cannot exhaust, which is what they meant to express, and were
mutation-checked to confirm they still catch the bugs they were written for.

`make ci` green, 100% coverage. It ran on the Mac – neither test Pi is a git
checkout, so `ci-remote` cannot use them; aarch64 coverage comes from the
on-device run below instead.

## Hardware verification

Two stations on one capture, decoded from a neutral Linux observer:

| | header timestamp | delta per packet | tracker TIMESTAMP | STATUS |
|---|---|---|---|---|
| pi66, this build | `21580884` (µs since start) | **17097 µs** | `21573498` (7.4 ms behind header) | **1.0** |
| pi59, stock | `1787489125139` (unix ms) | 17 (ms) | `0` | `0.0` |

A **grandMA3 2.4.2.2** console accepts the new header. On Menu → In & Out → PSN
its trackers 301–304 render live while pi66 runs this build, go red within
seconds of stopping the sender, and return to live on restart – while the stock
station's tracker stays live throughout, so the colour is tracking real packet
arrival rather than a cached row.

## Follow-up

Derive `STATUS` from detection confidence, decaying through `grace_period_ms`,
instead of the constant `1.0`.


---

## Review round

Review found six real defects, all fixed here and each mutation-checked:

1. **Freshness was tied to `viewer_marker_ids`.** The only unconditional per-frame
   data write sat inside the HUD loop over viewer ids, so a marker in
   `controlled_marker_ids` but *not* `viewer_marker_ids` was broadcast at 60 fps
   while its timestamp only advanced when the operator moved it - the exact
   failure this PR set out to remove, for that configuration. The outbound speed
   write now runs over the controlled set, which is the set PSN transmits.
2. **The header was stamped before the trackers were snapshotted**, so a marker
   written in that window shipped a timestamp ahead of its header; a receiver
   computing age as unsigned underflows to ~1.8e19 µs.
3. **`set_status` was overwritten by the next data write** - every frame for a
   controlled marker - leaving the confidence hook useless. The first write now
   promotes an untouched marker to valid; an explicit status stands after that.
4. **`set_status` raised on non-numeric input** and would pass NaN to
   `struct.pack`. It coerces instead: the value comes from detection confidence
   on the frame path, where an exception would take the frame down.
5. **The hot-reload marker-add path never seeded a position**, unlike startup, so
   a marker added live through the web UI broadcast (0,0,0) and reported itself
   invalid. Both that path and its rollback now seed it.
6. **A test that could not fail**: `test_does_not_move_when_the_wall_clock_is_stepped`
   patched `time.time`, which the implementation never calls, and stepped the
   clock *forward* while asserting `>=`, so it passed against the wall-clock
   implementation it existed to rule out. All six clock tests now fail against
   `time.time()`.

Also: the clock tests no longer depend on real sleeps or on host uptime (an exact
microsecond assertion over the real epoch truncated to 19_999 on the runner), a
receiver comment made false by marker stamping is corrected, and the duplicated
`_StepClock` / `_packet_clock` helpers moved to `conftest.py`.

## Hardware verification of the fixed build

pi66 + pi59, aarch64/py3.13, decoded from a neutral observer. The freshness fix
was proven by **reproducing the bug on the device**, not only by checking the
fixed build: with `controlled = [301..304]` and `viewer = [301,302,303]`,

| build | tracker 304 |
|---|---|
| this branch | advancing, 583 advances / 584 packets |
| pre-fix `services_marker_visuals.py` overlaid | **frozen**, 0 advances over 585 packets, 301-303 normal |

Ordering held across 585 packets × 4 trackers with zero trackers ahead of their
header. A live hot-reload add (no restart) brought marker 305 up broadcasting the
configured default `(2.5, -1.25, 1.6)` with STATUS 1.0. grandMA3 2.4.2.2 shows
every tracker live.

## Known state left behind

STATUS is a one-way latch once written, so a station whose frame loop has stopped
(#84) still advertises 1.0 - observed on the wire during verification. For a
frozen marker that means a status-keying receiver went from correctly-invalid to
incorrectly-valid; the timestamp, which is what this issue was about, is the field
that became informative, since it visibly stops advancing. #90 is what makes the
two agree. The receiver still stamps remote markers with the local epoch and
discards the wire's values (#92), and frames still are not split past 13 markers
(#91).
