### PR TITLE
ci(audit): unbreak the audit job on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,5 +193,12 @@ jobs:
       - name: Install dependencies
         run: poetry install --no-interaction -E detection
 
+      # pip is installed inside the venv being audited, so a vulnerable pip
+      # fails this job even when every project dependency is clean. Keep it
+      # current rather than ignoring the advisory - PIP_AUDIT_IGNORE is for
+      # findings with no fix available yet, and this one has one.
+      - name: Upgrade pip in the audited venv
+        run: poetry run python -m pip install --upgrade pip
+
       - name: pip-audit (supply-chain)
         run: make audit

--- a/tests/test_services_init_and_updates.py
+++ b/tests/test_services_init_and_updates.py
@@ -375,6 +375,19 @@ class TestSeedBundledDetectionModels:
 
         assert (tmp_path / "store" / "models" / "yolo26n.onnx").read_bytes() == b"nano"
 
+    def test_no_op_when_nothing_is_bundled(
+        self, services: AppRuntimeServices, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # noqa: ANN001
+        # Pinned explicitly: on a host with the .deb installed there is always
+        # something bundled, so this branch is otherwise never taken there.
+        monkeypatch.setattr("openfollow.model_seed.bundled_models_dir", lambda: None)
+        cfg = AppConfig()
+        cfg.detection.storage_path = str(tmp_path / "store")
+
+        services._seed_bundled_detection_models(cfg)
+
+        assert not (tmp_path / "store").exists()
+
 
 # --------------------------------------------------------------------------- #
 # init_camera


### PR DESCRIPTION
The `audit` job has failed on **every push to main since 52d20cf** (52d20cf, 249db4e, 1b943d3). The `test` job was green throughout, so the breakage is entirely in supply-chain audit.

## What was failing

```
Found 1 known vulnerability in 1 package
Name Version ID              Fix Versions
---- ------- --------------- ------------
pip  26.1.2  PYSEC-2026-3721 26.2
```

`pip` is installed inside the venv `pip-audit` inspects, so a vulnerable pip fails the job while every project dependency is clean.

Upgrading is the right response rather than `PIP_AUDIT_IGNORE`, which the Makefile reserves for findings with no fix available - this one is fixed in pip 26.2. Reproduced and verified locally: pip 26.1.2 reports the advisory and exits 1; pip 26.2.1 reports `No known vulnerabilities found` and exits 0.

**No PR run will exercise this.** The audit job carries `if: github.event_name != 'pull_request'` so a newly-disclosed CVE cannot block every open PR, which means it only runs on pushes to `main` and on the weekly schedule. That is also why this slipped in unnoticed.

## Second commit: a host-dependent coverage hole

Found while making `make ci-remote` genuinely run on the Raspberry Pi instead of silently falling back to the dev Mac.

`_seed_bundled_detection_models` has an early `return` for "nothing bundled". A dev machine bundles no models, so the branch was taken incidentally and read as covered. A Pi with the `.deb` installed has `/usr/share/openfollow/models`, so the branch is unreachable there and the suite drops to **99.99%**, below the gate.

GitHub's runners have nothing installed, so this never showed up in Actions - only on the real target. Pinning the case explicitly makes coverage independent of what the host happens to have installed. Mutation-checked: deleting the early return turns the new test red.

## Verification

`make ci-remote` green on the Pi (aarch64 / py3.13 / trixie), 100% coverage, wheel built.