### PR TITLE
fix(psn): carry the received tracker timestamp and status through

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,7 +301,7 @@ The HUD is **not** in the GStreamer chain. The video sink (`gtksink`) is wrapped
 
 | Site | Frame |
 |---|---|
-| `psn/receiver.py` (`set_pos` from incoming PSN packet) | PSN-absolute (raw) |
+| `psn/receiver.py` (`apply_remote` from incoming PSN packet) | PSN-absolute (raw) |
 | `psn/server.py` (`marker.to_psn_marker()` outbound) | PSN-absolute (verbatim) |
 | `input/mouse.py` (`unproject_to_plane` → `set_pos`) | PSN-absolute (direct) |
 | `runtime/services_detection_pin.py` (pin target) | PSN-absolute (direct) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,8 +327,9 @@ The HUD is **not** in the GStreamer chain. The video sink (`gtksink`) is wrapped
 - `_last_seen[tid]`: monotonic timestamp of last received packet
 - `_last_pos[tid]`: previous position for speed derivation
 - **Speed logic (per packet):**
-  1. If `t.speed` is non-zero vector: store as `set_speed(magnitude, 0, 0)`
+  1. If `t.speed` is non-zero vector: store as magnitude in the x component
   2. If `t.speed` is zero or None: derive from `delta_pos/dt`, only when actually moving (preserves last known speed when stationary)
+- **Received markers carry the sender's own `timestamp` / `status`.** Position, speed, and both fields land in one `Marker.apply_remote(...)` write, which never stamps the local clock – the wire values are the sender's, in *its* epoch, and are not comparable to `psn_timestamp_usec()` or to another sender's. Such a marker is built `remote=True` and reports `is_remote`; don't re-broadcast its timestamp as ours. Local freshness is `is_marker_online` (arrival), never the tracker timestamp
 - `is_marker_online(tid, timeout=2.0)`: returns True if packet received within 2s
 - `source_ip` parameter binds receive socket to a specific interface
 

--- a/openfollow/psn/marker.py
+++ b/openfollow/psn/marker.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import threading
 from collections.abc import Callable
+from typing import Any
 
 import pypsn
 
@@ -19,7 +20,7 @@ _VALID = 1.0
 _INVALID = 0.0
 
 
-def _clamped_status(status: float) -> float:
+def _clamped_status(status: Any) -> float:
     """Coerce a status into the spec's 0.0-1.0 range.
 
     A non-numeric or NaN value falls back to the declared default rather than
@@ -36,7 +37,7 @@ def _clamped_status(status: float) -> float:
     return min(1.0, max(0.0, value))
 
 
-def _clamped_timestamp(timestamp: int) -> int:
+def _clamped_timestamp(timestamp: Any) -> int:
     """Coerce a tracker timestamp into a non-negative microsecond count."""
     try:
         value = int(timestamp)
@@ -55,8 +56,9 @@ class Marker:
     by an internal lock to prevent torn reads when background PSN threads
     read state while the main thread updates it.
 
-    Every data write stamps ``timestamp`` and marks the marker valid, so a
-    receiver can tell a marker that is still being updated from a stale one.
+    Every position or speed write stamps ``timestamp`` and marks the marker
+    valid, so a receiver can tell a marker that is still being updated from a
+    stale one. ``set_status`` and ``set_name`` do not stamp.
 
     A marker built from received data (``remote=True``, written via
     ``apply_remote``) instead holds what its sender published, timed from that
@@ -178,8 +180,9 @@ class Marker:
         """Write one received tracker: the sender's values, never a local stamp.
 
         *speed* of ``None`` keeps the previous vector, so a sender that stops
-        publishing speed does not zero the last known one. The whole tracker
-        lands under a single lock acquisition.
+        publishing speed does not zero the last known one. ``timestamp`` and
+        ``status`` are clamped to the spec's ranges, never fabricated. The
+        whole tracker lands under a single lock acquisition.
         """
         remote_status = _clamped_status(status)
         remote_timestamp = _clamped_timestamp(timestamp)

--- a/openfollow/psn/marker.py
+++ b/openfollow/psn/marker.py
@@ -29,7 +29,7 @@ def _clamped_status(status: float) -> float:
     """
     try:
         value = float(status)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return _INVALID
     if value != value:  # NaN would reach struct.pack and ship a NaN status.
         return _INVALID
