### PR TITLE
test(osc): drive the throttle tests off a controlled clock

### DIFF
--- a/tests/test_osc_transmitter.py
+++ b/tests/test_osc_transmitter.py
@@ -2962,11 +2962,10 @@ class TestFaderOnChangeDispatch:
         manager.process_pending_events()
         assert svc.calls == []
 
-    def test_throttle_drops_burst(self) -> None:
-        """Two events in quick succession at rate_hz=60 (~16.67 ms
-        spacing) – the second one falls inside the throttle window
-        and is dropped. The third one, after enough wall-clock
-        time, fires."""
+    def test_throttle_drops_burst(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """At rate_hz=60 (~16.67 ms) the second event falls inside the
+        throttle window and is dropped; a third past the window fires.
+        Drives the time source so the test is hermetic."""
         manager, svc = _manager(fader_values={1: 0.5})
         manager.restart(
             OscTransmittersConfig(
@@ -2975,15 +2974,19 @@ class TestFaderOnChangeDispatch:
                 ]
             )
         )
+        clock_holder = [1000.0]
+        monkeypatch.setattr(
+            "openfollow.osc.transmitter.time.monotonic",
+            lambda: clock_holder[0],
+        )
         manager._handle_fader_change(1, 0.4)
         manager.process_pending_events()
         assert len(svc.calls) == 1
-        # Same instant – throttle drops the second event.
+        clock_holder[0] += 0.01  # inside the window – dropped
         manager._handle_fader_change(1, 0.6)
         manager.process_pending_events()
         assert len(svc.calls) == 1
-        # Sleep past the throttle window.
-        time.sleep(0.02)
+        clock_holder[0] += 0.02  # past the window – fires
         manager._handle_fader_change(1, 0.7)
         manager.process_pending_events()
         assert len(svc.calls) == 2
@@ -3155,7 +3158,8 @@ class TestMarkerFaderOnChangeDispatch:
         manager.process_pending_events()
         assert svc.calls == []
 
-    def test_throttle_drops_burst(self) -> None:
+    def test_throttle_drops_burst(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Same window contract as the fader-index path, on its own counter."""
         manager, svc = _manager(
             markers={4: _FakeMarker((1.0, 2.0, 3.0))},
             marker_fader_values={4: 0.4},
@@ -3167,14 +3171,19 @@ class TestMarkerFaderOnChangeDispatch:
                 ]
             )
         )
+        clock_holder = [1000.0]
+        monkeypatch.setattr(
+            "openfollow.osc.transmitter.time.monotonic",
+            lambda: clock_holder[0],
+        )
         manager._handle_marker_fader_change(4, 0.4)
         manager.process_pending_events()
         assert len(svc.calls) == 1
-        # Same instant – throttle drops the second event.
+        clock_holder[0] += 0.01  # inside the window – dropped
         manager._handle_marker_fader_change(4, 0.6)
         manager.process_pending_events()
         assert len(svc.calls) == 1
-        time.sleep(0.02)
+        clock_holder[0] += 0.02  # past the window – fires
         manager._handle_marker_fader_change(4, 0.7)
         manager.process_pending_events()
         assert len(svc.calls) == 2


### PR DESCRIPTION
## The flake

`test_throttle_drops_burst` exists twice - once for the fader-index dispatch
path, once for the marker-fader path - and both raced the wall clock. The middle
assertion requires two `_handle_*_change` + `process_pending_events` round-trips
to complete inside the `rate_hz=60` throttle window (16.67 ms), while reading the
same real `time.monotonic()` the throttle in `transmitter.py` reads.

Measured locally, those round-trips take **0.011 ms** median (p99 0.031 ms), so
the assertion holds by roughly 1500x - until a stall crosses the window. That
happened on pi66 during the gate run for #94, a PSN-only branch containing no OSC
code, and cost a full ~7 min gate cycle.

CLAUDE.md's test standard is explicit that tests must not rely on timers or
wall-clock time, and that a test flaky once is flaky forever.

## The change

Both tests now step `openfollow.osc.transmitter.time.monotonic` through a
`clock_holder`, which is the pattern
`test_status_for_pps_window_excludes_old_sends` already uses a few hundred lines
up in the same file ("Drives the time source so the test is hermetic").

Advancing 10 ms for the dropped event is also a slightly stronger assertion than
before: the old test fired the second event at the same instant, so it never
exercised the window itself, only a zero delta. The trailing `time.sleep(0.02)`
is gone from both.

**No production change** - the throttle is untouched. An injectable `clock=` on
`OscTransmitterManager` was the other option, but it would have covered only 2 of
the 5 `time.monotonic` reads in the module, leaving the ring-buffer timestamps on
the module clock and the file with two competing idioms.

## Verification

Mutation-checked: with the throttle disabled in both dispatch paths
(`if now - last < 1.0 / trigger.rate_hz` short-circuited), both tests fail; with
it intact, both pass. They still test the behaviour they claim to.

`make ci-remote` green on pi66 (aarch64 / Python 3.13 / trixie).
