### PR TITLE
fix(psn): give the data and info streams their own frame counters

### DIFF
--- a/openfollow/psn/server.py
+++ b/openfollow/psn/server.py
@@ -27,6 +27,7 @@ DEFAULT_PORT = 56565
 
 _MAX_SOCKET_RETRIES = 3
 _SOCKET_RETRY_DELAY = 2.0  # seconds
+_FRAME_ID_WRAP = 256  # frame_id is a uint8 on the wire
 
 
 class _Unchanged:
@@ -78,7 +79,10 @@ class PsnServer:
         self._markers: dict[int, Marker] = {}
         self._lock = threading.Lock()
         self._stop_event = threading.Event()
-        self._frame_id: int = 0
+        # Each stream numbers its own frames: on a shared counter the data stream
+        # skips an id whenever an info packet lands between two frames.
+        self._data_frame_id: int = 0
+        self._info_frame_id: int = 0
         self._socket: multicast_expert.McastTxSocket | socket.socket | None = None
         self._exit_stack: contextlib.ExitStack = contextlib.ExitStack()
         self._data_thread: threading.Thread | None = None
@@ -318,19 +322,29 @@ class PsnServer:
             self._send_info_packet()
             self._stop_event.wait(interval)
 
-    def _make_psn_info(self) -> pypsn.PsnInfo:
-        """Build a ``PsnInfo`` header and advance the frame counter."""
-        with self._lock:
-            frame_id = self._frame_id
-            self._frame_id = (self._frame_id + 1) % 256
-        info = pypsn.PsnInfo(
+    def _make_psn_info(self, frame_id: int) -> pypsn.PsnInfo:
+        """Build a ``PsnInfo`` header carrying ``frame_id``."""
+        return pypsn.PsnInfo(
             timestamp=self._clock(),
             version_high=2,
             version_low=0,
             frame_id=frame_id,
             packet_count=1,
         )
-        return info
+
+    def _next_data_header(self) -> pypsn.PsnInfo:
+        """Build a data-packet header, advancing the data stream's frame counter."""
+        with self._lock:
+            frame_id = self._data_frame_id
+            self._data_frame_id = (self._data_frame_id + 1) % _FRAME_ID_WRAP
+        return self._make_psn_info(frame_id)
+
+    def _next_info_header(self) -> pypsn.PsnInfo:
+        """Build an info-packet header, advancing the info stream's frame counter."""
+        with self._lock:
+            frame_id = self._info_frame_id
+            self._info_frame_id = (self._info_frame_id + 1) % _FRAME_ID_WRAP
+        return self._make_psn_info(frame_id)
 
     def _snapshot_markers(self) -> list[Marker]:
         """Return a consistent copy of the marker list under the lock."""
@@ -346,7 +360,7 @@ class PsnServer:
         # between would otherwise carry a timestamp ahead of the header it ships
         # in, which underflows a receiver computing age as unsigned.
         trackers = [t.to_psn_marker() for t in markers]
-        packet = pypsn.PsnDataPacket(info=self._make_psn_info(), trackers=trackers)
+        packet = pypsn.PsnDataPacket(info=self._next_data_header(), trackers=trackers)
         self._send(pypsn.prepare_psn_data_packet_bytes(packet))
 
     def _send_info_packet(self) -> None:
@@ -354,7 +368,7 @@ class PsnServer:
         if not markers:
             return
         packet = pypsn.PsnInfoPacket(
-            info=self._make_psn_info(),
+            info=self._next_info_header(),
             name=self._system_name,
             trackers=[t.to_psn_marker_info() for t in markers],
         )

--- a/openfollow/psn/server.py
+++ b/openfollow/psn/server.py
@@ -79,8 +79,8 @@ class PsnServer:
         self._markers: dict[int, Marker] = {}
         self._lock = threading.Lock()
         self._stop_event = threading.Event()
-        # Each stream numbers its own frames: on a shared counter the data stream
-        # skips an id whenever an info packet lands between two frames.
+        # A receiver reads a gap in a stream's frame ids as a dropped frame, so
+        # the two streams must not draw from one sequence.
         self._data_frame_id: int = 0
         self._info_frame_id: int = 0
         self._socket: multicast_expert.McastTxSocket | socket.socket | None = None

--- a/tests/test_psn_edge_cases.py
+++ b/tests/test_psn_edge_cases.py
@@ -266,15 +266,6 @@ def test_server_send_info_packet_is_noop_with_no_markers(monkeypatch) -> None:
     assert prepared == []
 
 
-def test_server_make_psn_info_advances_frame_id() -> None:
-    server = PsnServer(mcast_ip=None)
-    info1 = server._make_psn_info()
-    info2 = server._make_psn_info()
-    # The info object snapshots the *previous* frame_id before incrementing.
-    assert info1.frame_id != info2.frame_id
-    assert server._frame_id == 2
-
-
 def test_server_send_counts_errors_and_suppresses_spam(monkeypatch) -> None:
     """First 5 errors log, subsequent ones are aggregated (every 100th)."""
     import errno

--- a/tests/test_psn_frame_ids.py
+++ b/tests/test_psn_frame_ids.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 OpenFollow Project
-"""#86: the data and info streams each number their own frames.
+"""The data and info streams each number their own frames.
 
 ``frame_id`` is what a receiver groups a multi-packet frame on and spots a
 dropped frame with, so a counter shared between the two streams makes the data

--- a/tests/test_psn_frame_ids.py
+++ b/tests/test_psn_frame_ids.py
@@ -28,7 +28,10 @@ def _capturing_server(monkeypatch: pytest.MonkeyPatch) -> tuple[PsnServer, list[
 
 
 def _frame_ids(sent: list[bytes], packet_type: type) -> list[int]:
-    parsed = (pypsn.parse_psn_packet(datagram) for datagram in sent)
+    parsed = [pypsn.parse_psn_packet(datagram) for datagram in sent]
+    # parse_psn_packet returns None on an unrecognised chunk id; without this a
+    # serialisation regression would surface as an empty id list, not a parse.
+    assert None not in parsed
     return [p.info.frame_id for p in parsed if isinstance(p, packet_type)]
 
 
@@ -79,3 +82,47 @@ def test_frame_id_wraps_at_256(monkeypatch: pytest.MonkeyPatch, send_packet: str
     ids = _frame_ids(sent, packet_type)
     assert ids[:3] == [0, 1, 2]
     assert ids[255:] == [255, 0, 1]
+
+
+def test_a_send_with_no_markers_does_not_consume_a_frame_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both loops start before any marker is registered. Burning an id per empty
+    tick would hand the first real packet a frame id far past 0, behind a gap."""
+    server = PsnServer(mcast_ip=None)
+    sent: list[bytes] = []
+    monkeypatch.setattr(server, "_send", sent.append)
+
+    for _ in range(5):
+        server._send_data_packet()
+        server._send_info_packet()
+    assert sent == []
+
+    server.add_marker(1, "T1").set_pos(0.0, 0.0, 0.0)
+    server._send_data_packet()
+    server._send_info_packet()
+
+    assert _frame_ids(sent, pypsn.PsnDataPacket) == [0]
+    assert _frame_ids(sent, pypsn.PsnInfoPacket) == [0]
+
+
+@pytest.mark.parametrize(
+    ("send_packet", "packet_type"),
+    [
+        ("_send_data_packet", pypsn.PsnDataPacket),
+        ("_send_info_packet", pypsn.PsnInfoPacket),
+    ],
+)
+def test_header_declares_psn_v2_and_a_single_packet_frame(
+    monkeypatch: pytest.MonkeyPatch, send_packet: str, packet_type: type
+) -> None:
+    """A receiver rejects the stream outright on a version it does not speak, and
+    reassembles a frame on packet_count, so both are read back off the wire."""
+    server, sent = _capturing_server(monkeypatch)
+
+    getattr(server, send_packet)()
+
+    packet = pypsn.parse_psn_packet(sent[0])
+    assert isinstance(packet, packet_type)
+    assert (packet.info.version_high, packet.info.version_low) == (2, 0)
+    assert packet.info.packet_count == 1

--- a/tests/test_psn_frame_ids.py
+++ b/tests/test_psn_frame_ids.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""#86: the data and info streams each number their own frames.
+
+``frame_id`` is what a receiver groups a multi-packet frame on and spots a
+dropped frame with, so a counter shared between the two streams makes the data
+stream skip an id once per info packet. The ids are read back off the wire
+rather than off the counters, because that is what a receiver sees.
+"""
+
+from __future__ import annotations
+
+import pypsn
+import pytest
+
+from openfollow.psn.server import PsnServer
+
+pytestmark = pytest.mark.unit
+
+
+def _capturing_server(monkeypatch: pytest.MonkeyPatch) -> tuple[PsnServer, list[bytes]]:
+    """A server whose datagrams are collected instead of sent."""
+    server = PsnServer(mcast_ip=None)
+    server.add_marker(1, "T1").set_pos(0.0, 0.0, 0.0)
+    sent: list[bytes] = []
+    monkeypatch.setattr(server, "_send", sent.append)
+    return server, sent
+
+
+def _frame_ids(sent: list[bytes], packet_type: type) -> list[int]:
+    parsed = (pypsn.parse_psn_packet(datagram) for datagram in sent)
+    return [p.info.frame_id for p in parsed if isinstance(p, packet_type)]
+
+
+def test_data_frame_ids_stay_consecutive_across_an_interleaved_info_packet(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The 1 Hz info loop lands between two data frames. A shared counter steals
+    the id in between, which a receiver reads as a dropped frame."""
+    server, sent = _capturing_server(monkeypatch)
+
+    for _ in range(3):
+        server._send_data_packet()
+        server._send_info_packet()
+        server._send_data_packet()
+
+    assert _frame_ids(sent, pypsn.PsnDataPacket) == [0, 1, 2, 3, 4, 5]
+
+
+def test_info_frame_ids_stay_consecutive_across_interleaved_data_packets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The other side of the same counter: at 60:1 the info stream's ids would
+    jump by ~60 between packets."""
+    server, sent = _capturing_server(monkeypatch)
+
+    for _ in range(3):
+        server._send_info_packet()
+        for _ in range(5):
+            server._send_data_packet()
+
+    assert _frame_ids(sent, pypsn.PsnInfoPacket) == [0, 1, 2]
+
+
+@pytest.mark.parametrize(
+    ("send_packet", "packet_type"),
+    [
+        ("_send_data_packet", pypsn.PsnDataPacket),
+        ("_send_info_packet", pypsn.PsnInfoPacket),
+    ],
+)
+def test_frame_id_wraps_at_256(monkeypatch: pytest.MonkeyPatch, send_packet: str, packet_type: type) -> None:
+    """frame_id is a uint8 on the wire, and each stream wraps on its own."""
+    server, sent = _capturing_server(monkeypatch)
+
+    for _ in range(258):
+        getattr(server, send_packet)()
+
+    ids = _frame_ids(sent, packet_type)
+    assert ids[:3] == [0, 1, 2]
+    assert ids[255:] == [255, 0, 1]

--- a/tests/test_psn_server.py
+++ b/tests/test_psn_server.py
@@ -161,18 +161,6 @@ def test_psn_server_context_manager_starts_and_stops(udp_sink: socket.socket) ->
     assert server._info_thread is None
 
 
-def test_psn_server_frame_id_increments_and_wraps() -> None:
-    """frame_id advances on each info build and rolls over at 256."""
-    server = PsnServer(mcast_ip=None)
-    server._frame_id = 254
-
-    server._make_psn_info()  # consumes 254 → internal becomes 255
-    server._make_psn_info()  # consumes 255 → internal becomes 0
-    server._make_psn_info()  # consumes 0   → internal becomes 1
-
-    assert server._frame_id == 1
-
-
 def test_psn_server_get_marker_returns_registered_and_none_for_unknown() -> None:
     """get_marker returns the Marker object by ID or None when absent."""
     server = PsnServer(mcast_ip=None)

--- a/tests/test_psn_timestamps.py
+++ b/tests/test_psn_timestamps.py
@@ -111,7 +111,7 @@ class TestHeaderSharesTheTrackerClock:
     def test_header_reads_the_injected_clock(self) -> None:
         clock = _StepClock(555_000)
         server = PsnServer(clock=clock)
-        assert server._make_psn_info().timestamp == 555_000
+        assert server._next_data_header().timestamp == 555_000
 
     def test_header_and_tracker_stamps_share_one_time_base(self) -> None:
         """A receiver compares the two to judge tracker freshness, so they must
@@ -121,7 +121,7 @@ class TestHeaderSharesTheTrackerClock:
         marker = server.add_marker(301, "Marker 301")
         marker.set_pos(1.0, 2.0, 3.0)
         clock.now = 4_000
-        info = server._make_psn_info()
+        info = server._next_data_header()
         assert marker.to_psn_marker().timestamp == 1_000
         assert info.timestamp == 4_000
         assert info.timestamp - marker.timestamp == 3_000
@@ -138,7 +138,7 @@ class TestHeaderSharesTheTrackerClock:
 
         sent: list[bytes] = []
         monkeypatch.setattr(server, "_send", sent.append)
-        real_make = server._make_psn_info
+        real_make = server._next_data_header
 
         def _make_then_write() -> pypsn.PsnInfo:
             info = real_make()
@@ -146,7 +146,7 @@ class TestHeaderSharesTheTrackerClock:
             marker.set_pos(9.0, 9.0, 9.0)  # a write lands between the two reads
             return info
 
-        monkeypatch.setattr(server, "_make_psn_info", _make_then_write)
+        monkeypatch.setattr(server, "_next_data_header", _make_then_write)
         server._send_data_packet()
 
         packet = pypsn.parse_psn_packet(sent[0])
@@ -156,6 +156,6 @@ class TestHeaderSharesTheTrackerClock:
     def test_header_advances_between_packets(self) -> None:
         clock = _StepClock(1_000)
         server = PsnServer(clock=clock)
-        first = server._make_psn_info().timestamp
+        first = server._next_data_header().timestamp
         clock.now = 17_667
-        assert server._make_psn_info().timestamp > first
+        assert server._next_data_header().timestamp > first


### PR DESCRIPTION
Closes #86.

## The bug

`_make_psn_info()` advanced one instance counter and was called from both send
loops, so the data and info streams drew their frame ids from a single sequence.
At 60 fps data against 1 fps info the data stream skips an id roughly once per
second, and the info stream's ids jump by ~60 between packets - the two packets
captured off a 0.4.1 Pi in the issue (`data frame_id=56` next to
`info frame_id=35`) are the same sequence being shared.

`frame_id` is what a receiver groups a multi-packet frame on and spots a dropped
frame with, so the gap in the data stream reads as a lost frame. We always send
`packet_count=1` today, so nothing needs reassembly - this is a correctness fix
in the sequence semantics rather than an observed failure.

## The change

Each loop advances its own counter through `_next_data_header()` /
`_next_info_header()`, and `_make_psn_info()` is left as a pure header builder
taking the frame id.

An earlier revision of this description claimed the split is "what the
byte-budgeted frame chunking in #91 needs, since it has to build one header per
frame and reuse it across that frame's packets". That was overstated, and is
withdrawn: the previous `_make_psn_info()` could already be called once per frame
and its result reused across chunks, and `packet_count` is still a hardcoded `1`
that #91 has to turn into a parameter either way. Separating "advance the
counter" from "build the header" makes that change smaller, but this PR stands on
the sequence fix alone.

## Tests

The frame-id tests are consolidated into `tests/test_psn_frame_ids.py` and read
the ids back off the wire through `parse_psn_packet`, because that is what a
receiver sees - the previous assertions on the counter attribute could not tell
the two streams apart, which is why the suite never caught this.

Both sequence tests were mutation-checked against the unfixed code: the info
stream came back `[0, 6, 12]` where it must be `[0, 1, 2]`, and the data stream
skipped the id the info packet stole.

- data ids stay consecutive across an interleaved info packet
- info ids stay consecutive across interleaved data packets
- each stream wraps at 256 on its own (`frame_id` is a uint8 on the wire),
  driven through 258 real sends rather than by poking the counter

## Gate

`make ci-remote` green on pi66 (aarch64 / Python 3.13 / trixie): lint,
typecheck, security, 981 tests, 100% coverage, build.