@@ -40,7 +40,7 @@ def _clamped_timestamp(timestamp: int) -> int:
     """Coerce a tracker timestamp into a non-negative microsecond count."""
     try:
         value = int(timestamp)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return 0
     return max(0, value)
 
@@ -59,11 +59,8 @@ class Marker:
     receiver can tell a marker that is still being updated from a stale one.
 
     A marker built from received data (``remote=True``, written via
-    ``apply_remote``) instead holds the values its sender published. Those count
-    from *that sender's* start, so they must never be compared against
-    ``psn_timestamp_usec()`` or re-broadcast as ours; ``is_remote`` is how a
-    holder tells the two epochs apart. Local freshness for a received marker is
-    ``PsnReceiver.is_marker_online``, which times arrival instead.
+    ``apply_remote``) instead holds what its sender published, timed from that
+    sender's start: never comparable to ours, never re-broadcast as ours.
     """
 
     __slots__ = (
@@ -187,9 +184,9 @@ class Marker:
         remote_status = _clamped_status(status)
         remote_timestamp = _clamped_timestamp(timestamp)
         with self._lock:
-            self._pos = pos
+            self._pos = (pos[0], pos[1], pos[2])
             if speed is not None:
-                self._speed = speed
+                self._speed = (speed[0], speed[1], speed[2])
             self._status = remote_status
             self._timestamp = remote_timestamp
 

--- a/openfollow/psn/marker.py
+++ b/openfollow/psn/marker.py
@@ -19,6 +19,32 @@ _VALID = 1.0
 _INVALID = 0.0
 
 
+def _clamped_status(status: float) -> float:
+    """Coerce a status into the spec's 0.0-1.0 range.
+
+    A non-numeric or NaN value falls back to the declared default rather than
+    raising: callers derive this from tracking confidence on the frame path and
+    from untrusted wire data on the receive path, where an exception would take
+    the frame (or the rest of the packet) down.
+    """
+    try:
+        value = float(status)
+    except (TypeError, ValueError):
+        return _INVALID
+    if value != value:  # NaN would reach struct.pack and ship a NaN status.
+        return _INVALID
+    return min(1.0, max(0.0, value))
+
+
+def _clamped_timestamp(timestamp: int) -> int:
+    """Coerce a tracker timestamp into a non-negative microsecond count."""
+    try:
+        value = int(timestamp)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, value)
+
+
 class Marker:
     """Mutable state wrapper for a single PSN marker.
 
@@ -31,6 +57,13 @@ class Marker:
 
     Every data write stamps ``timestamp`` and marks the marker valid, so a
     receiver can tell a marker that is still being updated from a stale one.
+
+    A marker built from received data (``remote=True``, written via
+    ``apply_remote``) instead holds the values its sender published. Those count
+    from *that sender's* start, so they must never be compared against
+    ``psn_timestamp_usec()`` or re-broadcast as ours; ``is_remote`` is how a
+    holder tells the two epochs apart. Local freshness for a received marker is
+    ``PsnReceiver.is_marker_online``, which times arrival instead.
     """
 
     __slots__ = (
@@ -43,6 +76,7 @@ class Marker:
         "_trgtpos",
         "_status",
         "_timestamp",
+        "_remote",
         "_clock",
         "_lock",
     )
@@ -52,6 +86,7 @@ class Marker:
         marker_id: int,
         name: str,
         *,
+        remote: bool = False,
         clock: Callable[[], int] = psn_timestamp_usec,
     ) -> None:
         # Marker id 0 reserved on PSN wire; validate early.
@@ -68,6 +103,7 @@ class Marker:
         self._trgtpos: Vec3 = _ZERO
         self._status: float = _INVALID
         self._timestamp: int = 0
+        self._remote: bool = bool(remote)
         self._clock = clock
         self._lock = threading.Lock()
 
@@ -106,6 +142,11 @@ class Marker:
         with self._lock:
             return self._timestamp
 
+    @property
+    def is_remote(self) -> bool:
+        """True when this marker mirrors a sender on the network."""
+        return self._remote
+
     def set_pos(self, x: float, y: float, z: float) -> None:
         """Set the marker position in PSN coordinates."""
         with self._lock:
@@ -124,20 +165,33 @@ class Marker:
             self._stamp_locked()
 
     def set_status(self, status: float) -> None:
-        """Set the tracker validity, clamped to the 0.0-1.0 range.
-
-        A non-numeric value falls back to the declared default rather than
-        raising: callers derive this from tracking confidence on the frame
-        path, where an exception would take the frame down.
-        """
-        try:
-            value = float(status)
-        except (TypeError, ValueError):
-            value = _INVALID
-        if value != value:  # NaN would reach struct.pack and ship a NaN status.
-            value = _INVALID
+        """Set the tracker validity, clamped to the 0.0-1.0 range."""
+        value = _clamped_status(status)
         with self._lock:
-            self._status = min(1.0, max(0.0, value))
+            self._status = value
+
+    def apply_remote(
+        self,
+        pos: Vec3,
+        speed: Vec3 | None = None,
+        *,
+        timestamp: int,
+        status: float,
+    ) -> None:
+        """Write one received tracker: the sender's values, never a local stamp.
+
+        *speed* of ``None`` keeps the previous vector, so a sender that stops
+        publishing speed does not zero the last known one. The whole tracker
+        lands under a single lock acquisition.
+        """
+        remote_status = _clamped_status(status)
+        remote_timestamp = _clamped_timestamp(timestamp)
+        with self._lock:
+            self._pos = pos
+            if speed is not None:
+                self._speed = speed
+            self._status = remote_status
+            self._timestamp = remote_timestamp
 
     def _stamp_locked(self) -> None:
         """Record the time of this data write. Caller holds ``_lock``.

