### PR TITLE
test: retry the bind when a picked free port is taken

### DIFF
--- a/openfollow/osc/__init__.py
+++ b/openfollow/osc/__init__.py
@@ -7,7 +7,6 @@ from openfollow.osc.service import (
     _PYTHONOSC_AVAILABLE,
     ClientStats,
     OscService,
-    find_free_udp_port,
 )
 from openfollow.osc.template import (
     BUILTIN_TEMPLATES,
@@ -45,7 +44,6 @@ __all__ = [
     "_PYTHONOSC_AVAILABLE",
     "builtin_by_id",
     "compile_template",
-    "find_free_udp_port",
     "osc_arg_for",
     "render",
 ]

--- a/openfollow/osc/service.py
+++ b/openfollow/osc/service.py
@@ -669,10 +669,3 @@ def _join_multicast_group(sock: Any, group: str, port: int) -> bool:
         )
         return False
     return True
-
-
-def find_free_udp_port() -> int:  # pragma: no cover - test helper
-    """Bind a transient socket to ``(*, 0)`` and return the kernel-assigned port."""
-    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
-        s.bind(("", 0))
-        return int(s.getsockname()[1])

--- a/tests/_ports.py
+++ b/tests/_ports.py
@@ -10,7 +10,7 @@ across the handoff, because the listener under test has to bind it, so the fix
 is to retry the *bind* rather than the pick.
 
 The two retry helpers differ because the two failures look different:
-``bind_free_udp_port`` watches for the ``OSError`` a failed bind raises, while
+``bind_free_udp_port`` watches for the ``EADDRINUSE`` a lost bind raises, while
 ``live_on_free_port`` watches for the port never opening, since ``ConfigWebServer``
 answers a taken port by quietly serving a fallback port instead of raising.
 """
@@ -18,6 +18,7 @@ answers a taken port by quietly serving a fallback port instead of raising.
 from __future__ import annotations
 
 import contextlib
+import errno
 import socket
 import time
 from collections.abc import Callable, Iterator
@@ -55,8 +56,10 @@ def free_tcp_port(host: str = "") -> int:
 def bind_free_udp_port(bind: Callable[[int], object], *, attempts: int = BIND_ATTEMPTS) -> int:
     """Call ``bind(port)`` on a free UDP port and return the port it took.
 
-    Only an ``OSError`` from ``bind`` is retried, so a test that injects some
-    other failure into the bind path still sees its own exception. A test
+    Only ``EADDRINUSE`` is retried - the errno a lost race raises. Any other
+    failure is persistent, so retrying it four more times would only bury it
+    under this function's ``AssertionError``. A test that injects its own
+    failure into the bind path likewise still sees its own exception, and one
     asserting the bind-failure contract itself passes an explicitly occupied
     port and calls the listener directly - it wants the collision.
     """
@@ -64,7 +67,9 @@ def bind_free_udp_port(bind: Callable[[int], object], *, attempts: int = BIND_AT
         port = free_udp_port()
         try:
             bind(port)
-        except OSError:
+        except OSError as exc:
+            if exc.errno != errno.EADDRINUSE:
+                raise
             continue
         return port
     raise AssertionError(f"no free UDP port after {attempts} attempts")

--- a/tests/_ports.py
+++ b/tests/_ports.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""Free-port allocation for tests that bind a real socket.
+
+Picking a port by binding a transient socket to ``(*, 0)`` and closing it
+before the code under test binds it is a TOCTOU: anything on the host can take
+the port in between - another xdist worker (``make test`` runs several), or the
+kernel simply re-offering that ephemeral port. The port cannot be held open
+across the handoff, because the listener under test has to bind it, so the fix
+is to retry the *bind* rather than the pick.
+
+The two retry helpers differ because the two failures look different:
+``bind_free_udp_port`` watches for the ``OSError`` a failed bind raises, while
+``live_on_free_port`` watches for the port never opening, since ``ConfigWebServer``
+answers a taken port by quietly serving a fallback port instead of raising.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import socket
+import time
+from collections.abc import Callable, Iterator
+from typing import Protocol, TypeVar
+
+BIND_ATTEMPTS = 5
+STARTUP_TIMEOUT_S = 5.0
+
+
+class _Startable(Protocol):
+    """The ``start()`` / ``stop()`` surface :func:`live_on_free_port` drives."""
+
+    def start(self) -> None: ...
+
+    def stop(self) -> None: ...
+
+
+_ServerT = TypeVar("_ServerT", bound=_Startable)
+
+
+def free_udp_port() -> int:
+    """Kernel-assigned free UDP port, released before it is returned."""
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.bind(("", 0))
+        return int(sock.getsockname()[1])
+
+
+def free_tcp_port(host: str = "") -> int:
+    """Kernel-assigned free TCP port, released before it is returned."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        return int(sock.getsockname()[1])
+
+
+def bind_free_udp_port(bind: Callable[[int], object], *, attempts: int = BIND_ATTEMPTS) -> int:
+    """Call ``bind(port)`` on a free UDP port and return the port it took.
+
+    Only an ``OSError`` from ``bind`` is retried, so a test that injects some
+    other failure into the bind path still sees its own exception. A test
+    asserting the bind-failure contract itself passes an explicitly occupied
+    port and calls the listener directly - it wants the collision.
+    """
+    for _ in range(attempts):
+        port = free_udp_port()
+        try:
+            bind(port)
+        except OSError:
+            continue
+        return port
+    raise AssertionError(f"no free UDP port after {attempts} attempts")
+
+
+def wait_for_port(port: int, host: str = "127.0.0.1", timeout: float = STARTUP_TIMEOUT_S) -> bool:
+    """Poll until ``host:port`` accepts a TCP connection, or ``timeout`` elapses."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.1):
+                return True
+        except OSError:
+            time.sleep(0.05)
+    return False
+
+
+def start_on_free_port(
+    factory: Callable[[int], _ServerT],
+    *,
+    host: str = "127.0.0.1",
+    attempts: int = BIND_ATTEMPTS,
+    timeout: float = STARTUP_TIMEOUT_S,
+) -> tuple[_ServerT, str]:
+    """Start ``factory(port)`` on a free TCP port; return it with its base URL.
+
+    The caller owns ``stop()``; prefer :func:`live_on_free_port` where the
+    server's lifetime is a block.
+    """
+    for _ in range(attempts):
+        port = free_tcp_port(host)
+        server = factory(port)
+        server.start()
+        if wait_for_port(port, host, timeout):
+            return server, f"http://{host}:{port}"
+        server.stop()
+    raise AssertionError(f"no free TCP port after {attempts} attempts")
+
+
+@contextlib.contextmanager
+def live_on_free_port(
+    factory: Callable[[int], _ServerT],
+    *,
+    host: str = "127.0.0.1",
+    attempts: int = BIND_ATTEMPTS,
+    timeout: float = STARTUP_TIMEOUT_S,
+) -> Iterator[tuple[_ServerT, str]]:
+    """:func:`start_on_free_port`, stopped on the way out even if the body raises."""
+    server, base = start_on_free_port(factory, host=host, attempts=attempts, timeout=timeout)
+    try:
+        yield server, base
+    finally:
+        server.stop()

--- a/tests/test_osc_marker_adapter.py
+++ b/tests/test_osc_marker_adapter.py
@@ -13,11 +13,13 @@ from __future__ import annotations
 
 import socket
 import time
+from typing import Any
 
 import pytest
 
 from openfollow.osc.input import OscMarkerAdapter
-from openfollow.osc.service import _PYTHONOSC_AVAILABLE, OscService, find_free_udp_port
+from openfollow.osc.service import _PYTHONOSC_AVAILABLE, OscService
+from tests._ports import bind_free_udp_port
 
 pytestmark = pytest.mark.unit
 
@@ -28,6 +30,23 @@ pytestmark = pytest.mark.unit
 
 def _adapter() -> OscMarkerAdapter:
     return OscMarkerAdapter(OscService(), port=12345)
+
+
+def _listening_adapter(svc: OscService, **kwargs: Any) -> tuple[OscMarkerAdapter, int]:
+    """Started adapter on a free port, plus the port it took.
+
+    The adapter takes its port at construction, so a lost port race has to
+    rebuild it rather than re-``start()`` the same one.
+    """
+    built: list[OscMarkerAdapter] = []
+
+    def _start(port: int) -> None:
+        adapter = OscMarkerAdapter(svc, port=port, **kwargs)
+        adapter.start()
+        built.append(adapter)
+
+    port = bind_free_udp_port(_start)
+    return built[-1], port
 
 
 def test_handle_routes_three_floats_into_pending() -> None:
@@ -199,9 +218,7 @@ def test_triple_after_per_axis_clears_partial_state() -> None:
 @pytest.mark.skipif(not _PYTHONOSC_AVAILABLE, reason="python-osc not installed")
 def test_start_idempotent_on_second_call() -> None:
     svc = OscService()
-    port = find_free_udp_port()
-    a = OscMarkerAdapter(svc, port=port)
-    a.start()
+    a, _ = _listening_adapter(svc)
     listener_first = svc._listener
     a.start()
     assert svc._listener is listener_first
@@ -218,9 +235,7 @@ def test_stop_idempotent_when_not_started() -> None:
 @pytest.mark.skipif(not _PYTHONOSC_AVAILABLE, reason="python-osc not installed")
 def test_start_subscribes_triple_and_per_axis_patterns() -> None:
     svc = OscService()
-    port = find_free_udp_port()
-    a = OscMarkerAdapter(svc, port=port)
-    a.start()
+    a, _ = _listening_adapter(svc)
     try:
         assert "/marker/*" in svc._subscriptions
         assert "/marker/*/x" in svc._subscriptions
@@ -268,9 +283,7 @@ def test_real_udp_send_round_trips_through_adapter() -> None:
     """Wire-level proof: send via ``OscService.send`` to the adapter's
     own listener port, observe the dispatch via ``flush_updates``."""
     svc = OscService()
-    port = find_free_udp_port()
-    adapter = OscMarkerAdapter(svc, port=port)
-    adapter.start()
+    adapter, port = _listening_adapter(svc)
     try:
         svc.send(
             "/marker/2",
@@ -294,9 +307,7 @@ def test_real_udp_send_round_trips_through_adapter() -> None:
 @pytest.mark.skipif(not _PYTHONOSC_AVAILABLE, reason="python-osc not installed")
 def test_real_udp_per_axis_round_trip() -> None:
     svc = OscService()
-    port = find_free_udp_port()
-    adapter = OscMarkerAdapter(svc, port=port)
-    adapter.start()
+    adapter, port = _listening_adapter(svc)
     try:
         svc.send("/marker/2/y", [1.5], host="127.0.0.1", port=port)
         deadline = time.monotonic() + 1.0
@@ -317,15 +328,9 @@ def test_real_udp_dispatch_respects_allowlist() -> None:
     """The adapter inherits the listener's allowlist filter – packets
     from a non-allowed sender are dropped before reaching ``flush``."""
     svc = OscService()
-    port = find_free_udp_port()
     # Bind to a specific source address so we can demonstrate filtering;
     # localhost is in the allowlist, "192.0.2.1" wouldn't be (TEST-NET-1).
-    adapter = OscMarkerAdapter(
-        svc,
-        port=port,
-        allowed_sender_ips=["192.0.2.1"],
-    )
-    adapter.start()
+    adapter, port = _listening_adapter(svc, allowed_sender_ips=["192.0.2.1"])
     try:
         svc.send(
             "/marker/0",

--- a/tests/test_osc_service.py
+++ b/tests/test_osc_service.py
@@ -29,8 +29,8 @@ from openfollow.osc.service import (
     _PYTHONOSC_AVAILABLE,
     ClientStats,
     OscService,
-    find_free_udp_port,
 )
+from tests._ports import bind_free_udp_port
 
 pytestmark = pytest.mark.unit
 
@@ -723,14 +723,13 @@ def test_listener_starts_and_subscribers_receive() -> None:
     Proves the unified service preserves both sides of the existing OSC
     behaviour without a regression."""
     svc = OscService()
