### PR TITLE
docs: make the no-tracker-reference rule explicit and clear the tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,13 @@ See `docs/PROJECT_STRUCTURE.md` for layout.
   the first and leave the rest bare.
 - **Reasoning belongs in the commit message / PR description, not the source**:
   why a decision was taken, what alternatives were weighed, what review raised
-  it. Same rule for issue and PR numbers – never in code or comments.
+  it.
+- **A comment must be self-explaining.** Never reference an issue, PR, or bug
+  number in code, a comment, a docstring, or a user-facing string – not even as
+  a leading tag like `"""#86: ..."""`. A reader must not need to open a
+  tracker to know what a comment means, and an operator reading a log line
+  cannot open ours at all. The number goes in the commit message and the PR
+  description.
 - Docstrings follow the same instinct once they grow into essays. A load-bearing
   contract (what callers must not do, an invariant a refactor could break) earns
   more room than an inline comment; a narrative does not.

--- a/openfollow/configuration.py
+++ b/openfollow/configuration.py
@@ -2582,7 +2582,7 @@ def _warn_deprecated_controller_bindings(controller: ControllerConfig) -> None:
         current = getattr(controller, field_name)
         if current != getattr(defaults, field_name):
             logger.warning(
-                "Config field controller.%s=%r is deprecated (issue #71): direct shortcut "
+                "Config field controller.%s=%r is deprecated: direct shortcut "
                 "removed – use the Settings menu (btn_settings, default BACK) instead.",
                 field_name,
                 current,
@@ -2600,7 +2600,7 @@ def _warn_deprecated_controller_bindings(controller: ControllerConfig) -> None:
         current = getattr(controller, field_name)
         if current != getattr(defaults, field_name):
             logger.warning(
-                "Config field controller.%s=%r is deprecated (issue #71): per-menu "
+                "Config field controller.%s=%r is deprecated: per-menu "
                 "confirm/cancel bindings were consolidated – use btn_menu_confirm / "
                 "btn_menu_cancel instead.",
                 field_name,

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -2731,8 +2731,7 @@ def _build_diagnostics_cards(
             "journalctl is unreachable and the in-memory ring "
             "wasn't initialised – diagnostics bundles will not "
             "include a log tail. Wire ``setup_logging``'s "
-            "``RingBufferLogHandler`` into ``ConfigWebServer`` "
-            "(see issue #179)."
+            "``RingBufferLogHandler`` into ``ConfigWebServer``."
         )
         log_source_note = "No log source."
     elif "no journald" in log_source_label:

--- a/tests/test_marker_sync.py
+++ b/tests/test_marker_sync.py
@@ -569,7 +569,7 @@ class TestChunkEntries:
 
 
 class TestChunkedBeacons:
-    """#80: a catalog larger than one datagram must still reach peers."""
+    """A catalog larger than one datagram must still reach peers."""
 
     def _sync(self, **kwargs):
         return MarkerCatalogSync(
@@ -580,8 +580,8 @@ class TestChunkedBeacons:
         )
 
     def test_eight_entries_still_reach_peers(self) -> None:
-        """The exact reproduction from the issue: eight entries overflow a
-        single beacon, and used to be replaced by an empty-entries fallback."""
+        """Eight entries overflow a single beacon: they must be chunked across
+        datagrams, not replaced by an empty-entries fallback."""
         sync = self._sync()
         sock = MagicMock()
         sync._send_packet(sock, kind="heartbeat", entries=_catalog_entries(8))
@@ -681,9 +681,9 @@ class TestChunkedBeacons:
         assert all(len(call[0][0]) <= _MAX_TX_PACKET for call in sock.sendto.call_args_list)
 
     def test_a_large_selection_does_not_drop_the_beacon(self) -> None:
-        """Regression: a station viewing every marker on the LAN serialises
-        hundreds of ids. That used to push the empty-entries envelope past the
-        cap and drop the beacon outright - the same silent failure as #80."""
+        """A station viewing every marker on the LAN serialises hundreds of
+        ids. The empty-entries envelope must stay under the cap, or the beacon
+        is dropped outright and the failure is silent."""
         sync = self._sync(selection_provider=lambda: (list(range(1, 151)), list(range(1, 151))))
         sock = MagicMock()
         sync._send_packet(sock, kind="heartbeat", entries=_catalog_entries(10))

--- a/tests/test_psn_marker.py
+++ b/tests/test_psn_marker.py
@@ -106,7 +106,7 @@ def test_setters_use_lock_and_do_not_tear_reads() -> None:
 
 
 class TestTrackerTimestampAndStatus:
-    """#85: every tracker shipped ``TIMESTAMP=0`` and ``STATUS=0.0`` forever.
+    """Every tracker carries a real timestamp and status, never a constant zero.
 
     The PSN spec defines the per-tracker timestamp as the time of that tracker's
     last data update (microseconds, sharing the packet header's base) and status

--- a/tests/test_psn_timestamps.py
+++ b/tests/test_psn_timestamps.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 OpenFollow Project
-"""#85: PSN timestamps and tracker validity, from the clock to the wire.
+"""PSN timestamps and tracker validity, from the clock to the wire.
 
 The spec puts the packet header's timestamp in microseconds since the server
 started, and the reference implementation stamps trackers off the same clock, so


### PR DESCRIPTION
## Why

Copilot caught a `"""#86: ..."""` docstring tag on #94. The rule that forbids it
was already in CLAUDE.md, but as a trailing sub-clause of the *reasoning* bullet:

> Same rule for issue and PR numbers – never in code or comments.

Two things made that ineffective. It reads as an afterthought to a bullet about
prose, and the tree contained counterexamples - I wrote the `#86:` tag by copying
the shape from `tests/test_psn_timestamps.py`. A rule that the surrounding code
contradicts is a rule that gets copied over.

## What changed

**CLAUDE.md** states it positively and on its own line: a comment must be
self-explaining, and no issue / PR / bug number belongs in code, a comment, a
docstring, **or a user-facing string**. The last clause is new and is the reason
the production hits below are in scope.

**Two operator-facing strings** cited tracker numbers:

- `configuration.py` - both controller deprecation warnings said
  `is deprecated (issue #71)`. An operator reading a log line cannot open our
  tracker; the rest of each message already says what to use instead.
- `web/routes.py` - the "no log source" diagnostics warning ended with
  `(see issue #179)`. That number is from the **old repository** and resolves to
  nothing here, so it was actively misleading. The message already names the
  handler to wire up.

**Four test docstrings** led with a `#85:` / `#80:` tag. They now open with the
behaviour under test. Two of them also described the old broken behaviour in the
past tense ("used to be replaced by...", "That used to push...") which is the
legacy-breadcrumb pattern CLAUDE.md separately forbids, so those now state the
contract instead.

## Not touched

Ordinals (`# right-click #2`), hex colours (`#00000040`), and HTML entities
(`&#9888;`) match a naive `#\d+` grep but are not tracker references.

No test asserted on any of the changed strings.

`make ci-remote` green on pi66.