--- a/openfollow/psn/receiver.py
+++ b/openfollow/psn/receiver.py
@@ -154,9 +154,9 @@ class PsnReceiver:
                 # wire-protocol-derived names; our domain layer
                 # translates them into Marker instances at this seam.
                 # One read for the whole packet: all trackers in a packet arrive
-                # together, so they share an arrival time. Marker writes below
-                # stamp their own clock for the PSN tracker timestamp; that is a
-                # separate quantity from this arrival bookkeeping.
+                # together, so they share an arrival time. This bookkeeping is
+                # local and monotonic; the tracker timestamp the marker carries
+                # counts from the sender's start and is not comparable to it.
                 now = time.monotonic()
                 if now - self._last_evict_sweep >= _EVICT_SWEEP_INTERVAL_S:
                     self._last_evict_sweep = now
@@ -176,21 +176,21 @@ class PsnReceiver:
                     ):
                         continue
                     if t.tracker_id not in self._markers:
-                        self._markers[t.tracker_id] = Marker(t.tracker_id, f"Marker {t.tracker_id}")
+                        self._markers[t.tracker_id] = Marker(t.tracker_id, f"Marker {t.tracker_id}", remote=True)
                     tid = t.tracker_id
                     new_pos = (t.pos.x, t.pos.y, t.pos.z)
-                    self._markers[tid].set_pos(*new_pos)
                     # Use protocol speed only if non-zero; many servers (including
                     # OpenFollow itself) always send speed=(0,0,0) even when
                     # the marker is moving, so fall back to position derivation.
                     proto_speed_nonzero = t.speed is not None and (
                         t.speed.x != 0.0 or t.speed.y != 0.0 or t.speed.z != 0.0
                     )
+                    speed: tuple[float, float, float] | None = None
                     if proto_speed_nonzero:
                         # Store as scalar magnitude in the x component so
                         # services.py can read it without directional noise.
                         mag = (t.speed.x**2 + t.speed.y**2 + t.speed.z**2) ** 0.5
-                        self._markers[tid].set_speed(mag, 0.0, 0.0)
+                        speed = (mag, 0.0, 0.0)
                     else:
                         # Derive speed from position delta; only update when
                         # actually moving so the last known speed stays visible.
@@ -203,7 +203,15 @@ class PsnReceiver:
                                 dy = new_pos[1] - prev_pos[1]
                                 dz = new_pos[2] - prev_pos[2]
                                 if dx != 0.0 or dy != 0.0 or dz != 0.0:
-                                    self._markers[tid].set_speed(dx / dt, dy / dt, dz / dt)
+                                    speed = (dx / dt, dy / dt, dz / dt)
+                    # The sender's own timestamp and status, verbatim - stamping
+                    # our clock here would report a local quantity as theirs.
+                    self._markers[tid].apply_remote(
+                        new_pos,
+                        speed,
+                        timestamp=t.timestamp,
+                        status=t.status,
+                    )
                     self._last_pos[tid] = new_pos
                     self._last_seen[tid] = now
         except Exception:

--- a/openfollow/psn/receiver.py
+++ b/openfollow/psn/receiver.py
@@ -63,6 +63,7 @@ DEFAULT_PORT = 56565
 # process lifetime. A returning marker is re-created on its next packet.
 _MARKER_TTL_S = 60.0
 _EVICT_SWEEP_INTERVAL_S = 5.0  # throttle the sweep so a packet flood can't make it hot
+_INVALID_STATUS = 0.0  # what a tracker's validity reads as when the sender publishes none
 
 
 class PsnReceiver:
@@ -154,9 +155,8 @@ class PsnReceiver:
                 # wire-protocol-derived names; our domain layer
                 # translates them into Marker instances at this seam.
                 # One read for the whole packet: all trackers in a packet arrive
-                # together, so they share an arrival time. This bookkeeping is
-                # local and monotonic; the tracker timestamp the marker carries
-                # counts from the sender's start and is not comparable to it.
+                # together, so they share an arrival time. Local and monotonic -
+                # not comparable to the sender-timed stamp the marker carries.
                 now = time.monotonic()
                 if now - self._last_evict_sweep >= _EVICT_SWEEP_INTERVAL_S:
                     self._last_evict_sweep = now
@@ -204,13 +204,13 @@ class PsnReceiver:
                                 dz = new_pos[2] - prev_pos[2]
                                 if dx != 0.0 or dy != 0.0 or dz != 0.0:
                                     speed = (dx / dt, dy / dt, dz / dt)
-                    # The sender's own timestamp and status, verbatim - stamping
-                    # our clock here would report a local quantity as theirs.
+                    # The sender's own timestamp and status, verbatim; read
+                    # defensively so a parser swap can't abort the rest of the frame.
                     self._markers[tid].apply_remote(
                         new_pos,
                         speed,
-                        timestamp=t.timestamp,
-                        status=t.status,
+                        timestamp=getattr(t, "timestamp", 0),
+                        status=getattr(t, "status", _INVALID_STATUS),
                     )
                     self._last_pos[tid] = new_pos
                     self._last_seen[tid] = now

--- a/openfollow/psn/receiver.py
+++ b/openfollow/psn/receiver.py
@@ -204,8 +204,8 @@ class PsnReceiver:
                                 dz = new_pos[2] - prev_pos[2]
                                 if dx != 0.0 or dy != 0.0 or dz != 0.0:
                                     speed = (dx / dt, dy / dt, dz / dt)