-    port = find_free_udp_port()
     received: list[tuple[str, tuple[Any, ...]]] = []
 
     def _handler(address: str, *args: Any) -> None:
         received.append((address, args))
 
     svc.subscribe("/marker/*", _handler)
-    svc.start_listener(port, allowed_ips=())
+    port = bind_free_udp_port(lambda p: svc.start_listener(p, allowed_ips=()))
 
     try:
         svc.send("/marker/0", [1.0, 2.0, 3.0], host="127.0.0.1", port=port)
@@ -749,8 +748,7 @@ def test_listener_starts_and_subscribers_receive() -> None:
 @pytest.mark.skipif(not _PYTHONOSC_AVAILABLE, reason="python-osc not installed")
 def test_listener_idempotent_on_same_params() -> None:
     svc = OscService()
-    port = find_free_udp_port()
-    svc.start_listener(port, allowed_ips=())
+    port = bind_free_udp_port(lambda p: svc.start_listener(p, allowed_ips=()))
     listener = svc._listener
     svc.start_listener(port, allowed_ips=())
     # Same listener instance – the second call short-circuited.
@@ -762,11 +760,9 @@ def test_listener_idempotent_on_same_params() -> None:
 @pytest.mark.skipif(not _PYTHONOSC_AVAILABLE, reason="python-osc not installed")
 def test_listener_restart_on_changed_params() -> None:
     svc = OscService()
-    port_a = find_free_udp_port()
-    svc.start_listener(port_a, allowed_ips=())
+    bind_free_udp_port(lambda p: svc.start_listener(p, allowed_ips=()))
     first = svc._listener
-    port_b = find_free_udp_port()
-    svc.start_listener(port_b, allowed_ips=())
+    port_b = bind_free_udp_port(lambda p: svc.start_listener(p, allowed_ips=()))
     assert svc._listener is not first
     assert svc.listener_port == port_b
     svc.shutdown()
