### PR TITLE
test(hw-validation): add an OSC path driver for multi-marker testing

### DIFF
--- a/scripts/hw_validation/README.md
+++ b/scripts/hw_validation/README.md
@@ -18,6 +18,7 @@ to grow into a fuller two-Pi validation suite (see the tracking issue).
 | `osc_socket_options_probe.py` | DUT | Builds clients via the deployed `OscService._make_client` and asserts the broadcast/multicast socket options (#482). |
 | `eos_console_probe.py` | workstation | Drives the deployed `OscTransmitterManager` at an Eos console / ETCnomad. `verify` reads Eos's own parameter values back and asserts the bundled ETC Eos templates' X/Y/Z mapping, exiting `0` (mapping correct) / `1` (mismatch or setup fault). `test` / `sweep` / `stream` drive the console for an operator to watch; their exit code reports only whether the sends reached the socket. |
 | `marker_catalog_two_station.py` | workstation | Reproduces the clock-skew marker-rename revert across two stations: steps station B's clock ahead, renames on A, asserts the rename holds on both. Exits `0` (PASS) / `1` (FAIL). |
+| `osc_marker_paths.py` | companion / workstation | Drives any number of markers along predefined paths (circle, figure8, line, square, spiral, random, static) over OSC, so a receiver can be checked against motion rather than a single static write. Stdlib only. `--dry-run` prints the samples instead of sending. |
 
 ## DUT-local probes (no companion)
 

--- a/scripts/hw_validation/osc_marker_paths.py
+++ b/scripts/hw_validation/osc_marker_paths.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""Drive several markers along predefined paths over OSC.
+
+A companion-side traffic generator for anything that consumes marker
+positions - PSN / OTP / RTTrPM output, trigger zones, the overlay, a console
+downstream. Markers move continuously and predictably, so a receiver can be
+checked against motion rather than a single static write::
+
+    # four markers orbiting a shared centre, 90 degrees apart, 30 Hz
+    python3 scripts/hw_validation/osc_marker_paths.py --host 10.0.0.5 \\
+        --markers 301-304 --path circle --size 3 --period 8 --duration 60
+
+    # per-marker paths, and a vertical bob between 0.5 m and 2.5 m
+    python3 scripts/hw_validation/osc_marker_paths.py --host 10.0.0.5 \\
+        --markers 301:circle,302:figure8,303:square --z-range 0.5,2.5
+
+    # see the samples without touching the network
+    python3 scripts/hw_validation/osc_marker_paths.py --markers 1-2 --dry-run
+
+Coordinates are PSN-absolute metres (X stage-left, Y upstage, Z up) - the same
+frame ``/marker/<id>`` writes land in. Stdlib only, so it runs on a bare show
+Pi with no venv. Exits ``0`` once the run completes (or on Ctrl-C).
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import random
+import socket
+import struct
+import sys
+import time
+from dataclasses import dataclass
+
+DEFAULT_PORT = 8765
+AXES: tuple[str, ...] = ("x", "y", "z")
+
+
+# --------------------------------------------------------------------------- #
+# OSC encoding (stdlib only)
+# --------------------------------------------------------------------------- #
+
+
+def _osc_pad(raw: bytes) -> bytes:
+    """Pad to the next 4-byte boundary, adding nothing when already aligned."""
+    remainder = len(raw) % 4
+    return raw if remainder == 0 else raw + b"\x00" * (4 - remainder)
+
+
+def osc_message(address: str, *values: float) -> bytes:
+    """Encode one OSC message with an all-float argument list.
+
+    The null terminator is part of the string *before* padding: an address
+    whose length is already a multiple of 4 still gets exactly one null plus
+    three pad bytes, never a spurious extra word - a receiver reads the word
+    after the terminator as the type tag.
+    """
+    out = _osc_pad(address.encode("ascii") + b"\x00")
+    out += _osc_pad(("," + "f" * len(values)).encode("ascii") + b"\x00")
+    for value in values:
+        out += struct.pack(">f", value)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Paths
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class PathParams:
+    """Geometry shared by every path in a run."""
+
+    centre_x: float = 0.0
+    centre_y: float = 0.0
+    size: float = 3.0
+    period_s: float = 8.0
+    z_low: float = 1.6
+    z_high: float = 1.6
+    z_period_s: float = 5.0
+
+    def height(self, t: float, phase: float) -> float:
+        """Z at time ``t``; constant unless a z-range was given."""
+        if self.z_low == self.z_high:
+            return self.z_low
+        mid = (self.z_low + self.z_high) / 2.0
+        swing = (self.z_high - self.z_low) / 2.0
+        turns = (t / self.z_period_s + phase) * 2.0 * math.pi
+        return mid + swing * math.sin(turns)
+
+
+class Path:
+    """A marker trajectory sampled at an absolute time.
+
+    ``phase`` is a 0-1 fraction of the period, used to spread markers that
+    share a shape so they don't stack on one point.
+    """
+
+    name = "path"
+
+    def __init__(self, params: PathParams, phase: float = 0.0) -> None:
+        self.params = params
+        self.phase = phase
+
+    def _turns(self, t: float) -> float:
+        return (t / self.params.period_s + self.phase) * 2.0 * math.pi
+
+    def _lap(self, t: float) -> float:
+        """Position within the lap as a 0-1 fraction."""
+        return (t / self.params.period_s + self.phase) % 1.0
+
+    def plane(self, t: float) -> tuple[float, float]:
+        raise NotImplementedError
+
+    def sample(self, t: float) -> tuple[float, float, float]:
+        x, y = self.plane(t)
+        return x, y, self.params.height(t, self.phase)
+
+
+class CirclePath(Path):
+    name = "circle"
+
+    def plane(self, t: float) -> tuple[float, float]:
+        p = self.params
+        angle = self._turns(t)
+        return p.centre_x + p.size * math.cos(angle), p.centre_y + p.size * math.sin(angle)
+
+
+class Figure8Path(Path):
+    """Lemniscate of Gerono - crosses its own centre once per half lap."""
+
+    name = "figure8"
+
+    def plane(self, t: float) -> tuple[float, float]:
+        p = self.params
+        angle = self._turns(t)
+        return p.centre_x + p.size * math.sin(angle), p.centre_y + p.size * math.sin(angle) * math.cos(angle)
+
+
+class LinePath(Path):
+    """Straight sweep across X, reversing at each end (triangle wave)."""
+
+    name = "line"
+
+    def plane(self, t: float) -> tuple[float, float]:
+        p = self.params
+        lap = self._lap(t)
+        offset = 4.0 * lap - 1.0 if lap < 0.5 else 3.0 - 4.0 * lap
+        return p.centre_x + p.size * offset, p.centre_y
+
+
+class SquarePath(Path):
+    """Perimeter of a square, a quarter lap per side."""
+
+    name = "square"
+
+    def plane(self, t: float) -> tuple[float, float]:
+        p = self.params
+        side, within = divmod(self._lap(t) * 4.0, 1.0)
+        span = p.size * (2.0 * within - 1.0)
+        if side == 0:
+            return p.centre_x + span, p.centre_y - p.size
+        if side == 1:
+            return p.centre_x + p.size, p.centre_y + span
+        if side == 2:
+            return p.centre_x - span, p.centre_y + p.size
+        return p.centre_x - p.size, p.centre_y - span
+
+
+class SpiralPath(Path):
+    """Outward spiral that snaps back to the centre each lap."""
+
+    name = "spiral"
+
+    _TURNS_PER_LAP = 3.0
+
+    def plane(self, t: float) -> tuple[float, float]:
+        p = self.params
+        lap = self._lap(t)
+        radius = p.size * lap
+        angle = lap * self._TURNS_PER_LAP * 2.0 * math.pi
+        return p.centre_x + radius * math.cos(angle), p.centre_y + radius * math.sin(angle)
+
+
+class RandomWalkPath(Path):
+    """Bounded drunkard's walk - the awkward case for smoothing and zones."""
+
+    name = "random"
+
+    def __init__(self, params: PathParams, phase: float = 0.0, rng: random.Random | None = None) -> None:
+        super().__init__(params, phase)
+        self._rng = rng or random.Random()
+        self._x = params.centre_x
+        self._y = params.centre_y
+        self._last_t: float | None = None
+
+    def plane(self, t: float) -> tuple[float, float]:
+        p = self.params
+        elapsed = 0.0 if self._last_t is None else max(0.0, t - self._last_t)
+        self._last_t = t
+        # One size-worth of drift per period, so --size / --period steer it
+        # the same way they steer every other path.
+        step = p.size / p.period_s * elapsed
+        self._x = _clamp(self._x + self._rng.uniform(-step, step), p.centre_x - p.size, p.centre_x + p.size)
+        self._y = _clamp(self._y + self._rng.uniform(-step, step), p.centre_y - p.size, p.centre_y + p.size)
+        return self._x, self._y
+
+
+class StaticPath(Path):
+    """Parks the marker at the centre - a control for 'is anything moving?'."""
+
+    name = "static"
+
+    def plane(self, t: float) -> tuple[float, float]:
+        return self.params.centre_x, self.params.centre_y
+
+
+PATHS: dict[str, type[Path]] = {
+    cls.name: cls for cls in (CirclePath, Figure8Path, LinePath, SquarePath, SpiralPath, RandomWalkPath, StaticPath)
+}
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
+
+
+def build_path(name: str, params: PathParams, phase: float, rng: random.Random | None = None) -> Path:
+    """Instantiate a path by name. Raises ``KeyError`` for an unknown name."""
+    cls = PATHS[name]
+    if cls is RandomWalkPath:
+        return RandomWalkPath(params, phase, rng)
+    return cls(params, phase)
+
+
+# --------------------------------------------------------------------------- #
+# Marker spec
+# --------------------------------------------------------------------------- #
+
+
+def parse_marker_spec(spec: str, default_path: str) -> list[tuple[int, str]]:
+    """Parse ``301,302:circle,400-403:square`` into ``[(id, path), ...]``.
+
+    A group without ``:path`` uses ``default_path``. Ranges are inclusive.
+    Raises ``ValueError`` with the offending token on bad input.
+    """
+    assignments: list[tuple[int, str]] = []
+    for token in (part.strip() for part in spec.split(",")):
+        if not token:
+            continue
+        ids_text, _, path_name = token.partition(":")
+        path_name = path_name.strip() or default_path
+        if path_name not in PATHS:
+            raise ValueError(f"unknown path {path_name!r} in {token!r}; choose from {', '.join(sorted(PATHS))}")
+        low_text, dash, high_text = ids_text.strip().partition("-")
+        try:
+            low = int(low_text)
+            high = int(high_text) if dash else low
+        except ValueError:
+            raise ValueError(f"marker id must be an integer: {token!r}") from None
+        if high < low:
+            raise ValueError(f"range runs backwards: {token!r}")
+        assignments.extend((marker_id, path_name) for marker_id in range(low, high + 1))
+    if not assignments:
+        raise ValueError("no markers given")
+    return assignments
+
+
+def assign_phases(assignments: list[tuple[int, str]], *, spread: bool = True) -> list[tuple[int, str, float]]:
+    """Spread markers sharing a path evenly around its period."""
+    if not spread:
+        return [(marker_id, path, 0.0) for marker_id, path in assignments]
+    per_path: dict[str, list[int]] = {}
+    for marker_id, path in assignments:
+        per_path.setdefault(path, []).append(marker_id)
+    phases = {
+        (path, marker_id): index / len(ids) for path, ids in per_path.items() for index, marker_id in enumerate(ids)
+    }
+    return [(marker_id, path, phases[(path, marker_id)]) for marker_id, path in assignments]
+
+
+# --------------------------------------------------------------------------- #
+# Driving
+# --------------------------------------------------------------------------- #
+
+
+def messages_for(marker_id: int, position: tuple[float, float, float], *, axis_mode: str) -> list[bytes]:
+    """Encode one marker update as a triple, or as three per-axis writes."""
+    if axis_mode == "axis":
+        return [osc_message(f"/marker/{marker_id}/{axis}", value) for axis, value in zip(AXES, position, strict=True)]
+    return [osc_message(f"/marker/{marker_id}", *position)]
+
+
+def run(args: argparse.Namespace) -> int:
+    params = PathParams(
+        centre_x=args.centre[0],
+        centre_y=args.centre[1],
+        size=args.size,
+        period_s=args.period,
+        z_low=args.z_range[0],
+        z_high=args.z_range[1],
+        z_period_s=args.z_period,
+    )
+    rng = random.Random(args.seed)
+    try:
+        assignments = assign_phases(parse_marker_spec(args.markers, args.path), spread=not args.no_phase_spread)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    drivers = [(marker_id, build_path(path, params, phase, rng)) for marker_id, path, phase in assignments]
+    interval = 1.0 / args.rate
+
+    print(
+        f"{'DRY RUN, no packets' if args.dry_run else f'sending to {args.host}:{args.port}'} - "
+        f"{len(drivers)} marker(s) @ {args.rate:g} Hz, "
+        f"{'unbounded' if args.duration <= 0 else f'{args.duration:g}s'}, "
+        f"mode={args.axis_mode}",
+        flush=True,
+    )
+    for marker_id, path in drivers:
+        print(f"  marker {marker_id}: {path.name} (phase {path.phase:.2f})", flush=True)
+
+    sock = None if args.dry_run else socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    started = time.monotonic()
+    sent = 0
+    ticks = 0
+    try:
+        while True:
+            now = time.monotonic()
+            elapsed = now - started
+            if args.duration > 0 and elapsed >= args.duration:
+                break
+            for marker_id, path in drivers:
+                position = path.sample(elapsed)
+                if sock is None:
+                    if args.print_every and ticks % args.print_every == 0:
+                        x, y, z = position
+                        print(f"  t={elapsed:6.2f}s marker {marker_id}: ({x:7.3f}, {y:7.3f}, {z:6.3f})")
+                else:
+                    for payload in messages_for(marker_id, position, axis_mode=args.axis_mode):
+                        sock.sendto(payload, (args.host, args.port))
+                        sent += 1
+            ticks += 1
+            # Absolute deadline, so a slow tick doesn't accumulate drift.
+            time.sleep(max(0.0, started + ticks * interval - time.monotonic()))
+    except KeyboardInterrupt:
+        print("\ninterrupted", flush=True)
+    finally:
+        if sock is not None and args.park:
+            for marker_id, _path in drivers:
+                park = (params.centre_x, params.centre_y, params.z_low)
+                for payload in messages_for(marker_id, park, axis_mode=args.axis_mode):
+                    sock.sendto(payload, (args.host, args.port))
+            print(f"parked {len(drivers)} marker(s) at the centre", flush=True)
+        if sock is not None:
+            sock.close()
+
+    print(f"done: {ticks} ticks, {sent} message(s) in {time.monotonic() - started:.1f}s", flush=True)
+    return 0
+
+
+def _pair(text: str) -> tuple[float, float]:
+    parts = text.split(",")
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError(f"expected two comma-separated numbers, got {text!r}")
+    try:
+        return float(parts[0]), float(parts[1])
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"expected numbers, got {text!r}") from None
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Drive markers along predefined paths over OSC.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="OSC listener address of the station under test")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="OSC listener port")
+    parser.add_argument("--markers", default="1", help="ids and optional paths, e.g. '301-304' or '1:circle,2:line'")
+    parser.add_argument("--path", default="circle", choices=sorted(PATHS), help="path for ids given without one")
+    parser.add_argument("--rate", type=float, default=30.0, help="updates per second per marker")
+    parser.add_argument("--duration", type=float, default=30.0, help="seconds to run; <=0 runs until Ctrl-C")
+    parser.add_argument("--centre", type=_pair, default=(0.0, 0.0), metavar="X,Y", help="path centre in metres")
+    parser.add_argument("--size", type=float, default=3.0, help="radius / half-extent in metres")
+    parser.add_argument("--period", type=float, default=8.0, help="seconds per lap")
+    parser.add_argument(
+        "--z-range",
+        type=_pair,
+        default=(1.6, 1.6),
+        metavar="LO,HI",
+        help="height in metres; equal values hold a constant Z",
+    )
+    parser.add_argument("--z-period", type=float, default=5.0, help="seconds per vertical bob")
+    parser.add_argument(
+        "--axis-mode",
+        choices=("triple", "axis"),
+        default="triple",
+        help="'triple' sends /marker/<id> x y z; 'axis' sends three /marker/<id>/<axis> writes",
+    )
+    parser.add_argument("--no-phase-spread", action="store_true", help="start every marker at the same point")
+    parser.add_argument("--seed", type=int, default=0, help="seed for the random path")
+    parser.add_argument("--park", action="store_true", help="send a final centre position on exit")
+    parser.add_argument("--dry-run", action="store_true", help="print samples instead of sending")
+    parser.add_argument("--print-every", type=int, default=15, help="dry-run: print every Nth tick (0 to silence)")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.rate <= 0:
+        print("error: --rate must be positive", file=sys.stderr)
+        return 2
+    if args.period <= 0 or args.z_period <= 0:
+        print("error: --period and --z-period must be positive", file=sys.stderr)
+        return 2
+    return run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_osc_marker_paths.py
+++ b/tests/test_osc_marker_paths.py
@@ -1,0 +1,351 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""Checks for scripts/hw_validation/osc_marker_paths.py: wire encoding that a
+real OSC receiver accepts, path geometry, and the marker spec parser."""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import itertools
+import math
+import random
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from pythonosc.osc_message import OscMessage
+
+pytestmark = pytest.mark.unit
+
+
+def _load() -> ModuleType:
+    source = inspect.getsourcefile(_load)
+    assert source, "Could not resolve current test source path"
+    script = Path(source).resolve().parents[1] / "scripts" / "hw_validation" / "osc_marker_paths.py"
+    spec = importlib.util.spec_from_file_location("osc_marker_paths", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # Registered before exec: @dataclass resolves the module's postponed
+    # annotations through sys.modules.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+drive = _load()
+
+
+# --------------------------------------------------------------------------- #
+# Wire encoding – parsed by the same library the app listens with
+# --------------------------------------------------------------------------- #
+
+
+class TestOscEncoding:
+    @pytest.mark.parametrize(
+        "address",
+        [
+            "/marker/1",  # 9 bytes – unaligned
+            "/marker/301",  # 11 bytes – terminator lands on the boundary
+            "/marker/3010",  # 12 bytes – already a multiple of 4
+            "/marker/301/x",
+        ],
+    )
+    def test_address_lengths_round_trip_through_a_real_parser(self, address: str) -> None:
+        """A string whose length is already a multiple of 4 still needs exactly
+        one terminator plus padding – an extra word is read as the type tag and
+        the message is silently dropped."""
+        raw = drive.osc_message(address, 1.5, -2.25, 0.75)
+
+        parsed = OscMessage(raw)
+
+        assert parsed.address == address
+        assert [round(v, 3) for v in parsed.params] == [1.5, -2.25, 0.75]
+
+    def test_every_encoded_message_is_four_byte_aligned(self) -> None:
+        assert len(drive.osc_message("/marker/12", 0.0, 0.0, 0.0)) % 4 == 0
+
+    def test_single_argument_message_round_trips(self) -> None:
+        parsed = OscMessage(drive.osc_message("/marker/7/z", 2.5))
+
+        assert parsed.address == "/marker/7/z"
+        assert [round(v, 3) for v in parsed.params] == [2.5]
+
+    def test_axis_mode_sends_one_message_per_axis(self) -> None:
+        payloads = drive.messages_for(4, (1.0, 2.0, 3.0), axis_mode="axis")
+
+        parsed = [OscMessage(p) for p in payloads]
+        assert [m.address for m in parsed] == ["/marker/4/x", "/marker/4/y", "/marker/4/z"]
+        assert [round(m.params[0], 3) for m in parsed] == [1.0, 2.0, 3.0]
+
+    def test_triple_mode_sends_one_message_with_three_arguments(self) -> None:
+        payloads = drive.messages_for(4, (1.0, 2.0, 3.0), axis_mode="triple")
+
+        assert len(payloads) == 1
+        parsed = OscMessage(payloads[0])
+        assert parsed.address == "/marker/4"
+        assert [round(v, 3) for v in parsed.params] == [1.0, 2.0, 3.0]
+
+
+# --------------------------------------------------------------------------- #
+# Path geometry
+# --------------------------------------------------------------------------- #
+
+
+def _params(**overrides: float) -> object:
+    base = {"centre_x": 0.0, "centre_y": 0.0, "size": 3.0, "period_s": 8.0}
+    base.update(overrides)
+    return drive.PathParams(**base)
+
+
+class TestPathGeometry:
+    def test_circle_holds_its_radius_all_the_way_round(self) -> None:
+        path = drive.CirclePath(_params())
+
+        radii = [math.dist((0.0, 0.0), path.plane(t)) for t in [0.0, 1.0, 2.5, 4.0, 6.3, 8.0]]
+
+        assert all(r == pytest.approx(3.0) for r in radii)
+
+    def test_circle_honours_a_shifted_centre(self) -> None:
+        path = drive.CirclePath(_params(centre_x=10.0, centre_y=-4.0))
+
+        for t in (0.0, 2.0, 5.5):
+            assert math.dist((10.0, -4.0), path.plane(t)) == pytest.approx(3.0)
+
+    def test_figure_eight_returns_to_the_centre_mid_lap(self) -> None:
+        """The crossing is what makes it a figure eight rather than a loop."""
+        path = drive.Figure8Path(_params())
+
+        x, y = path.plane(4.0)  # half a lap
+
+        assert (x, y) == (pytest.approx(0.0, abs=1e-9), pytest.approx(0.0, abs=1e-9))
+
+    def test_line_sweeps_the_full_span_and_reverses_at_each_end(self) -> None:
+        path = drive.LinePath(_params())
+
+        xs = [path.plane(t)[0] for t in [i * 0.05 for i in range(240)]]  # 1.5 laps
+
+        assert min(xs) == pytest.approx(-3.0, abs=0.05)
+        assert max(xs) == pytest.approx(3.0, abs=0.05)
+        assert all(abs(x) <= 3.0 + 1e-9 for x in xs)
+        deltas = [b - a for a, b in itertools.pairwise(xs)]
+        flips = sum(1 for a, b in itertools.pairwise(deltas) if a * b < 0)
+        assert flips == 2, "expected one reversal at each end of the sweep"
+
+    def test_line_stays_on_its_centre_axis(self) -> None:
+        path = drive.LinePath(_params(centre_y=2.0))
+
+        assert {round(path.plane(t)[1], 6) for t in (0.0, 1.0, 3.0, 7.0)} == {2.0}
+
+    def test_square_stays_on_its_perimeter(self) -> None:
+        path = drive.SquarePath(_params())
+
+        for t in [i * 0.05 for i in range(160)]:
+            x, y = path.plane(t)
+            assert max(abs(x), abs(y)) == pytest.approx(3.0), f"left the perimeter at t={t}"
+
+    def test_spiral_grows_from_the_centre_to_the_full_size(self) -> None:
+        path = drive.SpiralPath(_params())
+
+        radii = [math.dist((0.0, 0.0), path.plane(t)) for t in (0.0, 2.0, 4.0, 6.0)]
+
+        assert radii == sorted(radii)
+        assert radii[0] == pytest.approx(0.0)
+        assert math.dist((0.0, 0.0), path.plane(7.99)) == pytest.approx(3.0, abs=0.02)
+
+    def test_static_path_never_moves(self) -> None:
+        path = drive.StaticPath(_params(centre_x=1.0, centre_y=2.0))
+
+        assert {path.plane(t) for t in (0.0, 3.0, 11.0)} == {(1.0, 2.0)}
+
+    def test_random_walk_stays_inside_its_box_and_is_seed_reproducible(self) -> None:
+        def walk(seed: int) -> list[tuple[float, float]]:
+            path = drive.RandomWalkPath(_params(), rng=random.Random(seed))
+            return [path.plane(t) for t in [i * 0.1 for i in range(200)]]
+
+        first, again, different = walk(7), walk(7), walk(8)
+
+        assert first == again, "a seeded run must be reproducible"
+        assert first != different
+        assert all(abs(x) <= 3.0 + 1e-9 and abs(y) <= 3.0 + 1e-9 for x, y in first)
+
+
+class TestHeight:
+    def test_equal_bounds_hold_a_constant_height(self) -> None:
+        params = _params(z_low=1.6, z_high=1.6)
+
+        assert {params.height(t, 0.0) for t in (0.0, 1.0, 4.0)} == {1.6}
+
+    def test_a_range_bobs_within_its_bounds_and_uses_both_halves(self) -> None:
+        params = _params(z_low=0.5, z_high=2.5, z_period_s=4.0)
+
+        heights = [params.height(t, 0.0) for t in [i * 0.1 for i in range(40)]]
+
+        assert min(heights) == pytest.approx(0.5, abs=0.01)
+        assert max(heights) == pytest.approx(2.5, abs=0.01)
+
+    def test_sample_combines_the_plane_and_the_height(self) -> None:
+        path = drive.CirclePath(_params(z_low=2.0, z_high=2.0))
+
+        x, y, z = path.sample(0.0)
+
+        assert (x, y) == path.plane(0.0)
+        assert z == 2.0
+
+
+# --------------------------------------------------------------------------- #
+# Marker spec
+# --------------------------------------------------------------------------- #
+
+
+class TestMarkerSpec:
+    def test_bare_ids_take_the_default_path(self) -> None:
+        assert drive.parse_marker_spec("1,2", "line") == [(1, "line"), (2, "line")]
+
+    def test_per_group_paths_override_the_default(self) -> None:
+        assert drive.parse_marker_spec("1:circle,2", "line") == [(1, "circle"), (2, "line")]
+
+    def test_ranges_are_inclusive(self) -> None:
+        assert drive.parse_marker_spec("301-304:square", "circle") == [
+            (301, "square"),
+            (302, "square"),
+            (303, "square"),
+            (304, "square"),
+        ]
+
+    def test_whitespace_and_empty_tokens_are_tolerated(self) -> None:
+        assert drive.parse_marker_spec(" 1 , , 2:circle ", "line") == [(1, "line"), (2, "circle")]
+
+    @pytest.mark.parametrize(
+        ("spec", "fragment"),
+        [
+            ("1:orbit", "unknown path"),
+            ("abc", "must be an integer"),
+            ("5-2", "runs backwards"),
+            ("", "no markers"),
+            ("   ", "no markers"),
+        ],
+    )
+    def test_bad_input_names_the_offending_token(self, spec: str, fragment: str) -> None:
+        with pytest.raises(ValueError, match=fragment):
+            drive.parse_marker_spec(spec, "circle")
+
+    def test_every_registered_path_is_selectable_by_name(self) -> None:
+        for name in drive.PATHS:
+            assert drive.parse_marker_spec(f"1:{name}", "circle") == [(1, name)]
+            assert drive.build_path(name, _params(), 0.0, random.Random(0)).sample(1.0)
+
+
+class TestPhaseSpread:
+    def test_markers_sharing_a_path_are_spread_around_the_period(self) -> None:
+        spread = drive.assign_phases([(1, "circle"), (2, "circle"), (3, "circle"), (4, "circle")])
+
+        assert [phase for _id, _path, phase in spread] == [0.0, 0.25, 0.5, 0.75]
+
+    def test_each_path_is_spread_independently(self) -> None:
+        spread = drive.assign_phases([(1, "circle"), (2, "line"), (3, "circle")])
+
+        assert spread == [(1, "circle", 0.0), (2, "line", 0.0), (3, "circle", 0.5)]
+
+    def test_spread_can_be_disabled(self) -> None:
+        spread = drive.assign_phases([(1, "circle"), (2, "circle")], spread=False)
+
+        assert [phase for _id, _path, phase in spread] == [0.0, 0.0]
+
+    def test_spread_markers_do_not_occupy_the_same_point(self) -> None:
+        spread = drive.assign_phases([(1, "circle"), (2, "circle")])
+        points = {drive.build_path(path, _params(), phase).plane(0.0) for _id, path, phase in spread}
+
+        assert len(points) == 2
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+
+class TestCli:
+    def test_dry_run_sends_no_packets(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+        def explode(*_a: object, **_kw: object) -> None:
+            raise AssertionError("--dry-run must not open a socket")
+
+        monkeypatch.setattr(drive.socket, "socket", explode)
+
+        assert drive.main(["--markers", "1-2", "--duration", "0.05", "--rate", "20", "--dry-run"]) == 0
+        assert "DRY RUN" in capsys.readouterr().out
+
+    def test_run_sends_one_datagram_per_marker_per_tick(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sent: list[tuple[bytes, tuple[str, int]]] = []
+
+        class _FakeSocket:
+            def __init__(self, *_a: object, **_kw: object) -> None:
+                pass
+
+            def sendto(self, payload: bytes, dest: tuple[str, int]) -> None:
+                sent.append((payload, dest))
+
+            def close(self) -> None:
+                pass
+
+        monkeypatch.setattr(drive.socket, "socket", _FakeSocket)
+
+        rc = drive.main(
+            ["--host", "10.0.0.9", "--markers", "301-303", "--duration", "0.2", "--rate", "10", "--period", "4"]
+        )
+
+        assert rc == 0
+        assert sent, "expected datagrams"
+        assert {dest for _p, dest in sent} == {("10.0.0.9", 8765)}
+        addresses = {OscMessage(p).address for p, _d in sent}
+        assert addresses == {"/marker/301", "/marker/302", "/marker/303"}
+        assert len(sent) % 3 == 0, "each tick must cover every marker"
+
+    def test_park_sends_a_final_centre_position(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sent: list[bytes] = []
+
+        class _FakeSocket:
+            def __init__(self, *_a: object, **_kw: object) -> None:
+                pass
+
+            def sendto(self, payload: bytes, _dest: tuple[str, int]) -> None:
+                sent.append(payload)
+
+            def close(self) -> None:
+                pass
+
+        monkeypatch.setattr(drive.socket, "socket", _FakeSocket)
+
+        drive.main(
+            [
+                "--markers", "1",
+                "--duration", "0.1", "--rate", "10",
+                "--centre", "2,3", "--z-range", "1.2,1.2",
+                "--park",
+            ]
+        )  # fmt: skip
+
+        final = OscMessage(sent[-1])
+        assert [round(v, 3) for v in final.params] == [2.0, 3.0, 1.2]
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["--rate", "0"],
+            ["--rate", "-1"],
+            ["--period", "0"],
+            ["--z-period", "0"],
+        ],
+    )
+    def test_non_positive_timing_is_rejected(self, argv: list[str], capsys: pytest.CaptureFixture) -> None:
+        assert drive.main([*argv, "--dry-run", "--duration", "0.01"]) == 2
+        assert "must be positive" in capsys.readouterr().err
+
+    def test_bad_marker_spec_exits_two(self, capsys: pytest.CaptureFixture) -> None:
+        assert drive.main(["--markers", "nope", "--dry-run"]) == 2
+        assert "must be an integer" in capsys.readouterr().err
+
+    @pytest.mark.parametrize("value", ["1", "1,2,3", "a,b"])
+    def test_pair_arguments_reject_malformed_input(self, value: str) -> None:
+        with pytest.raises(SystemExit):
+            drive.build_parser().parse_args(["--centre", value])


### PR DESCRIPTION
Adds `scripts/hw_validation/osc_marker_paths.py`: a companion-side traffic generator that drives any number of markers along predefined paths over OSC.

## Why

Checking anything downstream of marker positions - PSN / OTP / RTTrPM output, trigger zones, the overlay, a console - needs markers that *move*, not a single static write. Every ad-hoc driver so far has been retyped per session. One of those retypes carried a hand-rolled OSC encoder with the wrong string padding (an address whose length is already a multiple of 4 still takes exactly one terminator plus padding, not an extra word); on a live station it read as the app dropping input, and cost a debugging detour before the real cause turned out to be the sender.

## What it does

```sh
# four markers orbiting a shared centre, 90 degrees apart, 30 Hz
python3 scripts/hw_validation/osc_marker_paths.py --host 10.0.0.5 \
    --markers 301-304 --path circle --size 3 --period 8 --duration 60

# per-marker paths plus a vertical bob
python3 scripts/hw_validation/osc_marker_paths.py --host 10.0.0.5 \
    --markers 301:circle,302:figure8,303:square --z-range 0.5,2.5

# see the samples without touching the network
python3 scripts/hw_validation/osc_marker_paths.py --markers 1-2 --dry-run
```

- **Paths**: `circle`, `figure8`, `line`, `square`, `spiral`, `random` (seeded, bounded), `static`.
- **Phase spread**: markers sharing a shape are spread evenly around its period, so four on a circle sit 90 degrees apart instead of stacking on one point. `--no-phase-spread` disables it.
- **Geometry / timing**: `--centre`, `--size`, `--period`, `--z-range`, `--z-period`, `--rate`, `--duration` (`<=0` runs until Ctrl-C).
- **`--axis-mode`**: `triple` sends `/marker/<id> x y z`; `axis` sends three `/marker/<id>/<axis>` writes, so both sides of `OscMarkerAdapter` get exercised.
- **`--dry-run`** prints samples instead of sending; **`--park`** returns every marker to the centre on exit so a run leaves no state behind.

Coordinates are PSN-absolute metres, the frame `/marker/<id>` writes land in. Stdlib only, so it runs on a bare show Pi with no venv - which is why the OSC encoder is ours rather than `python-osc`'s.

## Tests

45 tests in `tests/test_osc_marker_paths.py`: wire encoding, path geometry, the marker-spec parser, phase spread, and the CLI.

The encoding tests parse the emitted bytes back with **`pythonosc`** - the library the app actually listens with - so interoperability is pinned against a real parser rather than against my own assumptions. The padding case that caused the original bug is a parametrised case there, including an address whose length is already 4-byte aligned.

Four mutants verified to fail a test: broken padding, disabled phase spread, an unbounded random walk, and a square that cuts a corner.

## Verification

- `make ci-remote` **passed on the Pi** (aarch64 / py3.13 / trixie): 985 tests, 100.00% line + branch coverage. The Pi run caught two `zip()` calls missing `strict=` in the test file that a local script-only lint had missed.
- Driven live against a station: 500 sends, 504 receipts in the app's log (the 4 extra are `--park`), all four markers tracking.

The script lives under `scripts/`, which the coverage gate does not measure, so the new tests add no coverage surface; the README table in `scripts/hw_validation/` gains a row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)