-                    # The sender's own timestamp and status, verbatim; read
-                    # defensively so a parser swap can't abort the rest of the frame.
+                    # The sender's own timestamp and status, normalised but never
+                    # fabricated; absent fields default rather than abort the frame.
                     self._markers[tid].apply_remote(
                         new_pos,
                         speed,

--- a/openfollow/runtime/services_marker_visuals.py
+++ b/openfollow/runtime/services_marker_visuals.py
@@ -545,7 +545,7 @@ def build_marker_visual_state(
         marker_fader = _fader_bus.marker_fader_value(tid) if _fader_bus is not None else None
 
         # Read the position tuple once so x/y/z come from a single locked
-        # snapshot. The receiver thread can call ``set_pos`` between separate
+        # snapshot. The receiver thread can call ``apply_remote`` between separate
         # ``marker.pos`` accesses, which would tear X/Y/Z across two packets.
         px, py, pz = marker.pos
 

--- a/tests/test_coordinate_system_invariants.py
+++ b/tests/test_coordinate_system_invariants.py
@@ -177,12 +177,13 @@ def test_psn_received_marker_pos_is_psn_absolute(offsets) -> None:
     """PSN receiver stores raw PSN coords; no grid-offset translation applied.
 
     This is the *definition* the rest of the system is aligned to:
-    ``set_pos`` is documented as "in PSN coordinates" and must remain so
+    ``apply_remote`` - the write ``PsnReceiver._on_packet`` makes for every
+    received tracker - is documented as "in PSN coordinates" and must remain so
     regardless of any grid offsets configured downstream.
     """
     ox, oy, oz = offsets
-    marker = Marker(7, "remote")
-    marker.set_pos(4.0, 5.0, 6.0)
+    marker = Marker(7, "remote", remote=True)
+    marker.apply_remote((4.0, 5.0, 6.0), timestamp=1, status=1.0)
 
     assert marker.pos == (4.0, 5.0, 6.0)
     # Outgoing PSN packet carries marker.pos verbatim – independent of

--- a/tests/test_psn_edge_cases.py
+++ b/tests/test_psn_edge_cases.py
@@ -40,6 +40,8 @@ class _PacketTracker:
     tracker_id: int
     pos: _Vec | None
     speed: _Vec | None
+    timestamp: int = 0
+    status: float = 0.0
 
 
 class _FakeDataPacket:

--- a/tests/test_psn_marker.py
+++ b/tests/test_psn_marker.py
@@ -106,7 +106,9 @@ def test_setters_use_lock_and_do_not_tear_reads() -> None:
 
 
 class TestTrackerTimestampAndStatus:
-    """Every tracker carries a real timestamp and status, never a constant zero.
+    """Every tracker we drive carries a real timestamp and status, never a
+    constant zero. (A received one carries its sender's values instead - see
+    :class:`TestRemoteMarker`.)
 
     The PSN spec defines the per-tracker timestamp as the time of that tracker's
     last data update (microseconds, sharing the packet header's base) and status
@@ -235,7 +237,7 @@ class TestRemoteMarker:
 
     @pytest.mark.parametrize(
         ("given", "expected"),
-        [(0.5, 0.5), (7.5, 1.0), (-3.0, 0.0), (float("nan"), 0.0), ("high", 0.0), (None, 0.0)],
+        [(0.5, 0.5), (7.5, 1.0), (-3.0, 0.0), (float("nan"), 0.0), ("high", 0.0), (None, 0.0), (10**400, 0.0)],
     )
     def test_a_wire_status_is_normalised_to_the_validity_range(self, given: object, expected: float) -> None:
         """Wire data is untrusted, and the receive thread drops the rest of the
@@ -244,7 +246,9 @@ class TestRemoteMarker:
         t.apply_remote((0.0, 0.0, 0.0), timestamp=1, status=given)  # type: ignore[arg-type]
         assert t.status == pytest.approx(expected)
 
-    @pytest.mark.parametrize(("given", "expected"), [(7, 7), (-5, 0), ("nope", 0), (None, 0)])
+    @pytest.mark.parametrize(
+        ("given", "expected"), [(7, 7), (-5, 0), ("nope", 0), (None, 0), (float("inf"), 0), (float("nan"), 0)]
+    )
     def test_a_wire_timestamp_is_normalised_to_a_non_negative_count(self, given: object, expected: int) -> None:
         t = Marker(marker_id=1, name="T1", remote=True)
         t.apply_remote((0.0, 0.0, 0.0), timestamp=given, status=1.0)  # type: ignore[arg-type]

--- a/tests/test_psn_marker.py
+++ b/tests/test_psn_marker.py
@@ -188,3 +188,68 @@ class TestTrackerTimestampAndStatus:
         converted = t.to_psn_marker()
         assert converted.timestamp == 4_242
         assert converted.status == 1.0
+
+
+class TestRemoteMarker:
+    """A marker mirroring a sender reports what that sender published.
+
+    ``timestamp`` counts from the sender's start, so any value this process
+    could stamp is the wrong quantity. Every test here pins the local clock to
+    a value distinct from the wire value: an implementation that stamps fails
+    them rather than passing by coincidence.
+    """
+
+    def test_wire_timestamp_is_kept_instead_of_the_local_clock(self) -> None:
+        t = Marker(marker_id=1, name="T1", remote=True, clock=_StepClock(999_999))
+        t.apply_remote((1.0, 2.0, 3.0), timestamp=4_242, status=1.0)
+        assert t.timestamp == 4_242
+        assert t.pos == (1.0, 2.0, 3.0)
+
+    def test_wire_status_is_kept_instead_of_being_promoted_to_valid(self) -> None:
+        """The local write path promotes an untouched marker to 1.0 on its first
+        data write; a partial validity the sender published must survive."""
+        t = Marker(marker_id=1, name="T1", remote=True, clock=_StepClock(1))
+        t.apply_remote((0.0, 0.0, 0.0), timestamp=10, status=0.25)
+        assert t.status == pytest.approx(0.25)
+
+    def test_a_later_write_can_move_the_timestamp_backwards(self) -> None:
+        """Two senders' epochs aside, one sender restarting sends its tracker
+        clock back to near zero. Only a verbatim carry can report that."""
+        t = Marker(marker_id=1, name="T1", remote=True, clock=_StepClock(1))
+        t.apply_remote((0.0, 0.0, 0.0), timestamp=9_000_000, status=1.0)
+        t.apply_remote((0.0, 0.0, 0.0), timestamp=25, status=1.0)
+        assert t.timestamp == 25
+
+    def test_speed_is_written_when_given(self) -> None:
+        t = Marker(marker_id=1, name="T1", remote=True)
+        t.apply_remote((0.0, 0.0, 0.0), (5.0, 0.0, 0.0), timestamp=1, status=1.0)
+        assert t.speed == (5.0, 0.0, 0.0)
+
+    def test_omitted_speed_keeps_the_previous_vector(self) -> None:
+        """A stationary marker stops producing a derived speed; zeroing it there
+        would drop the last known value out of the HUD."""
+        t = Marker(marker_id=1, name="T1", remote=True)
+        t.apply_remote((0.0, 0.0, 0.0), (5.0, 0.0, 0.0), timestamp=1, status=1.0)
+        t.apply_remote((1.0, 0.0, 0.0), timestamp=2, status=1.0)
+        assert t.speed == (5.0, 0.0, 0.0)
+
+    @pytest.mark.parametrize(
+        ("given", "expected"),
+        [(0.5, 0.5), (7.5, 1.0), (-3.0, 0.0), (float("nan"), 0.0), ("high", 0.0), (None, 0.0)],
+    )
+    def test_a_wire_status_is_normalised_to_the_validity_range(self, given: object, expected: float) -> None:
+        """Wire data is untrusted, and the receive thread drops the rest of the
+        packet if a write raises."""
+        t = Marker(marker_id=1, name="T1", remote=True)
+        t.apply_remote((0.0, 0.0, 0.0), timestamp=1, status=given)  # type: ignore[arg-type]
+        assert t.status == pytest.approx(expected)
+
+    @pytest.mark.parametrize(("given", "expected"), [(7, 7), (-5, 0), ("nope", 0), (None, 0)])
+    def test_a_wire_timestamp_is_normalised_to_a_non_negative_count(self, given: object, expected: int) -> None:
+        t = Marker(marker_id=1, name="T1", remote=True)
+        t.apply_remote((0.0, 0.0, 0.0), timestamp=given, status=1.0)  # type: ignore[arg-type]
+        assert t.timestamp == expected
+
+    def test_markers_are_local_unless_declared_remote(self) -> None:
+        assert Marker(marker_id=1, name="T1").is_remote is False
+        assert Marker(marker_id=1, name="T1", remote=True).is_remote is True

--- a/tests/test_psn_receiver.py
+++ b/tests/test_psn_receiver.py
@@ -36,6 +36,8 @@ class _PacketTracker:
     tracker_id: int
     pos: _Vec | None
     speed: _Vec | None
+    timestamp: int = 0
+    status: float = 0.0
 
 
 class _FakeDataPacket:
@@ -77,6 +79,42 @@ def test_receiver_derives_speed_from_position_when_protocol_speed_is_zero(monkey
     assert marker is not None
     vx, _, _ = marker.speed
     assert vx == pytest.approx(2.0)
+
+
+def test_receiver_carries_the_wire_timestamp_and_status(monkeypatch) -> None:
+    """Both fields belong to the sender: ``timestamp`` counts from the sender's
+    start and ``status`` is the validity it published. Stamping our own clock
+    (or promoting the status) reports a local quantity under a remote name."""
+    monkeypatch.setattr(receiver_module.pypsn, "PsnDataPacket", _FakeDataPacket)
+    monkeypatch.setattr(receiver_module.time, "monotonic", lambda: 10.0)
+
+    receiver = PsnReceiver()
+    receiver._on_packet(
+        _FakeDataPacket([_PacketTracker(5, _Vec(1.0, 2.0, 3.0), _Vec(0.0, 0.0, 0.0), timestamp=4_242, status=0.25)])
+    )
+
+    marker = receiver.get_marker(5)
+    assert marker is not None
+    assert marker.timestamp == 4_242
+    assert marker.status == pytest.approx(0.25)
+    assert marker.is_remote is True
+
+
+def test_receiver_lets_the_tracker_timestamp_go_backwards(monkeypatch) -> None:
+    """A restarted sender resets its tracker clock. No local stamp can move
+    backwards, so this fails any implementation that stamps - without the test
+    itself having to know what our clock reads."""
+    monkeypatch.setattr(receiver_module.pypsn, "PsnDataPacket", _FakeDataPacket)
+    monkeypatch.setattr(receiver_module.time, "monotonic", _packet_clock(1.0, 1.5))
+
+    receiver = PsnReceiver()
+    zero = _Vec(0.0, 0.0, 0.0)
+    receiver._on_packet(_FakeDataPacket([_PacketTracker(5, _Vec(1.0, 0.0, 0.0), zero, timestamp=9_000_000)]))
+    receiver._on_packet(_FakeDataPacket([_PacketTracker(5, _Vec(2.0, 0.0, 0.0), zero, timestamp=25)]))
+
+    marker = receiver.get_marker(5)
+    assert marker is not None
+    assert marker.timestamp == 25
 
 
 def test_receiver_online_timeout_uses_last_seen(monkeypatch) -> None:

--- a/tests/test_psn_receiver.py
+++ b/tests/test_psn_receiver.py
@@ -40,6 +40,16 @@ class _PacketTracker:
     status: float = 0.0
 
 
+@dataclass
+class _FieldlessPacketTracker:
+    """A tracker whose parser emitted neither optional chunk - the shape
+    ``pypsn`` would hand us if it stopped exposing the two attributes."""
+
+    tracker_id: int
+    pos: _Vec | None
+    speed: _Vec | None
+
+
 class _FakeDataPacket:
     def __init__(self, trackers: list[_PacketTracker]) -> None:
         self.trackers = trackers
@@ -117,6 +127,34 @@ def test_receiver_lets_the_tracker_timestamp_go_backwards(monkeypatch) -> None:
     assert marker.timestamp == 25
 
 
+def test_receiver_survives_a_tracker_without_timestamp_or_status(monkeypatch) -> None:
+    """``pypsn`` is an unpinned git dependency. If a parser swap stops exposing
+    either field, the tracker must degrade to the default - not raise and take
+    every later tracker in the frame down with it."""
+    monkeypatch.setattr(receiver_module.pypsn, "PsnDataPacket", _FakeDataPacket)
+    monkeypatch.setattr(receiver_module.time, "monotonic", lambda: 10.0)
+
+    receiver = PsnReceiver()
+    zero = _Vec(0.0, 0.0, 0.0)
+    receiver._on_packet(
+        _FakeDataPacket(
+            [
+                _FieldlessPacketTracker(5, _Vec(1.0, 2.0, 3.0), zero),
+                _PacketTracker(6, _Vec(4.0, 5.0, 6.0), zero, timestamp=77, status=1.0),
+            ]
+        )
+    )
+
+    fieldless = receiver.get_marker(5)
+    assert fieldless is not None
+    assert fieldless.pos == (1.0, 2.0, 3.0)
+    assert fieldless.timestamp == 0
+    assert fieldless.status == 0.0
+    later = receiver.get_marker(6)
+    assert later is not None
+    assert later.timestamp == 77
+
+
 def test_receiver_online_timeout_uses_last_seen(monkeypatch) -> None:
     receiver = PsnReceiver()
     receiver._last_seen[9] = 10.0
@@ -148,8 +186,8 @@ def test_receiver_skips_tracker_id_zero_without_dropping_later_trackers(monkeypa
 
 
 def test_receiver_skips_non_int_tracker_id_without_dropping_later_trackers(monkeypatch) -> None:
-    """#540 Low: a non-int tracker_id must be skipped, not raise on the ``< 1``
-    compare and abort the whole frame."""
+    """A non-int tracker_id must be skipped, not raise on the ``< 1`` compare
+    and abort the whole frame."""
     monkeypatch.setattr(receiver_module.pypsn, "PsnDataPacket", _FakeDataPacket)
     monkeypatch.setattr(receiver_module.time, "monotonic", lambda: 10.0)
 

--- a/tests/test_psn_receiver_mutation.py
+++ b/tests/test_psn_receiver_mutation.py
@@ -6,8 +6,11 @@ Pins wire-format parse + speed-derivation semantics of
 ``PsnReceiver._on_packet`` against mutation survivors. Targets specific
 branches that survived mutation:
 
-* ``Marker(t.marker_id, f"Marker {t.marker_id}")`` – both the id
-  and the default name must flow through unchanged.
+* ``Marker(t.tracker_id, f"Marker {t.tracker_id}", remote=True)`` – the
+  id, the default name, and the remote flag must flow through unchanged.
+  The remote flag and the four ``apply_remote`` arguments are killed in
+  ``test_psn_receiver.py`` instead, where the wire values they carry are
+  the subject rather than the parse.
 * ``t.speed is not None`` vs ``is None`` – protocol-speed vs
   position-derived dispatch.
 * ``t.speed.x != 0.0 or t.speed.y != 0.0 or t.speed.z != 0.0`` – the
@@ -74,7 +77,7 @@ class _FakeDataPacket:
 
 
 class TestMarkerIdAndNamePreserved:
-    """``Marker(t.marker_id, f"Marker {t.marker_id}")`` – mutmut
+    """``Marker(t.tracker_id, f"Marker {t.tracker_id}")`` – mutmut
     can swap either arg for ``None``; the receiver then hands back a
     ``Marker`` with a ``None`` field.
     """

--- a/tests/test_psn_receiver_mutation.py
+++ b/tests/test_psn_receiver_mutation.py
@@ -59,6 +59,8 @@ class _PacketTracker:
     tracker_id: int
     pos: _Vec | None
     speed: _Vec | None
+    timestamp: int = 0
+    status: float = 0.0
 
 
 class _FakeDataPacket:

--- a/tests/test_psn_receiver_sockets.py
+++ b/tests/test_psn_receiver_sockets.py
@@ -48,6 +48,8 @@ class _PacketTracker:
     tracker_id: int
     pos: _Vec | None
     speed: _Vec | None
+    timestamp: int = 0
+    status: float = 0.0
 
 
 class _FakeDataPacket:


### PR DESCRIPTION
Closes #92.

## The bug

`PsnReceiver._on_packet` drove every remote marker with `set_pos` / `set_speed`. Since #85 both stamp `timestamp` off **our** process epoch (`psn/clock.py`) and promote `status` to valid, while `t.timestamp` / `t.status` – the values the packet actually carried – were never read.

`Marker.timestamp` means "microseconds since *this* server started". For a marker owned by a remote sender it therefore held a quantity computed against the wrong epoch, behind an attribute name promising otherwise, and the freshness a conforming sender publishes was thrown away. Nothing reads either field on the receive path today, so this was latent – it turns real the moment the HUD, the zone engine, or a stats surface asks how fresh a remote marker is.

## The fix

The receive path now makes **one** `Marker.apply_remote(...)` write per tracker – position, speed, and the wire `timestamp` / `status` verbatim, under a single lock acquisition:

- `speed=None` keeps the previous vector, which is what the existing "stationary → keep the last known speed" path needs.
- `status` is clamped to the spec's `0.0–1.0` (NaN / non-numeric → `0.0`), `timestamp` coerced to a non-negative count. Wire data is untrusted and a raise on the receive thread drops the rest of the packet – the same failure mode the `tracker_id` guard exists for. Normalised, never fabricated.
- Received markers are built `remote=True` and expose `is_remote`, so an object carrying a foreign epoch is self-describing rather than relying on the caller remembering which getter it came from.
- Local freshness is unchanged: `_last_seen` / `is_marker_online`, which time arrival.

Status normalisation is factored out of `set_status` into `_clamped_status` and shared by both write paths.

### Semantics chosen

The sender's raw value, not a local arrival stamp. A remote `timestamp` counts from *that sender's* start and is comparable only against that sender's own header. Converting to arrival time was considered and rejected: it would duplicate `_last_seen` and discard exactly the freshness the sender published.

### Behaviour change worth knowing

`pypsn` defaults an absent status chunk to `0`, indistinguishable after parsing from a sender that genuinely published `0.0`. So a remote marker's `status` now reads `0.0` where it used to read a fabricated `1.0`. Nothing consumes it today, and `0.0` is honest ("the sender told us nothing better") where `1.0` was a claim we invented.

## Tests

- `TestRemoteMarker` in `tests/test_psn_marker.py`: wire timestamp kept over a pinned local clock, a partial wire status not promoted to valid, `speed=None` keeping the previous vector, both normalisation ladders, `is_remote` default vs declared.
- `tests/test_psn_receiver.py`: wire values land on the marker; **a second packet with an *older* timestamp moves `marker.timestamp` backwards** – impossible for any local-stamp implementation, so the test cannot pass a revert without knowing what our clock reads.
- Both new receiver tests were verified against a hand-applied revert to `set_pos` / `set_speed` (they fail), and against dropping `remote=True` (it fails).
- The four `_PacketTracker` fakes mirroring `pypsn.PsnTracker` gained the two fields; no other assertions moved.

`make ci-remote` green – 983 passed, 100% line + branch coverage, `mypy --strict` clean, build OK. No Pi was reachable, so the gate fell back to the local Mac run.