@@ -812,9 +808,8 @@ def test_listener_with_allowlist_logs_info(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     svc = OscService()
-    port = find_free_udp_port()
     with caplog.at_level(logging.INFO):
-        svc.start_listener(port, allowed_ips=["127.0.0.1"])
+        bind_free_udp_port(lambda p: svc.start_listener(p, allowed_ips=["127.0.0.1"]))
     info_records = [r for r in caplog.records if "accepting packets only" in r.message]
     assert len(info_records) == 1
     svc.shutdown()
@@ -826,9 +821,8 @@ def test_listener_without_allowlist_warns_about_exposure(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     svc = OscService()
-    port = find_free_udp_port()
     with caplog.at_level(logging.WARNING):
-        svc.start_listener(port, allowed_ips=())
+        bind_free_udp_port(lambda p: svc.start_listener(p, allowed_ips=()))
     warnings = [r for r in caplog.records if "no sender allowlist" in r.message]
     assert len(warnings) == 1
     svc.shutdown()
@@ -846,8 +840,7 @@ class TestFilteredOSCUDPServerVerifyRequest:
 
     def _server(self, allowed: frozenset[str]) -> Any:
         svc = OscService()
-        port = find_free_udp_port()
-        svc.start_listener(port, allowed_ips=allowed)
+        bind_free_udp_port(lambda p: svc.start_listener(p, allowed_ips=allowed))
         srv = svc._listener
         try:
             yield srv
@@ -1001,9 +994,8 @@ def test_restart_listener_joins_multicast_group(
         "_join_multicast_group",
         lambda sock, group, port: calls.append((group, port)) or True,
     )
-    port = find_free_udp_port()
     with caplog.at_level(logging.WARNING):
-        svc.restart_listener(port=port, allowed_ips=(), multicast_group="239.1.2.3")
+        port = bind_free_udp_port(lambda p: svc.restart_listener(port=p, allowed_ips=(), multicast_group="239.1.2.3"))
     try:
         assert calls == [("239.1.2.3", port)]
         assert svc._listener_multicast_group == "239.1.2.3"
@@ -1030,9 +1022,8 @@ def test_restart_listener_failed_join_omits_joined_log(
     """A failed multicast join must not produce a misleading 'joined' log."""
     svc = OscService()
     monkeypatch.setattr(service_module, "_join_multicast_group", lambda *a: False)
-    port = find_free_udp_port()
     with caplog.at_level(logging.WARNING):
-        svc.restart_listener(port=port, allowed_ips=(), multicast_group="239.1.2.3")
+        bind_free_udp_port(lambda p: svc.restart_listener(port=p, allowed_ips=(), multicast_group="239.1.2.3"))
     try:
         assert not any("joined multicast group" in r.message for r in caplog.records)
         # Group requested but join failed → status distinguishes the two.
@@ -1051,9 +1042,8 @@ def test_listener_with_allowlist_and_group_logs_info(
 ) -> None:
     svc = OscService()
     monkeypatch.setattr(service_module, "_join_multicast_group", lambda *a: True)
-    port = find_free_udp_port()
     with caplog.at_level(logging.INFO):
-        svc.start_listener(port, allowed_ips=["127.0.0.1"], multicast_group="239.4.5.6")
+        bind_free_udp_port(lambda p: svc.start_listener(p, allowed_ips=["127.0.0.1"], multicast_group="239.4.5.6"))
     try:
         assert any("joined multicast group 239.4.5.6" in r.message for r in caplog.records)
     finally:
@@ -1065,8 +1055,7 @@ def test_listener_with_allowlist_and_group_logs_info(
 def test_start_listener_idempotent_with_same_group(monkeypatch: pytest.MonkeyPatch) -> None:
     svc = OscService()
     monkeypatch.setattr(service_module, "_join_multicast_group", lambda *a: None)
-    port = find_free_udp_port()
-    svc.start_listener(port, allowed_ips=(), multicast_group="239.1.2.3")
+    port = bind_free_udp_port(lambda p: svc.start_listener(p, allowed_ips=(), multicast_group="239.1.2.3"))
     first = svc._listener
     svc.start_listener(port, allowed_ips=(), multicast_group="239.1.2.3")
     assert svc._listener is first  # same params → no rebind
@@ -1078,8 +1067,7 @@ def test_start_listener_idempotent_with_same_group(monkeypatch: pytest.MonkeyPat
 def test_start_listener_rebinds_on_group_change(monkeypatch: pytest.MonkeyPatch) -> None:
     svc = OscService()
     monkeypatch.setattr(service_module, "_join_multicast_group", lambda *a: None)
-    port = find_free_udp_port()
-    svc.start_listener(port, allowed_ips=(), multicast_group="239.1.2.3")
+    port = bind_free_udp_port(lambda p: svc.start_listener(p, allowed_ips=(), multicast_group="239.1.2.3"))
     first = svc._listener
     svc.start_listener(port, allowed_ips=(), multicast_group="239.9.9.9")
     assert svc._listener is not first  # group change → rebind
@@ -1238,7 +1226,6 @@ def test_restart_listener_resets_state_when_thread_start_fails(monkeypatch: pyte
     """If the serve thread can't start, the bound listener is torn down and the
     listener fields reset, so a later stop_listener has nothing half-installed."""
     svc = OscService()
-    port = find_free_udp_port()
 
     class _BadThread:
         def __init__(self, *a: Any, **k: Any) -> None: ...
@@ -1248,7 +1235,7 @@ def test_restart_listener_resets_state_when_thread_start_fails(monkeypatch: pyte
 
     monkeypatch.setattr(service_module.threading, "Thread", _BadThread)
     with pytest.raises(RuntimeError, match="can't start new thread"):
-        svc.restart_listener(port=port, allowed_ips=())
+        bind_free_udp_port(lambda p: svc.restart_listener(port=p, allowed_ips=()))
     assert svc._listener is None
     assert svc._listener_thread is None
     svc.stop_listener()  # clean no-op – nothing half-installed

--- a/tests/test_port_helpers.py
+++ b/tests/test_port_helpers.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""Tests for the shared free-port helpers in ``tests/_ports.py``.
+
+The reported flake was a TOCTOU: the port was released between the pick and
+the bind, so another process on the host could take it. These pin the
+retry contract that absorbs it - including the cases where retrying would be
+wrong (a non-bind failure must surface, an exhausted retry must fail loudly).
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from openfollow.osc.service import _PYTHONOSC_AVAILABLE, OscService
+from tests import _ports
+from tests._ports import (
+    bind_free_udp_port,
+    free_tcp_port,
+    free_udp_port,
+    live_on_free_port,
+    start_on_free_port,
+    wait_for_port,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeServer:
+    """Server whose ``start()`` only really listens from ``listen_from`` on."""
+
+    instances: list[_FakeServer] = []
+
+    def __init__(self, port: int, listen_from: int) -> None:
+        self.port = port
+        self.attempt = len(_FakeServer.instances)
+        self.listen_from = listen_from
+        self.sock: socket.socket | None = None
+        self.stopped = False
+        _FakeServer.instances.append(self)
+
+    def start(self) -> None:
+        if self.attempt < self.listen_from:
+            return
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.bind(("127.0.0.1", self.port))
+        self.sock.listen(16)
+
+    def stop(self) -> None:
+        self.stopped = True
+        if self.sock is not None:
+            self.sock.close()
+            self.sock = None
+
+
+@pytest.fixture()
+def fake_servers() -> list[_FakeServer]:
+    _FakeServer.instances = []
+    yield _FakeServer.instances
+    for server in _FakeServer.instances:
+        server.stop()
+
+
+# ---------------------------------------------------------------------------
+# Port pickers
+# ---------------------------------------------------------------------------
+
+
+def test_free_udp_port_is_bindable() -> None:
+    port = free_udp_port()
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.bind(("", port))
+
+
+def test_free_tcp_port_is_bindable() -> None:
+    port = free_tcp_port("127.0.0.1")
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", port))
+
+
+# ---------------------------------------------------------------------------
+# bind_free_udp_port
+# ---------------------------------------------------------------------------
+
+
+def test_bind_free_udp_port_returns_the_port_it_bound() -> None:
+    bound: list[int] = []
+    port = bind_free_udp_port(bound.append)
+    assert bound == [port]
+
+
+def test_bind_free_udp_port_retries_a_stolen_port() -> None:
+    """The flake itself: the first pick loses the race, the second wins."""
+    seen: list[int] = []
+
+    def _bind(port: int) -> None:
+        seen.append(port)
+        if len(seen) == 1:
+            raise OSError("address already in use")
+
+    port = bind_free_udp_port(_bind)
+    assert len(seen) == 2
+    assert port == seen[1]
+
+
+def test_bind_free_udp_port_gives_up_loudly() -> None:
+    """An always-failing bind must fail as an assertion, not spin forever."""
+    attempts = 0
+
+    def _bind(port: int) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise OSError("address already in use")
+
+    with pytest.raises(AssertionError, match="no free UDP port after 3 attempts"):
+        bind_free_udp_port(_bind, attempts=3)
+    assert attempts == 3
+
+
+def test_bind_free_udp_port_does_not_swallow_a_non_bind_failure() -> None:
+    """Retrying a failure the test injected on purpose would hide it."""
+    attempts = 0
+
+    def _bind(port: int) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("can't start new thread")
+
+    with pytest.raises(RuntimeError, match="can't start new thread"):
+        bind_free_udp_port(_bind)
+    assert attempts == 1
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _PYTHONOSC_AVAILABLE, reason="python-osc not installed")
+def test_osc_listener_survives_a_stolen_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end shape of the reported failure: the first port handed out is
+    already occupied, so the listener's bind raises and the retry takes over."""
+    blocker = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    blocker.bind(("127.0.0.1", 0))
+    stolen = blocker.getsockname()[1]
+    picks = iter([stolen])
+    monkeypatch.setattr(_ports, "free_udp_port", lambda: next(picks, free_udp_port()))
+
+    svc = OscService()
+    try:
+        port = bind_free_udp_port(lambda p: svc.start_listener(p, allowed_ips=()))
+        assert port != stolen
+        assert svc.listener_port == port
+    finally:
+        svc.shutdown()
+        blocker.close()
+
+
+# ---------------------------------------------------------------------------
+# wait_for_port
+# ---------------------------------------------------------------------------
+
+
+def test_wait_for_port_sees_a_listening_socket() -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        assert wait_for_port(sock.getsockname()[1]) is True
+
+
+def test_wait_for_port_times_out_on_a_closed_port() -> None:
+    assert wait_for_port(free_tcp_port("127.0.0.1"), timeout=0.2) is False
+
+
+# ---------------------------------------------------------------------------
+# start_on_free_port / live_on_free_port
+# ---------------------------------------------------------------------------
+
+
+def test_start_on_free_port_returns_a_reachable_server(fake_servers: list[_FakeServer]) -> None:
+    server, base = start_on_free_port(lambda port: _FakeServer(port, listen_from=0))
+    try:
+        assert base == f"http://127.0.0.1:{server.port}"
+        assert wait_for_port(server.port) is True
+    finally:
+        server.stop()
+
+
+def test_start_on_free_port_retries_when_the_port_never_opens(fake_servers: list[_FakeServer]) -> None:
+    """A ``ConfigWebServer`` that loses the race serves a fallback port instead
+    of raising, so the retry has to key off the port never opening."""
+    server, _ = start_on_free_port(lambda port: _FakeServer(port, listen_from=1), timeout=0.2)
+    try:
+        assert len(fake_servers) == 2
+        assert fake_servers[0].stopped is True
+        assert server is fake_servers[1]
+    finally:
+        server.stop()
+
+
+def test_start_on_free_port_gives_up_loudly(fake_servers: list[_FakeServer]) -> None:
+    with pytest.raises(AssertionError, match="no free TCP port after 2 attempts"):
+        start_on_free_port(lambda port: _FakeServer(port, listen_from=99), attempts=2, timeout=0.1)
+    assert len(fake_servers) == 2
+    assert all(server.stopped for server in fake_servers)
+
+
+def test_live_on_free_port_stops_the_server_when_the_body_raises(fake_servers: list[_FakeServer]) -> None:
+    with pytest.raises(ValueError, match="boom"):
+        with live_on_free_port(lambda port: _FakeServer(port, listen_from=0)):
+            raise ValueError("boom")
+    assert fake_servers[-1].stopped is True

--- a/tests/test_port_helpers.py
+++ b/tests/test_port_helpers.py
@@ -10,6 +10,7 @@ wrong (a non-bind failure must surface, an exhausted retry must fail loudly).
 
 from __future__ import annotations
 
+import errno
 import socket
 
 import pytest
@@ -98,7 +99,7 @@ def test_bind_free_udp_port_retries_a_stolen_port() -> None:
     def _bind(port: int) -> None:
         seen.append(port)
         if len(seen) == 1:
-            raise OSError("address already in use")
+            raise OSError(errno.EADDRINUSE, "address already in use")
 
     port = bind_free_udp_port(_bind)
     assert len(seen) == 2
@@ -112,7 +113,7 @@ def test_bind_free_udp_port_gives_up_loudly() -> None:
     def _bind(port: int) -> None:
         nonlocal attempts
         attempts += 1
-        raise OSError("address already in use")
+        raise OSError(errno.EADDRINUSE, "address already in use")
 
     with pytest.raises(AssertionError, match="no free UDP port after 3 attempts"):
         bind_free_udp_port(_bind, attempts=3)
@@ -130,6 +131,24 @@ def test_bind_free_udp_port_does_not_swallow_a_non_bind_failure() -> None:
 
     with pytest.raises(RuntimeError, match="can't start new thread"):
         bind_free_udp_port(_bind)
+    assert attempts == 1
+
+
+def test_bind_free_udp_port_reraises_an_oserror_that_is_not_a_lost_race() -> None:
+    """Only EADDRINUSE means "someone took it, pick another". A persistent
+    failure - fd exhaustion is the realistic one under xdist - would otherwise
+    be retried four more times and reported as this helper's AssertionError,
+    losing the errno that says what actually happened."""
+    attempts = 0
+
+    def _bind(port: int) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise OSError(errno.EMFILE, "Too many open files")
+
+    with pytest.raises(OSError, match="Too many open files") as excinfo:
+        bind_free_udp_port(_bind)
+    assert excinfo.value.errno == errno.EMFILE
     assert attempts == 1
 
 
@@ -167,7 +186,13 @@ def test_wait_for_port_sees_a_listening_socket() -> None:
 
 
 def test_wait_for_port_times_out_on_a_closed_port() -> None:
-    assert wait_for_port(free_tcp_port("127.0.0.1"), timeout=0.2) is False
+    """Hold the port bound but never ``listen()``: connections are refused, and
+    nothing else can take it mid-test. Asserting against a merely *released*
+    port would be the same TOCTOU these helpers exist to close - another worker
+    could bind and listen inside the window and flip the result."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        assert wait_for_port(sock.getsockname()[1], timeout=0.2) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_psn_server.py
+++ b/tests/test_psn_server.py
@@ -25,13 +25,6 @@ pytestmark = pytest.mark.integration
 # ---------------------------------------------------------------------------
 
 
-def _find_free_udp_port() -> int:
-    """Return a currently-free UDP port number (best-effort)."""
-    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
-        s.bind(("", 0))
-        return s.getsockname()[1]
-
-
 def _recv_typed(sock: socket.socket, expected_type: type, timeout: float = 2.0) -> object | None:
     """Receive packets until one of *expected_type* arrives, or the budget expires."""
     deadline = time.monotonic() + timeout

--- a/tests/test_web_diagnostics_routes.py
+++ b/tests/test_web_diagnostics_routes.py
@@ -13,7 +13,6 @@ the private-IP allowlist on the peer probe).
 from __future__ import annotations
 
 import os
-import socket
 import time
 import urllib.error
 import urllib.parse
@@ -27,6 +26,7 @@ from openfollow.configuration import load_config, save_config
 from openfollow.logging_setup import setup_logging
 from openfollow.web.discovery import PeerInfo
 from openfollow.web.server import ConfigWebServer
+from tests._ports import live_on_free_port
 
 pytestmark = pytest.mark.integration
 
@@ -51,23 +51,6 @@ def _clear_probe_log_source_cache():
 # ---------------------------------------------------------------------------
 # Infrastructure
 # ---------------------------------------------------------------------------
-
-
-def _find_free_tcp_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        return s.getsockname()[1]
-
-
-def _wait_for_port(port: int, host: str = "127.0.0.1", timeout: float = 5.0) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection((host, port), timeout=0.1):
-                return True
-        except OSError:
-            time.sleep(0.05)
-    return False
 
 
 @pytest.fixture()
@@ -104,21 +87,19 @@ def live_server(tmp_path, monkeypatch) -> Iterator[tuple[ConfigWebServer, str, s
     original_level = root.level
 
     ring = setup_logging(ring_capacity=64)
-    port = _find_free_tcp_port()
     config_path = tmp_path / "config.toml"
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name="TestSystem",
-        log_ring=ring,
-    )
-    server.start()
-    assert _wait_for_port(port)
     try:
-        yield server, f"http://127.0.0.1:{port}", str(config_path)
+        with live_on_free_port(
+            lambda port: ConfigWebServer(
+                config_path=str(config_path),
+                host="127.0.0.1",
+                port=port,
+                system_name="TestSystem",
+                log_ring=ring,
+            )
+        ) as (server, base):
+            yield server, base, str(config_path)
     finally:
-        server.stop()
         root.setLevel(original_level)
         for h in list(root.handlers):
             if h not in original_handlers:

--- a/tests/test_web_experimental_toggle.py
+++ b/tests/test_web_experimental_toggle.py
@@ -10,8 +10,6 @@ persist on/off, the one-way cascade-disable of person detection when off
 
 from __future__ import annotations
 
-import socket
-import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -21,25 +19,9 @@ import pytest
 import openfollow.web.discovery as discovery_module
 from openfollow.configuration import load_config, save_config
 from openfollow.web.server import ConfigWebServer
+from tests._ports import live_on_free_port
 
 pytestmark = pytest.mark.integration
-
-
-def _find_free_tcp_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        return int(s.getsockname()[1])
-
-
-def _wait_for_port(port: int, host: str = "127.0.0.1", timeout: float = 5.0) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection((host, port), timeout=0.1):
-                return True
-        except OSError:
-            time.sleep(0.05)
-    return False
 
 
 @pytest.fixture()
@@ -48,17 +30,15 @@ def live_server(tmp_path, monkeypatch):  # noqa: ANN001, ANN201
     for cls in (discovery_module.BeaconSender, discovery_module.BeaconReceiver):
         monkeypatch.setattr(cls, "start", lambda self: None)
         monkeypatch.setattr(cls, "stop", lambda self: None)
-    port = _find_free_tcp_port()
-    server = ConfigWebServer(
-        config_path=str(tmp_path / "config.toml"),
-        host="127.0.0.1",
-        port=port,
-        system_name="TestSystem",
-    )
-    server.start()
-    assert _wait_for_port(port), f"web server did not start on {port}"
-    yield server, f"http://127.0.0.1:{port}"
-    server.stop()
+    with live_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(tmp_path / "config.toml"),
+            host="127.0.0.1",
+            port=port,
+            system_name="TestSystem",
+        )
+    ) as (server, base):
+        yield server, base
 
 
 def _get(base: str, path: str) -> tuple[int, str]:

--- a/tests/test_web_help.py
+++ b/tests/test_web_help.py
@@ -8,8 +8,6 @@ guard, and the ``/help/<id>.html`` route (slug allow-list, 404s, content type).
 from __future__ import annotations
 
 import re
-import socket
-import time
 import urllib.error
 import urllib.request
 
@@ -22,6 +20,7 @@ from openfollow.web import server as _server_module  # noqa: F401 – registers 
 from openfollow.web._md import render_help_markdown
 from openfollow.web.routes import _WEB_HELP_DIR
 from openfollow.web.server import ConfigWebServer
+from tests._ports import live_on_free_port
 
 _TEMPLATES_DIR = _WEB_HELP_DIR.parent / "templates"
 
@@ -156,23 +155,6 @@ class TestHelpDocImageAssets:
 # ---------------------------------------------------------------------------
 
 
-def _find_free_tcp_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        return s.getsockname()[1]
-
-
-def _wait_for_port(port: int, host: str = "127.0.0.1", timeout: float = 5.0) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection((host, port), timeout=0.1):
-                return True
-        except OSError:
-            time.sleep(0.05)
-    return False
-
-
 def _get(base: str, path: str) -> tuple[int, str, str]:
     """GET ``path``; return ``(status, body, content_type)``."""
     try:
@@ -190,17 +172,15 @@ def live_server(tmp_path, monkeypatch):
     monkeypatch.setattr(discovery_module.BeaconReceiver, "start", lambda self: None)
     monkeypatch.setattr(discovery_module.BeaconReceiver, "stop", lambda self: None)
 
-    port = _find_free_tcp_port()
-    server = ConfigWebServer(
-        config_path=str(tmp_path / "config.toml"),
-        host="127.0.0.1",
-        port=port,
-        system_name="TestSystem",
-    )
-    server.start()
-    assert _wait_for_port(port), f"Web server did not start within 5 s on port {port}"
-    yield f"http://127.0.0.1:{port}"
-    server.stop()
+    with live_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(tmp_path / "config.toml"),
+            host="127.0.0.1",
+            port=port,
+            system_name="TestSystem",
+        )
+    ) as (_server, base):
+        yield base
 
 
 class TestHelpRoute:

--- a/tests/test_web_markers.py
+++ b/tests/test_web_markers.py
@@ -11,7 +11,6 @@ own catalog without sharing state across tests.
 from __future__ import annotations
 
 import json
-import socket
 import time
 import urllib.error
 import urllib.parse
@@ -24,25 +23,9 @@ from openfollow.configuration import load_config
 from openfollow.marker_catalog import MarkerCatalog
 from openfollow.marker_catalog.sync import PeerSelection
 from openfollow.web.server import ConfigWebServer
+from tests._ports import live_on_free_port
 
 pytestmark = pytest.mark.integration
-
-
-def _find_free_tcp_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        return s.getsockname()[1]
-
-
-def _wait_for_port(port: int, host: str = "127.0.0.1", timeout: float = 5.0) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection((host, port), timeout=0.1):
-                return True
-        except OSError:
-            time.sleep(0.05)
-    return False
 
 
 class _FakeSync:
@@ -66,23 +49,20 @@ def live_server(tmp_path, monkeypatch):
     monkeypatch.setattr(discovery_module.BeaconReceiver, "start", lambda self: None)
     monkeypatch.setattr(discovery_module.BeaconReceiver, "stop", lambda self: None)
 
-    port = _find_free_tcp_port()
     config_path = tmp_path / "config.toml"
     catalog = MarkerCatalog()
     sync = _FakeSync()
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name="OpenFollow test",
-        marker_catalog_provider=lambda: catalog,
-        marker_catalog_sync_provider=lambda: sync,
-    )
-    server.start()
-    assert _wait_for_port(port)
-    base = f"http://127.0.0.1:{port}"
-    yield server, base, str(config_path), catalog, sync
-    server.stop()
+    with live_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(config_path),
+            host="127.0.0.1",
+            port=port,
+            system_name="OpenFollow test",
+            marker_catalog_provider=lambda: catalog,
+            marker_catalog_sync_provider=lambda: sync,
+        )
+    ) as (server, base):
+        yield server, base, str(config_path), catalog, sync
 
 
 def _request(base: str, path: str, method: str = "GET", body: dict | None = None):
@@ -481,19 +461,16 @@ def live_server_no_providers(tmp_path, monkeypatch):
     monkeypatch.setattr(discovery_module.BeaconReceiver, "start", lambda self: None)
     monkeypatch.setattr(discovery_module.BeaconReceiver, "stop", lambda self: None)
 
-    port = _find_free_tcp_port()
     config_path = tmp_path / "config.toml"
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name="OpenFollow test",
-    )
-    server.start()
-    assert _wait_for_port(port)
-    base = f"http://127.0.0.1:{port}"
-    yield server, base, str(config_path)
-    server.stop()
+    with live_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(config_path),
+            host="127.0.0.1",
+            port=port,
+            system_name="OpenFollow test",
+        )
+    ) as (server, base):
+        yield server, base, str(config_path)
 
 
 class TestCatalogUnavailable:
@@ -544,21 +521,18 @@ def live_server_no_sync(tmp_path, monkeypatch):
     monkeypatch.setattr(discovery_module.BeaconReceiver, "start", lambda self: None)
     monkeypatch.setattr(discovery_module.BeaconReceiver, "stop", lambda self: None)
 
-    port = _find_free_tcp_port()
     config_path = tmp_path / "config.toml"
     catalog = MarkerCatalog()
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name="OpenFollow test",
-        marker_catalog_provider=lambda: catalog,
-    )
-    server.start()
-    assert _wait_for_port(port)
-    base = f"http://127.0.0.1:{port}"
-    yield server, base, str(config_path), catalog
-    server.stop()
+    with live_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(config_path),
+            host="127.0.0.1",
+            port=port,
+            system_name="OpenFollow test",
+            marker_catalog_provider=lambda: catalog,
+        )
+    ) as (server, base):
+        yield server, base, str(config_path), catalog
 
 
 class TestSyncUnavailable:
@@ -688,22 +662,19 @@ def live_server_bad_catalog_path(tmp_path, monkeypatch):
     cfg.markers_catalog_path = str(tmp_path / "does-not-exist-dir" / "markers.toml")
     save_config(cfg, str(config_path))
 
-    port = _find_free_tcp_port()
     catalog = MarkerCatalog()
     sync = _FakeSync()
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name="OpenFollow test",
-        marker_catalog_provider=lambda: catalog,
-        marker_catalog_sync_provider=lambda: sync,
-    )
-    server.start()
-    assert _wait_for_port(port)
-    base = f"http://127.0.0.1:{port}"
-    yield server, base, str(config_path), catalog, sync
-    server.stop()
+    with live_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(config_path),
+            host="127.0.0.1",
+            port=port,
+            system_name="OpenFollow test",
+            marker_catalog_provider=lambda: catalog,
+            marker_catalog_sync_provider=lambda: sync,
+        )
+    ) as (server, base):
+        yield server, base, str(config_path), catalog, sync
 
 
 class TestCatalogPersistenceFailure:

--- a/tests/test_web_midi_page.py
+++ b/tests/test_web_midi_page.py
@@ -18,8 +18,6 @@ endpoints or the populated Devices table.
 from __future__ import annotations
 
 import contextlib
-import socket
-import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -37,29 +35,9 @@ from openfollow.configuration import (
     save_config,
 )
 from openfollow.web.server import ConfigWebServer
+from tests._ports import live_on_free_port
 
 pytestmark = pytest.mark.integration
-
-
-def _find_free_tcp_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        return s.getsockname()[1]
-
-
-def _wait_for_port(
-    port: int,
-    host: str = "127.0.0.1",
-    timeout: float = 5.0,
-) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection((host, port), timeout=0.1):
-                return True
-        except OSError:
-            time.sleep(0.05)
-    return False
 
 
 def _get(base: str, path: str) -> tuple[int, str]:
@@ -109,18 +87,16 @@ def live_server(tmp_path, monkeypatch):
         "stop",
         lambda self: None,
     )
-    port = _find_free_tcp_port()
     config_path = tmp_path / "config.toml"
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name="TestSystem",
-    )
-    server.start()
-    assert _wait_for_port(port)
-    yield server, f"http://127.0.0.1:{port}", str(config_path)
-    server.stop()
+    with live_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(config_path),
+            host="127.0.0.1",
+            port=port,
+            system_name="TestSystem",
+        )
+    ) as (server, base):
+        yield server, base, str(config_path)
 
 
 @contextlib.contextmanager
@@ -158,7 +134,6 @@ def _live_server_with_midi_providers(
         "stop",
         lambda self: None,
     )
-    port = _find_free_tcp_port()
     config_path = tmp_path / "config.toml"
 
     def _devices() -> list[dict[str, Any]]:
@@ -181,26 +156,25 @@ def _live_server_with_midi_providers(
     def _capture_poll(row_id: str = "") -> dict[str, Any]:
         return dict(capture_state or {"status": "idle"})
 
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name="TestSystem",
-        midi_discovered_devices_provider=_devices,
-        midi_fader_values_provider=_values,
-        marker_fader_values_provider=_marker_values,
-        midi_capture_arm=_capture_arm,
-        midi_capture_poll=_capture_poll,
-    )
-    # Stash the arm-call counter on the server object so route
-    # tests can assert on it without exposing a global.
-    server._test_capture_arm_calls = capture_arm_calls  # type: ignore[attr-defined]
-    server.start()
-    try:
-        assert _wait_for_port(port)
-        yield server, f"http://127.0.0.1:{port}", str(config_path)
-    finally:
-        server.stop()
+    def _build(port: int) -> ConfigWebServer:
+        server = ConfigWebServer(
+            config_path=str(config_path),
+            host="127.0.0.1",
+            port=port,
+            system_name="TestSystem",
+            midi_discovered_devices_provider=_devices,
+            midi_fader_values_provider=_values,
+            marker_fader_values_provider=_marker_values,
+            midi_capture_arm=_capture_arm,
+            midi_capture_poll=_capture_poll,
+        )
+        # Stash the arm-call counter on the server object so route
+        # tests can assert on it without exposing a global.
+        server._test_capture_arm_calls = capture_arm_calls  # type: ignore[attr-defined]
+        return server
+
+    with live_on_free_port(_build) as (server, base):
+        yield server, base, str(config_path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_web_network_write.py
+++ b/tests/test_web_network_write.py
@@ -10,8 +10,6 @@ contract surfaced through the server's provider/handler callbacks.
 
 from __future__ import annotations
 
-import socket
-import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -22,6 +20,7 @@ import openfollow.web.discovery as discovery_module
 from openfollow.network.adapter import ApplyResult, Ipv4Method
 from openfollow.web.routes import _port_suffix
 from openfollow.web.server import ConfigWebServer
+from tests._ports import free_tcp_port, live_on_free_port
 
 pytestmark = pytest.mark.integration
 
@@ -102,22 +101,6 @@ class FakeNetwork:
         return self.renew_result
 
 
-def _find_free_tcp_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-
-
-def _wait_for_port(port: int, timeout: float = 5.0) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            if s.connect_ex(("127.0.0.1", port)) == 0:
-                return True
-        time.sleep(0.02)
-    return False
-
-
 def _get(base: str, path: str) -> tuple[int, str]:
     try:
         with urllib.request.urlopen(f"{base}{path}", timeout=5) as r:
@@ -162,22 +145,20 @@ def net_server(tmp_path, monkeypatch):
         monkeypatch.setattr(getattr(discovery_module, attr), "start", lambda self: None)
         monkeypatch.setattr(getattr(discovery_module, attr), "stop", lambda self: None)
     fake = FakeNetwork()
-    port = _find_free_tcp_port()
     config_path = tmp_path / "config.toml"
     config_path.write_text("controlled_marker_ids = [1]\n", encoding="utf-8")
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name="TestSystem",
-        network_config_provider=fake.config_provider,
-        network_apply_handler=fake.apply_handler,
-        network_renew_handler=fake.renew_handler,
-    )
-    server.start()
-    assert _wait_for_port(port)
-    yield fake, f"http://127.0.0.1:{port}"
-    server.stop()
+    with live_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(config_path),
+            host="127.0.0.1",
+            port=port,
+            system_name="TestSystem",
+            network_config_provider=fake.config_provider,
+            network_apply_handler=fake.apply_handler,
+            network_renew_handler=fake.renew_handler,
+        )
+    ) as (_server, base):
+        yield fake, base
 
 
 # --------------------------------------------------------------------------- #
@@ -493,24 +474,22 @@ def test_no_provider_renders_unavailable(tmp_path, monkeypatch) -> None:
     for attr in ("BeaconSender", "BeaconReceiver"):
         monkeypatch.setattr(getattr(discovery_module, attr), "start", lambda self: None)
         monkeypatch.setattr(getattr(discovery_module, attr), "stop", lambda self: None)
-    port = _find_free_tcp_port()
     config_path = tmp_path / "config.toml"
     config_path.write_text("controlled_marker_ids = [1]\n", encoding="utf-8")
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name="TestSystem",
-    )
-    server.start()
-    assert _wait_for_port(port)
-    try:
-        status, body = _get(f"http://127.0.0.1:{port}", "/section/network/status")
+    with live_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(config_path),
+            host="127.0.0.1",
+            port=port,
+            system_name="TestSystem",
+        )
+    ) as (_server, base):
+        status, body = _get(base, "/section/network/status")
         assert status == 200
         assert "unavailable" in body
         # apply with no handler returns the not-available banner, not a 500.
         status, body = _post(
-            f"http://127.0.0.1:{port}",
+            base,
             "/section/network/apply",
             {
                 "iface": "eth0",
@@ -521,7 +500,7 @@ def test_no_provider_renders_unavailable(tmp_path, monkeypatch) -> None:
         assert "not available" in body
         # renew with no handler is likewise the not-available banner, not a 500.
         status, body = _post(
-            f"http://127.0.0.1:{port}",
+            base,
             "/section/network/renew",
             {
                 "iface": "eth0",
@@ -529,8 +508,6 @@ def test_no_provider_renders_unavailable(tmp_path, monkeypatch) -> None:
         )
         assert status == 200
         assert "not available" in body
-    finally:
-        server.stop()
 
 
 # --------------------------------------------------------------------------- #
@@ -544,7 +521,7 @@ def _make_server(tmp_path, **kwargs) -> ConfigWebServer:
     return ConfigWebServer(
         config_path=str(config_path),
         host="127.0.0.1",
-        port=_find_free_tcp_port(),
+        port=free_tcp_port(),
         system_name="T",
         **kwargs,
     )

--- a/tests/test_web_osc_bindings.py
+++ b/tests/test_web_osc_bindings.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 
 import json
 import re
-import socket
-import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -48,6 +46,7 @@ from openfollow.web.routes import (
     _virtual_fader_names_for_form,
 )
 from openfollow.web.server import ConfigWebServer
+from tests._ports import live_on_free_port, start_on_free_port
 
 pytestmark = pytest.mark.integration
 
@@ -57,23 +56,6 @@ pytestmark = pytest.mark.integration
 # ---------------------------------------------------------------------------
 
 
-def _find_free_tcp_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        return s.getsockname()[1]
-
-
-def _wait_for_port(port: int, host: str = "127.0.0.1", timeout: float = 5.0) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection((host, port), timeout=0.1):
-                return True
-        except OSError:
-            time.sleep(0.05)
-    return False
-
-
 @pytest.fixture()
 def live_server(tmp_path, monkeypatch):
     monkeypatch.setattr(discovery_module.BeaconSender, "start", lambda self: None)
@@ -81,20 +63,18 @@ def live_server(tmp_path, monkeypatch):
     monkeypatch.setattr(discovery_module.BeaconReceiver, "start", lambda self: None)
     monkeypatch.setattr(discovery_module.BeaconReceiver, "stop", lambda self: None)
 
-    port = _find_free_tcp_port()
     config_path = tmp_path / "config.toml"
     # Seed a controlled marker; id 0 is reserved as "ignored" project-wide.
     config_path.write_text("controlled_marker_ids = [1]\n", encoding="utf-8")
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name="TestSystem",
-    )
-    server.start()
-    assert _wait_for_port(port)
-    yield server, f"http://127.0.0.1:{port}", str(config_path)
-    server.stop()
+    with live_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(config_path),
+            host="127.0.0.1",
+            port=port,
+            system_name="TestSystem",
+        )
+    ) as (server, base):
+        yield server, base, str(config_path)
 
 
 def _live_server_with_providers(tmp_path, monkeypatch, **providers):
@@ -106,18 +86,17 @@ def _live_server_with_providers(tmp_path, monkeypatch, **providers):
     monkeypatch.setattr(discovery_module.BeaconSender, "stop", lambda self: None)
     monkeypatch.setattr(discovery_module.BeaconReceiver, "start", lambda self: None)
     monkeypatch.setattr(discovery_module.BeaconReceiver, "stop", lambda self: None)
-    port = _find_free_tcp_port()
     config_path = tmp_path / "config.toml"
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name="TestSystem",
-        **providers,
+    server, base = start_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(config_path),
+            host="127.0.0.1",
+            port=port,
+            system_name="TestSystem",
+            **providers,
+        )
     )
-    server.start()
-    assert _wait_for_port(port)
-    return server, f"http://127.0.0.1:{port}", str(config_path)
+    return server, base, str(config_path)
 
 
 def _get(base: str, path: str) -> tuple[int, str]:

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import json
 import os
 import re
-import socket
 import sys
 import time
 import urllib.error
@@ -27,29 +26,13 @@ import openfollow.web.discovery as discovery_module
 from openfollow.configuration import AppConfig, load_config, save_config
 from openfollow.web import peer_auth
 from openfollow.web.server import ConfigWebServer
+from tests._ports import live_on_free_port, start_on_free_port
 
 pytestmark = pytest.mark.integration
 
 # ---------------------------------------------------------------------------
 # Infrastructure
 # ---------------------------------------------------------------------------
-
-
-def _find_free_tcp_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        return s.getsockname()[1]
-
-
-def _wait_for_port(port: int, host: str = "127.0.0.1", timeout: float = 5.0) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection((host, port), timeout=0.1):
-                return True
-        except OSError:
-            time.sleep(0.05)
-    return False
 
 
 @pytest.fixture()
@@ -60,20 +43,16 @@ def live_server(tmp_path, monkeypatch):
     monkeypatch.setattr(discovery_module.BeaconReceiver, "start", lambda self: None)
     monkeypatch.setattr(discovery_module.BeaconReceiver, "stop", lambda self: None)
 
-    port = _find_free_tcp_port()
     config_path = tmp_path / "config.toml"
-
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name="TestSystem",
-    )
-    server.start()
-    assert _wait_for_port(port), f"Web server did not start within 5 s on port {port}"
-
-    yield server, f"http://127.0.0.1:{port}"
-    server.stop()
+    with live_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(config_path),
+            host="127.0.0.1",
+            port=port,
+            system_name="TestSystem",
+        )
+    ) as (server, base):
+        yield server, base
 
 
 # ---------------------------------------------------------------------------
@@ -1084,7 +1063,6 @@ def pin_protected_server(tmp_path, monkeypatch):
     monkeypatch.setattr(discovery_module.BeaconReceiver, "start", lambda self: None)
     monkeypatch.setattr(discovery_module.BeaconReceiver, "stop", lambda self: None)
 
-    port = _find_free_tcp_port()
     config_path = tmp_path / "config.toml"
 
     # Write a config with a PIN before the server starts; ``_check_auth``
@@ -1093,17 +1071,15 @@ def pin_protected_server(tmp_path, monkeypatch):
     initial.web_pin = "sekret"
     save_config(initial, str(config_path))
 
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name="TestSystem",
-    )
-    server.start()
-    assert _wait_for_port(port), f"Web server did not start within 5 s on port {port}"
-
-    yield server, f"http://127.0.0.1:{port}", "sekret"
-    server.stop()
+    with live_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(config_path),
+            host="127.0.0.1",
+            port=port,
+            system_name="TestSystem",
+        )
+    ) as (server, base):
+        yield server, base, "sekret"
 
 
 def _signed_post(base: str, path: str, body_bytes: bytes, pin: str) -> int:
@@ -2389,7 +2365,6 @@ def test_api_config_export_sanitises_unsafe_system_name(
     monkeypatch.setattr(discovery_module.BeaconReceiver, "start", lambda self: None)
     monkeypatch.setattr(discovery_module.BeaconReceiver, "stop", lambda self: None)
 
-    port = _find_free_tcp_port()
     config_path = tmp_path / "config.toml"
 
     # Write config with a risky system name.
@@ -2397,17 +2372,14 @@ def test_api_config_export_sanitises_unsafe_system_name(
     cfg.psn_system_name = "Name with / and ; chars"
     save_config(cfg, str(config_path))
 
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name=cfg.psn_system_name,
-    )
-    server.start()
-    try:
-        assert _wait_for_port(port)
-        base = f"http://127.0.0.1:{port}"
-
+    with live_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(config_path),
+            host="127.0.0.1",
+            port=port,
+            system_name=cfg.psn_system_name,
+        )
+    ) as (_server, base):
         with urllib.request.urlopen(f"{base}/api/config/export", timeout=5) as resp:
             disposition = resp.headers.get("Content-Disposition", "")
             resp.read()
@@ -2415,8 +2387,6 @@ def test_api_config_export_sanitises_unsafe_system_name(
         # Forward slash and semicolon must be replaced with '-'.
         assert "/" not in disposition.split('filename="', 1)[1].split('"')[0]
         assert ";" not in disposition.split('filename="', 1)[1].split('"')[0]
-    finally:
-        server.stop()
 
 
 def test_api_config_import_rejects_non_object_json(live_server) -> None:
@@ -4476,18 +4446,16 @@ def _live_server_with_zone_providers(tmp_path, monkeypatch, **providers):
     monkeypatch.setattr(discovery_module.BeaconSender, "stop", lambda self: None)
     monkeypatch.setattr(discovery_module.BeaconReceiver, "start", lambda self: None)
     monkeypatch.setattr(discovery_module.BeaconReceiver, "stop", lambda self: None)
-    port = _find_free_tcp_port()
     config_path = tmp_path / "config.toml"
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name="TestSystem",
-        **providers,
+    return start_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(config_path),
+            host="127.0.0.1",
+            port=port,
+            system_name="TestSystem",
+            **providers,
+        )
     )
-    server.start()
-    assert _wait_for_port(port)
-    return server, f"http://127.0.0.1:{port}"
 
 
 def test_api_list_zones_uses_diagnostics_provider_when_attached(
@@ -5078,21 +5046,17 @@ def test_api_video_snapshot_returns_jpeg_when_provider_yields_bytes(
     monkeypatch.setattr(discovery_module.BeaconReceiver, "start", lambda self: None)
     monkeypatch.setattr(discovery_module.BeaconReceiver, "stop", lambda self: None)
 
-    port = _find_free_tcp_port()
     config_path = tmp_path / "config.toml"
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name="SnapTest",
-        preview_snapshot_provider=lambda: b"\xff\xd8\xff\xe0jpegbody",
-        full_snapshot_provider=lambda: b"\xff\xd8\xff\xe0fulljpeg",
-    )
-    server.start()
-    try:
-        assert _wait_for_port(port)
-        base = f"http://127.0.0.1:{port}"
-
+    with live_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(config_path),
+            host="127.0.0.1",
+            port=port,
+            system_name="SnapTest",
+            preview_snapshot_provider=lambda: b"\xff\xd8\xff\xe0jpegbody",
+            full_snapshot_provider=lambda: b"\xff\xd8\xff\xe0fulljpeg",
+        )
+    ) as (_server, base):
         with urllib.request.urlopen(f"{base}/api/video/snapshot", timeout=5) as r:
             assert r.status == 200
             assert r.headers.get("Content-Type", "").startswith("image/jpeg")
@@ -5103,8 +5067,6 @@ def test_api_video_snapshot_returns_jpeg_when_provider_yields_bytes(
             assert r.status == 200
             assert r.headers.get("Content-Type", "").startswith("image/jpeg")
             assert r.read() == b"\xff\xd8\xff\xe0fulljpeg"
-    finally:
-        server.stop()
 
 
 def test_api_wizard_solve_returns_camera_and_reprojected_corners(live_server) -> None:
@@ -5977,23 +5939,21 @@ def _speeds_server(tmp_path, monkeypatch, *, live_speeds, controlled_ids, disk_s
     monkeypatch.setattr(discovery_module.BeaconReceiver, "start", lambda self: None)
     monkeypatch.setattr(discovery_module.BeaconReceiver, "stop", lambda self: None)
 
-    port = _find_free_tcp_port()
     config_path = tmp_path / "config.toml"
     cfg = AppConfig(controlled_marker_ids=list(controlled_ids))
     if disk_speeds:
         cfg.marker_move_speeds = dict(disk_speeds)
     save_config(cfg, str(config_path))
 
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name="TestSystem",
-        marker_move_speeds_provider=lambda: dict(live_speeds),
+    return start_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(config_path),
+            host="127.0.0.1",
+            port=port,
+            system_name="TestSystem",
+            marker_move_speeds_provider=lambda: dict(live_speeds),
+        )
     )
-    server.start()
-    assert _wait_for_port(port)
-    return server, f"http://127.0.0.1:{port}"
 
 
 def test_section_save_preserves_live_marker_speeds_on_disk(tmp_path, monkeypatch) -> None:

--- a/tests/test_web_templates.py
+++ b/tests/test_web_templates.py
@@ -8,8 +8,6 @@ Routes are exercised against a live :class:`ConfigWebServer`.
 from __future__ import annotations
 
 import json
-import socket
-import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -28,29 +26,13 @@ from openfollow.templates import TEMPLATE_VERSION
 from openfollow.templates.loader import list_templates_by_type
 from openfollow.templates.writer import TemplateWriteError, write_user_template
 from openfollow.web.server import ConfigWebServer
+from tests._ports import live_on_free_port
 
 pytestmark = pytest.mark.integration
 
 # ---------------------------------------------------------------------------
 # Live-server fixture
 # ---------------------------------------------------------------------------
-
-
-def _find_free_tcp_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        return s.getsockname()[1]
-
-
-def _wait_for_port(port: int, host: str = "127.0.0.1", timeout: float = 5.0) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection((host, port), timeout=0.1):
-                return True
-        except OSError:
-            time.sleep(0.05)
-    return False
 
 
 @pytest.fixture()
@@ -60,18 +42,16 @@ def live_server(tmp_path, monkeypatch):
     monkeypatch.setattr(discovery_module.BeaconReceiver, "start", lambda self: None)
     monkeypatch.setattr(discovery_module.BeaconReceiver, "stop", lambda self: None)
 
-    port = _find_free_tcp_port()
     config_path = tmp_path / "config.toml"
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name="TestSystem",
-    )
-    server.start()
-    assert _wait_for_port(port)
-    yield server, f"http://127.0.0.1:{port}", str(config_path)
-    server.stop()
+    with live_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(config_path),
+            host="127.0.0.1",
+            port=port,
+            system_name="TestSystem",
+        )
+    ) as (server, base):
+        yield server, base, str(config_path)
 
 
 def _get(base: str, path: str) -> tuple[int, str]:

--- a/tests/test_web_units_toggle.py
+++ b/tests/test_web_units_toggle.py
@@ -9,8 +9,6 @@ POST parsing, and blur validation.
 
 from __future__ import annotations
 
-import socket
-import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -20,25 +18,9 @@ import pytest
 import openfollow.web.discovery as discovery_module
 from openfollow.configuration import load_config
 from openfollow.web.server import ConfigWebServer
+from tests._ports import live_on_free_port
 
 pytestmark = pytest.mark.integration
-
-
-def _find_free_tcp_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        return int(s.getsockname()[1])
-
-
-def _wait_for_port(port: int, host: str = "127.0.0.1", timeout: float = 5.0) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection((host, port), timeout=0.1):
-                return True
-        except OSError:
-            time.sleep(0.05)
-    return False
 
 
 @pytest.fixture()
@@ -47,17 +29,15 @@ def live_server(tmp_path, monkeypatch):  # noqa: ANN001, ANN201
     for cls in (discovery_module.BeaconSender, discovery_module.BeaconReceiver):
         monkeypatch.setattr(cls, "start", lambda self: None)
         monkeypatch.setattr(cls, "stop", lambda self: None)
-    port = _find_free_tcp_port()
-    server = ConfigWebServer(
-        config_path=str(tmp_path / "config.toml"),
-        host="127.0.0.1",
-        port=port,
-        system_name="TestSystem",
-    )
-    server.start()
-    assert _wait_for_port(port), f"web server did not start on {port}"
-    yield server, f"http://127.0.0.1:{port}"
-    server.stop()
+    with live_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(tmp_path / "config.toml"),
+            host="127.0.0.1",
+            port=port,
+            system_name="TestSystem",
+        )
+    ) as (server, base):
+        yield server, base
 
 
 def _get(base: str, path: str) -> tuple[int, str]:

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -9,8 +9,6 @@ the /wizard page rendering, and the updated camera/grid default values.
 from __future__ import annotations
 
 import json
-import socket
-import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -22,6 +20,7 @@ import openfollow.web.discovery as discovery_module
 from openfollow.configuration import CameraConfig, GridConfig
 from openfollow.scene.solver import apply_overlay_distortion, project_points, solve_camera_dlt
 from openfollow.web.server import ConfigWebServer
+from tests._ports import live_on_free_port
 
 # ---------------------------------------------------------------------------
 # Markers
@@ -58,23 +57,6 @@ _GRID = {
 IMG_W, IMG_H = 1920.0, 1080.0
 
 
-def _find_free_tcp_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        return s.getsockname()[1]
-
-
-def _wait_for_port(port: int, host: str = "127.0.0.1", timeout: float = 5.0) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection((host, port), timeout=0.1):
-                return True
-        except OSError:
-            time.sleep(0.05)
-    return False
-
-
 @pytest.fixture()
 def live_server(tmp_path, monkeypatch):
     monkeypatch.setattr(discovery_module.BeaconSender, "start", lambda self: None)
@@ -82,20 +64,16 @@ def live_server(tmp_path, monkeypatch):
     monkeypatch.setattr(discovery_module.BeaconReceiver, "start", lambda self: None)
     monkeypatch.setattr(discovery_module.BeaconReceiver, "stop", lambda self: None)
 
-    port = _find_free_tcp_port()
     config_path = tmp_path / "config.toml"
-
-    server = ConfigWebServer(
-        config_path=str(config_path),
-        host="127.0.0.1",
-        port=port,
-        system_name="WizardTest",
-    )
-    server.start()
-    assert _wait_for_port(port), f"Web server did not start on port {port}"
-
-    yield server, f"http://127.0.0.1:{port}"
-    server.stop()
+    with live_on_free_port(
+        lambda port: ConfigWebServer(
+            config_path=str(config_path),
+            host="127.0.0.1",
+            port=port,
+            system_name="WizardTest",
+        )
+    ) as (server, base):
+        yield server, base
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #62.

## The race

`find_free_udp_port` (and the eleven copy-pasted `_find_free_tcp_port` helpers)
closed the probe socket before returning the port, so anything on the host could
take it before the listener under test bound it: another xdist worker (`make
test` runs several), or the kernel simply re-offering that ephemeral port.

The port cannot be held open across the handoff, because the listener under test
has to bind it. So the retry belongs on the **bind**, not the pick.

## Two retry shapes, because the two failures differ

`tests/_ports.py` holds the shared helpers.

- **`bind_free_udp_port`** keys off the `OSError` a failed bind raises, and
  deliberately retries nothing else. `test_restart_listener_resets_state_when_thread_start_fails`
  injects its own `RuntimeError` into the bind path; retrying that would hide it.
- **`start_on_free_port` / `live_on_free_port`** key off the port never opening.
  `ConfigWebServer.start()` answers a taken port by quietly serving a *fallback*
  port rather than raising, so a lost race there surfaces as a five-second
  timeout on an assertion, never an exception. The issue's "worth checking the
  same pattern in the web tests" note didn't anticipate this; it needed its own
  detection.

Tests that assert the bind-failure contract itself still pass an explicitly
occupied port and call the listener directly. They want the collision.

## Scope

58 racy call sites, not the 13 the issue counted: 18 UDP across two OSC files,
22 TCP across eleven web-test files, plus the helper definitions. Consolidating
removed eleven copies of `_find_free_tcp_port` and eleven of `_wait_for_port`,
so the diff is net-negative on test code.

One site needed no change: `_make_server` in `test_web_network_write.py` only
needs a port number for the constructor and never starts the server.

## `find_free_udp_port` leaves production

It moves into `tests/_ports.py`. Nothing in `openfollow/` called it, it was
exported from `openfollow.osc.__all__`, and it carried a
`# pragma: no cover - test helper` with no matching row in the `docs/COVERAGE.md`
pragma audit table, which CLAUDE.md calls a review blocker.

## Verification

`tests/test_port_helpers.py` covers the helpers directly, including an
end-to-end test that hands `OscService` an already-occupied port and asserts the
retry takes over.

Every test was mutation-checked against a reverted helper:

| Mutation | Tests that fail |
|---|---|
| `bind_free_udp_port` doesn't retry | 3 |
| retry widened to `except Exception` | 1 |
| `start_on_free_port` doesn't retry | 2 |
| losing attempt left running | 2 |
| `live_on_free_port` skips `stop()` on a raise | 1 |

`make ci-remote` green on pi66: lint, typecheck, security, 982 tests at 100%
coverage, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
