### PR TITLE
fix(outputs): split oversize PSN, OTP and RTTrPM datagrams at the MTU

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,6 +334,22 @@ The HUD is **not** in the GStreamer chain. The video sink (`gtksink`) is wrapped
 
 **Do not gate the per-frame `set_speed` on movement.** A deliberately still marker would go stale and drop off the wire on all four protocols. `tests/test_output_staleness.py` pins the wire behaviour; `tests/test_marker_freshness.py` pins the rule.
 
+### Datagram size (`packet_chunking.MAX_DATAGRAM_BYTES`, shared by every output)
+
+Every marker-carrying output grows its datagram with the marker count, and **1472 bytes** (a 1500 B Ethernet MTU less the 20 B IPv4 and 8 B UDP headers) is the ceiling for all of them. That is the *fragmentation* threshold, which bites before any protocol's own packet limit and degrades silently – a quiet bench LAN reassembles the fragments, a loaded show network drops one and loses the whole datagram. Budget against 1472, never 1500.
+
+`chunk_to_datagrams(items, encoded_size, budget)` in [`packet_chunking.py`](openfollow/packet_chunking.py) is the one splitter: it measures through the caller's own encoder (so a protocol field added later moves the split instead of silently pushing the datagram over), keeps order, loses nothing, and emits an item that can never fit alone rather than dropping it or spinning. Each protocol then applies its own grouping mechanism:
+
+| Output | How one marker set spans datagrams | Crossed at |
+|---|---|---|
+| PSN data / info | Packets of one frame: one `frame_id` and one header timestamp repeated across them, `frame_packet_count` = the chunk count. Build the header **once per frame** – a per-packet id reassembles nothing. Capped at 255 packets (`frame_packet_count` is a uint8) | 14 / 85 markers |
+| OTP transform / name advertisement | Pages of one folio (E1.59 §6.7-6.9): shared Folio Number, `page` 0..`last_page`. Everything outside the split list repeats verbatim on every page, the Transform Layer's **Full Point Set** flag included – it describes the folio, so a page contradicting its siblings describes no coherent point set | 32 / 36 markers |
+| RTTrPM | Independent packets, each with its own `pkt_id`. RTTrPM groups nothing across packets, so no reassembly is involved | 34 markers |
+
+`PsnReceiver` needs no reassembly buffer: it reads 65535 and applies each packet's trackers independently, so a peer's split frame accumulates naturally. The `MAX_OTP_MESSAGE_OCTETS` (§6.3.1) and RTTrPM `_MAX_MODULES` / `_MAX_PACKET_BYTES` checks stay as structural backstops behind the split – they guard what the wire format can *express*, which is a different question from what the network can carry.
+
+`tests/test_output_packet_splitting.py` pins the cross-protocol invariant (no stream emits a datagram past 1472 at any marker count) plus each protocol's grouping; `scripts/hw_validation/output_datagram_size_probe.py` re-checks it on the DUT against the deployed send paths.
+
 ### PsnServer (`psn/server.py`)
 - Sends PSN multicast every ~33ms
 - `add_marker(id, name)` / `remove_marker(id)` / `get_marker(id)`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,7 +344,7 @@ Every marker-carrying output grows its datagram with the marker count, and **147
 |---|---|---|
 | PSN data / info | Packets of one frame: one `frame_id` and one header timestamp repeated across them, `frame_packet_count` = the chunk count. Build the header **once per frame** – a per-packet id reassembles nothing. Capped at 255 packets (`frame_packet_count` is a uint8) | 14 / 85 markers |
 | OTP transform / name advertisement | Pages of one folio (E1.59 §6.7-6.9): shared Folio Number, `page` 0..`last_page`. Everything outside the split list repeats verbatim on every page, the Transform Layer's **Full Point Set** flag included – it describes the folio, so a page contradicting its siblings describes no coherent point set | 32 / 36 markers |
-| RTTrPM | Independent packets, each with its own `pkt_id`. RTTrPM groups nothing across packets, so no reassembly is involved | 34 markers |
+| RTTrPM | Independent packets, each with its own `pkt_id`. RTTrPM groups nothing across packets, so no reassembly is involved | 35 markers |
 
 `PsnReceiver` needs no reassembly buffer: it reads 65535 and applies each packet's trackers independently, so a peer's split frame accumulates naturally. The `MAX_OTP_MESSAGE_OCTETS` (§6.3.1) and RTTrPM `_MAX_MODULES` / `_MAX_PACKET_BYTES` checks stay as structural backstops behind the split – they guard what the wire format can *express*, which is a different question from what the network can carry.
 

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -10,6 +10,7 @@ openfollow/              # Single unified package
 ├── system_stats.py      # Runtime system stats collector
 ├── runtime_metrics.py   # Frame metrics + overlay-state pooling helpers
 ├── net_utils.py         # Local IP/network helpers
+├── packet_chunking.py   # MTU-budgeted datagram split shared by every output
 ├── window.py            # GTK native sink window wrapper
 ├── psn/                 # PSN protocol subpackage
 │   ├── clock.py         # Shared microsecond time base (headers + trackers)

--- a/openfollow/otp/server.py
+++ b/openfollow/otp/server.py
@@ -12,10 +12,12 @@ import socket
 import struct
 import threading
 import time
+from collections.abc import Callable, Sequence
 from uuid import uuid4
 
 import multicast_expert
 
+from openfollow.packet_chunking import MAX_DATAGRAM_BYTES, chunk_to_datagrams
 from openfollow.psn.marker import Marker, marker_age_s
 
 logger = logging.getLogger(__name__)
@@ -55,6 +57,9 @@ OTP_PORT = 5568
 COMPONENT_NAME_OCTETS = 32
 POINT_NAME_OCTETS = 32
 MAX_OTP_MESSAGE_OCTETS = 1472
+
+# Page and Last Page are uint16 (Sections 6.8, 6.9).
+_MAX_FOLIO_LAST_PAGE = 0xFFFF
 
 # Timing: advertisements every 10s; transforms governed by fps (20-1000 Hz).
 ADVERTISEMENT_INTERVAL_S = 10.0
@@ -313,6 +318,20 @@ def _build_system_advertisement_layer(
 # ---------------------------------------------------------------------------
 
 
+def _check_message_length(packet: bytes, what: str) -> None:
+    """Enforce the Section 6.3.1 message cap on one page.
+
+    Callers that can span a folio split their points across pages so this never
+    fires; it stays as the backstop for a single page that cannot be divided
+    further, which no realistic point or name reaches.
+    """
+    if len(packet) > MAX_OTP_MESSAGE_OCTETS:
+        raise ValueError(
+            f"OTP {what} packet of {len(packet)} octets exceeds spec maximum "
+            f"of {MAX_OTP_MESSAGE_OCTETS} for a single page.",
+        )
+
+
 def encode_otp_transform_packet(
     *,
     cid: bytes,
@@ -323,10 +342,12 @@ def encode_otp_transform_packet(
     markers: list[Marker],
     priority: int,
     group: int = 1,
+    page: int = 0,
+    last_page: int = 0,
     sampled_timestamp_us: int | None = None,
     full_point_set: bool = True,
 ) -> bytes:
-    """Build a complete OTP Transform Message UDP payload.
+    """Build one page of an OTP Transform Message UDP payload.
 
     Section 9.6 defines a Point's sampled timestamp as the moment the
     Producer read that Point's transform, so each point carries its own:
@@ -386,20 +407,12 @@ def encode_otp_transform_packet(
         vector=VECTOR_OTP_TRANSFORM_MESSAGE,
         cid=cid,
         folio=folio,
-        page=0,
-        last_page=0,
+        page=page,
+        last_page=last_page,
         component_name=component_name,
         inner_pdu=transform,
     )
-    if len(packet) > MAX_OTP_MESSAGE_OCTETS:
-        # Section 6.3.1 – hard cap. Page splitting is intentionally out of
-        # scope for the pragmatic compliance level; fail loud
-        # so we know to revisit if a real installation ever needs it.
-        raise ValueError(
-            f"OTP transform packet of {len(packet)} octets exceeds spec maximum "
-            f"of {MAX_OTP_MESSAGE_OCTETS}; reduce marker count or implement "
-            f"Page splitting (Section 6.8).",
-        )
+    _check_message_length(packet, "transform")
     return packet
 
 
@@ -443,8 +456,10 @@ def encode_otp_name_advertisement_packet(
     system_number: int,
     markers: list[Marker],
     group: int = 1,
+    page: int = 0,
+    last_page: int = 0,
 ) -> bytes:
-    """Build a complete OTP Name Advertisement Message UDP payload."""
+    """Build one page of an OTP Name Advertisement Message UDP payload."""
     apds = [(system_number, group, marker.marker_id, marker.name) for marker in markers]
     name_layer = _build_name_advertisement_layer(
         response=True,
@@ -454,15 +469,17 @@ def encode_otp_name_advertisement_packet(
         advertisement_vector=VECTOR_OTP_ADVERTISEMENT_NAME,
         inner_pdu=name_layer,
     )
-    return _build_otp_layer(
+    packet = _build_otp_layer(
         vector=VECTOR_OTP_ADVERTISEMENT_MESSAGE,
         cid=cid,
         folio=folio,
-        page=0,
-        last_page=0,
+        page=page,
+        last_page=last_page,
         component_name=component_name,
         inner_pdu=advertisement,
     )
+    _check_message_length(packet, "name advertisement")
+    return packet
 
 
 def encode_otp_system_advertisement_packet(
@@ -891,40 +908,67 @@ class OtpServer:
     def _current_timestamp(self) -> int:
         return int(time.monotonic() * 1_000_000) - self._start_time_us
 
-    def _send_transform_packet(self, stop_event: threading.Event | None = None) -> None:
-        markers = self._snapshot_markers()
-        if not markers:
-            return
-        try:
-            payload = encode_otp_transform_packet(
-                cid=self._cid,
-                component_name=self._system_name,
-                folio=self._next_folio("transform"),
-                system_number=self._system_number,
-                timestamp_us=self._current_timestamp(),
-                markers=markers,
-                priority=self._priority,
-            )
-        except ValueError as exc:
-            # Length-cap blew (Section 6.3.1, 1472-octet hard cap).
-            # This is a config-error path: oversize means too many
-            # markers in one folio – the condition won't fix itself
-            # without operator action, so we throttle to first-5-then-
-            # every-100th occurrence. At 60 fps that's ~1.7s between
-            # log lines after the initial burst, which is enough to
-            # diagnose without flooding. Drop the packet rather than
-            # killing the loop.
+    def _send_folio(
+        self,
+        markers: list[Marker],
+        encode: Callable[[Sequence[Marker], int, int], bytes],
+        dest_ip: str,
+        what: str,
+        stop_event: threading.Event | None,
+    ) -> None:
+        """Send one folio, spread over Pages when it exceeds the MTU.
+
+        Sections 6.7-6.9: pages of one folio share its Folio Number and each
+        names the folio's last page, which is what a Consumer collects them on.
+        Everything outside the split list is repeated verbatim on every page,
+        the Transform Layer's Full Point Set flag included – it describes the
+        folio, so a page that contradicted its siblings would describe no
+        coherent point set at all.
+        """
+        pages = chunk_to_datagrams(
+            markers,
+            lambda subset: len(encode(subset, 0, 0)),
+            MAX_DATAGRAM_BYTES,
+        )
+        last_page = len(pages) - 1
+        if last_page > _MAX_FOLIO_LAST_PAGE:
             with self._lock:
                 self._oversize_drops += 1
                 drops = self._oversize_drops
             if drops <= 5 or drops % 100 == 0:
                 logger.warning(
-                    "OTP transform packet skipped (%d drops): %s",
+                    "OTP %s folio needs %d pages, capped at %d (%d drops) – markers beyond the cap are not sent",
+                    what,
+                    len(pages),
+                    _MAX_FOLIO_LAST_PAGE + 1,
                     drops,
-                    exc,
                 )
+            pages = pages[: _MAX_FOLIO_LAST_PAGE + 1]
+            last_page = _MAX_FOLIO_LAST_PAGE
+        for page, page_markers in enumerate(pages):
+            self._send(encode(page_markers, page, last_page), dest_ip, stop_event)
+
+    def _send_transform_packet(self, stop_event: threading.Event | None = None) -> None:
+        markers = self._snapshot_markers()
+        if not markers:
             return
-        self._send(payload, self._transform_dest, stop_event)
+        folio = self._next_folio("transform")
+        timestamp_us = self._current_timestamp()
+
+        def encode(page_markers: Sequence[Marker], page: int, last_page: int) -> bytes:
+            return encode_otp_transform_packet(
+                cid=self._cid,
+                component_name=self._system_name,
+                folio=folio,
+                system_number=self._system_number,
+                timestamp_us=timestamp_us,
+                markers=list(page_markers),
+                priority=self._priority,
+                page=page,
+                last_page=last_page,
+            )
+
+        self._send_folio(markers, encode, self._transform_dest, "transform", stop_event)
 
     def _send_advertisement_packets(self, stop_event: threading.Event | None = None) -> None:
         """Send Module, Name, and System advertisement packets in sequence."""
@@ -940,17 +984,20 @@ class OtpServer:
                 self._advertisement_dest,
                 stop_event,
             )
-            self._send(
-                encode_otp_name_advertisement_packet(
+            name_folio = self._next_folio("name_adv")
+
+            def encode_names(page_markers: Sequence[Marker], page: int, last_page: int) -> bytes:
+                return encode_otp_name_advertisement_packet(
                     cid=self._cid,
                     component_name=self._system_name,
-                    folio=self._next_folio("name_adv"),
+                    folio=name_folio,
                     system_number=self._system_number,
-                    markers=markers,
-                ),
-                self._advertisement_dest,
-                stop_event,
-            )
+                    markers=list(page_markers),
+                    page=page,
+                    last_page=last_page,
+                )
+
+            self._send_folio(markers, encode_names, self._advertisement_dest, "name advertisement", stop_event)
 
         self._send(
             encode_otp_system_advertisement_packet(

--- a/openfollow/otp/server.py
+++ b/openfollow/otp/server.py
@@ -56,6 +56,9 @@ MODULE_NUMBER_POSITION = 0x0001
 OTP_PORT = 5568
 COMPONENT_NAME_OCTETS = 32
 POINT_NAME_OCTETS = 32
+# Section 6.3.1. Equal to ``packet_chunking.MAX_DATAGRAM_BYTES`` because it is
+# the same rule reached from the other side: the standard caps a message at the
+# UDP payload an Ethernet MTU carries, so a legal message never fragments.
 MAX_OTP_MESSAGE_OCTETS = 1472
 
 # Page and Last Page are uint16 (Sections 6.8, 6.9).
@@ -344,6 +347,7 @@ def encode_otp_transform_packet(
     group: int = 1,
     page: int = 0,
     last_page: int = 0,
+    now_us: int | None = None,
     sampled_timestamp_us: int | None = None,
     full_point_set: bool = True,
 ) -> bytes:
@@ -364,9 +368,11 @@ def encode_otp_transform_packet(
     # immutable bytes – at 60 Hz with N markers, repeated ``+=``
     # allocates and copies in O(N²); join is O(N). Same pattern as
     # ``openfollow/rttrpm/server.py``.
-    # One read from the markers' own clock, so every point in the packet ages
-    # against the same instant.
-    now_us = markers[0].clock_now_us if markers else 0
+    # One instant for every point, so they age against the same reference. A
+    # caller spanning several pages passes the folio's, since the pages share a
+    # Transform Layer timestamp.
+    if now_us is None:
+        now_us = markers[0].clock_now_us if markers else 0
     point_pdu_parts: list[bytes] = []
     for marker in markers:
         x, y, z = marker.pos
@@ -591,10 +597,10 @@ class OtpServer:
         self._socket_thread: threading.Thread | None = None
         self._send_errors: int = 0
         self._send_total: int = 0
-        # Counter for oversized-packet drops. The length-cap (Section
-        # 6.3.1) only fires on misconfigured installs (~70+ markers in
-        # one folio); without throttling we'd flood logs at the
-        # transform fps. Same first-5-then-every-100 pattern ``_send``
+        # Counter for dropped folios: one needing more pages than Last Page
+        # can number, or one whose pages will not encode. Neither is reachable
+        # by configuration, but without throttling either would flood the log
+        # at the transform fps. Same first-5-then-every-100 pattern ``_send``
         # uses for OSError logging.
         self._oversize_drops: int = 0
 
@@ -924,17 +930,38 @@ class OtpServer:
         the Transform Layer's Full Point Set flag included – it describes the
         folio, so a page that contradicted its siblings would describe no
         coherent point set at all.
+
+        Every page is encoded before any is sent: a folio that half-arrives
+        leaves a Consumer waiting on pages that will never come, which is worse
+        than the frame simply not being there.
         """
-        pages = chunk_to_datagrams(
-            markers,
-            lambda subset: len(encode(subset, 0, 0)),
-            MAX_DATAGRAM_BYTES,
-        )
-        last_page = len(pages) - 1
-        if last_page > _MAX_FOLIO_LAST_PAGE:
-            with self._lock:
-                self._oversize_drops += 1
-                drops = self._oversize_drops
+        try:
+            payloads = self._encode_folio(markers, encode, what)
+        except ValueError:
+            # Section 6.3.1 rejects a page that cannot be made legal. Unhandled,
+            # that propagates out of the send thread and ends this output for
+            # the life of the process; drop the folio and keep transmitting.
+            drops = self._note_folio_drop()
+            if drops <= 5 or drops % 100 == 0:
+                logger.exception("OTP %s folio dropped (%d drops): page could not be encoded", what, drops)
+            return
+        for payload in payloads:
+            self._send(payload, dest_ip, stop_event)
+
+    def _encode_folio(
+        self,
+        markers: list[Marker],
+        encode: Callable[[Sequence[Marker], int, int], bytes],
+        what: str,
+    ) -> list[bytes]:
+        """Encode a folio as one page, or as the pages it needs."""
+        try:
+            return [encode(markers, 0, 0)]
+        except ValueError:
+            pass  # Over the Section 6.3.1 page cap – it needs paging.
+        pages = chunk_to_datagrams(markers, lambda subset: len(encode(subset, 0, 0)), MAX_DATAGRAM_BYTES)
+        if len(pages) - 1 > _MAX_FOLIO_LAST_PAGE:
+            drops = self._note_folio_drop()
             if drops <= 5 or drops % 100 == 0:
                 logger.warning(
                     "OTP %s folio needs %d pages, capped at %d (%d drops) – markers beyond the cap are not sent",
@@ -944,9 +971,14 @@ class OtpServer:
                     drops,
                 )
             pages = pages[: _MAX_FOLIO_LAST_PAGE + 1]
-            last_page = _MAX_FOLIO_LAST_PAGE
-        for page, page_markers in enumerate(pages):
-            self._send(encode(page_markers, page, last_page), dest_ip, stop_event)
+        last_page = len(pages) - 1
+        return [encode(page_markers, page, last_page) for page, page_markers in enumerate(pages)]
+
+    def _note_folio_drop(self) -> int:
+        """Count a dropped folio and return the running total."""
+        with self._lock:
+            self._oversize_drops += 1
+            return self._oversize_drops
 
     def _send_transform_packet(self, stop_event: threading.Event | None = None) -> None:
         markers = self._snapshot_markers()
@@ -954,6 +986,10 @@ class OtpServer:
             return
         folio = self._next_folio("transform")
         timestamp_us = self._current_timestamp()
+        # Read once for the folio, not once per page: the pages share a
+        # Transform Layer timestamp, so ageing them against different instants
+        # would report identically-fresh points as different ages.
+        now_us = markers[0].clock_now_us
 
         def encode(page_markers: Sequence[Marker], page: int, last_page: int) -> bytes:
             return encode_otp_transform_packet(
@@ -966,6 +1002,7 @@ class OtpServer:
                 priority=self._priority,
                 page=page,
                 last_page=last_page,
+                now_us=now_us,
             )
 
         self._send_folio(markers, encode, self._transform_dest, "transform", stop_event)
@@ -985,6 +1022,10 @@ class OtpServer:
                 stop_event,
             )
             name_folio = self._next_folio("name_adv")
+            # Section 13.5 wants one ascending list across the folio. Each page
+            # sorts what it is given, so the split has to cut an already-sorted
+            # list - registration order is the operator's, not ascending.
+            by_point = sorted(markers, key=lambda marker: marker.marker_id)
 
             def encode_names(page_markers: Sequence[Marker], page: int, last_page: int) -> bytes:
                 return encode_otp_name_advertisement_packet(
@@ -997,7 +1038,7 @@ class OtpServer:
                     last_page=last_page,
                 )
 
-            self._send_folio(markers, encode_names, self._advertisement_dest, "name advertisement", stop_event)
+            self._send_folio(by_point, encode_names, self._advertisement_dest, "name advertisement", stop_event)
 
         self._send(
             encode_otp_system_advertisement_packet(

--- a/openfollow/packet_chunking.py
+++ b/openfollow/packet_chunking.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""Splits an output protocol's payload list across datagrams that fit the MTU.
+
+Every marker-carrying output (PSN, OTP, RTTrPM) grows its datagram with the
+marker count, and each has its own on-the-wire mechanism for spreading one
+logical frame over several datagrams. What they share is the question of where
+to cut, which is what this module answers: pack items greedily into chunks whose
+encoded size stays inside ``MAX_DATAGRAM_BYTES``.
+
+Sizes are measured through the caller's real encoder rather than derived from a
+per-item constant, so a protocol field added later moves the split instead of
+silently pushing the datagram over the limit.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import TypeVar
+
+T = TypeVar("T")
+
+# A 1500-octet Ethernet MTU less the 20-octet IPv4 and 8-octet UDP headers.
+# This is the fragmentation threshold, which bites before any protocol's own
+# packet-size limit: an over-MTU datagram is split by IP and usually still
+# arrives on a quiet LAN, so the failure surfaces only under show-network load.
+MAX_DATAGRAM_BYTES = 1472
+
+
+def chunk_to_datagrams(
+    items: Sequence[T],
+    encoded_size: Callable[[Sequence[T]], int],
+    budget: int = MAX_DATAGRAM_BYTES,
+) -> list[Sequence[T]]:
+    """Split *items* into chunks that each encode to at most *budget* bytes.
+
+    ``encoded_size`` must return the datagram size for a given item subset. It
+    is called once per item plus once for the empty list, and the split assumes
+    per-item cost is additive on top of that fixed overhead – true of every
+    length-prefixed protocol here, where a packet is a header followed by
+    concatenated per-item records.
+
+    An item too large to ever fit is emitted alone in an oversize chunk rather
+    than dropped or spun on: the caller's protocol layer decides what an
+    unsendable single item means.
+    """
+    if not items:
+        return []
+    overhead = encoded_size(())
+    sizes = [encoded_size((item,)) - overhead for item in items]
+    chunks: list[Sequence[T]] = []
+    start = 0
+    used = overhead
+    for index, size in enumerate(sizes):
+        if index > start and used + size > budget:
+            chunks.append(items[start:index])
+            start = index
+            used = overhead
+        used += size
+    chunks.append(items[start:])
+    return chunks

--- a/openfollow/packet_chunking.py
+++ b/openfollow/packet_chunking.py
@@ -6,7 +6,9 @@ Every marker-carrying output (PSN, OTP, RTTrPM) grows its datagram with the
 marker count, and each has its own on-the-wire mechanism for spreading one
 logical frame over several datagrams. What they share is the question of where
 to cut, which is what this module answers: pack items greedily into chunks whose
-encoded size stays inside ``MAX_DATAGRAM_BYTES``.
+encoded size stays inside ``MAX_DATAGRAM_BYTES`` wherever that is possible at
+all. An item too large to fit even alone is handed back in a chunk of its own,
+for the protocol layer to decide what an unsendable item means.
 
 Sizes are measured through the caller's real encoder rather than derived from a
 per-item constant, so a protocol field added later moves the split instead of

--- a/openfollow/psn/server.py
+++ b/openfollow/psn/server.py
@@ -12,11 +12,13 @@ import errno
 import logging
 import socket
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
+from typing import TypeVar
 
 import multicast_expert
 import pypsn
 
+from openfollow.packet_chunking import MAX_DATAGRAM_BYTES, chunk_to_datagrams
 from openfollow.psn.clock import psn_timestamp_usec
 from openfollow.psn.marker import Marker, is_marker_stale
 
@@ -28,6 +30,11 @@ DEFAULT_PORT = 56565
 _MAX_SOCKET_RETRIES = 3
 _SOCKET_RETRY_DELAY = 2.0  # seconds
 _FRAME_ID_WRAP = 256  # frame_id is a uint8 on the wire
+_MAX_FRAME_PACKETS = 255  # frame_packet_count is a uint8 on the wire
+
+# Data trackers and info trackers are distinct pypsn types; a frame is built the
+# same way for both.
+_TrackerT = TypeVar("_TrackerT", pypsn.PsnTracker, pypsn.PsnTrackerInfo)
 
 
 class _Unchanged:
@@ -90,6 +97,7 @@ class PsnServer:
         self._socket_thread: threading.Thread | None = None
         self._send_errors: int = 0
         self._send_total: int = 0
+        self._oversize_drops: int = 0
 
     def add_marker(self, marker_id: int, name: str) -> Marker:
         """Register new marker (marker_id must be >= 1)."""
@@ -351,29 +359,74 @@ class PsnServer:
             self._send_info_packet(stop)
             stop.wait(interval)
 
-    def _make_psn_info(self, frame_id: int) -> pypsn.PsnInfo:
-        """Build a ``PsnInfo`` header carrying ``frame_id``."""
+    def _make_psn_info(self, frame_id: int, timestamp: int, packet_count: int) -> pypsn.PsnInfo:
+        """Build the header shared by every packet of one frame."""
         return pypsn.PsnInfo(
-            timestamp=self._clock(),
+            timestamp=timestamp,
             version_high=2,
             version_low=0,
             frame_id=frame_id,
-            packet_count=1,
+            packet_count=packet_count,
         )
 
-    def _next_data_header(self) -> pypsn.PsnInfo:
-        """Build a data-packet header, advancing the data stream's frame counter."""
+    def _next_data_frame_id(self) -> int:
+        """Take the next data-stream frame id, advancing that stream's counter."""
         with self._lock:
             frame_id = self._data_frame_id
             self._data_frame_id = (self._data_frame_id + 1) % _FRAME_ID_WRAP
-        return self._make_psn_info(frame_id)
+        return frame_id
 
-    def _next_info_header(self) -> pypsn.PsnInfo:
-        """Build an info-packet header, advancing the info stream's frame counter."""
+    def _next_info_frame_id(self) -> int:
+        """Take the next info-stream frame id, advancing that stream's counter."""
         with self._lock:
             frame_id = self._info_frame_id
             self._info_frame_id = (self._info_frame_id + 1) % _FRAME_ID_WRAP
-        return self._make_psn_info(frame_id)
+        return frame_id
+
+    def _send_frame(
+        self,
+        frame_id: int,
+        trackers: Sequence[_TrackerT],
+        encode: Callable[[pypsn.PsnInfo, Sequence[_TrackerT]], bytes],
+        stop_event: threading.Event | None,
+    ) -> None:
+        """Send one frame, split across packets when it exceeds the MTU.
+
+        Every packet of a split frame repeats one frame id and one timestamp,
+        and declares the whole frame's packet count – that triple is what a
+        receiver buffers a frame's trackers on until it has them all.
+        """
+        timestamp = self._clock()
+        # Header fields are fixed-width, so this one also sizes the chunks below.
+        single_header = self._make_psn_info(frame_id, timestamp, 1)
+        single = encode(single_header, trackers)
+        if len(single) <= MAX_DATAGRAM_BYTES:
+            self._send(single, stop_event)
+            return
+        chunks = chunk_to_datagrams(
+            trackers,
+            lambda subset: len(encode(single_header, subset)),
+            MAX_DATAGRAM_BYTES,
+        )
+        if len(chunks) > _MAX_FRAME_PACKETS:
+            # packet_count is a uint8, so a frame past this many packets cannot
+            # describe itself and struct.pack would kill the send thread. Only
+            # reachable in the thousands of markers; drop the tail rather than
+            # the stream, and throttle like the send-error path.
+            with self._lock:
+                self._oversize_drops += 1
+                drops = self._oversize_drops
+            if drops <= 5 or drops % 100 == 0:
+                logger.warning(
+                    "PSN frame needs %d packets, capped at %d (%d drops) – markers beyond the cap are not sent",
+                    len(chunks),
+                    _MAX_FRAME_PACKETS,
+                    drops,
+                )
+            chunks = chunks[:_MAX_FRAME_PACKETS]
+        header = self._make_psn_info(frame_id, timestamp, len(chunks))
+        for chunk in chunks:
+            self._send(encode(header, chunk), stop_event)
 
     def _snapshot_markers(self) -> list[Marker]:
         """Return a consistent copy of the marker list under the lock."""
@@ -392,19 +445,26 @@ class PsnServer:
         # invalid: this thread keeps transmitting at full rate regardless, so
         # validity is the only field that can say the position is no longer live.
         trackers = [t.to_psn_marker(stale=is_marker_stale(t)) for t in markers]
-        packet = pypsn.PsnDataPacket(info=self._next_data_header(), trackers=trackers)
-        self._send(pypsn.prepare_psn_data_packet_bytes(packet), stop_event)
+
+        def encode(info: pypsn.PsnInfo, chunk: Sequence[pypsn.PsnTracker]) -> bytes:
+            payload: bytes = pypsn.prepare_psn_data_packet_bytes(pypsn.PsnDataPacket(info=info, trackers=list(chunk)))
+            return payload
+
+        self._send_frame(self._next_data_frame_id(), trackers, encode, stop_event)
 
     def _send_info_packet(self, stop_event: threading.Event | None = None) -> None:
         markers = self._snapshot_markers()
         if not markers:
             return
-        packet = pypsn.PsnInfoPacket(
-            info=self._next_info_header(),
-            name=self._system_name,
-            trackers=[t.to_psn_marker_info() for t in markers],
-        )
-        self._send(pypsn.prepare_psn_info_packet_bytes(packet), stop_event)
+        trackers = [t.to_psn_marker_info() for t in markers]
+        name = self._system_name
+
+        def encode(info: pypsn.PsnInfo, chunk: Sequence[pypsn.PsnTrackerInfo]) -> bytes:
+            packet = pypsn.PsnInfoPacket(info=info, name=name, trackers=list(chunk))
+            payload: bytes = pypsn.prepare_psn_info_packet_bytes(packet)
+            return payload
+
+        self._send_frame(self._next_info_frame_id(), trackers, encode, stop_event)
 
     def _send(self, data: bytes, stop_event: threading.Event | None = None) -> None:
         sock = self._socket

--- a/openfollow/rttrpm/server.py
+++ b/openfollow/rttrpm/server.py
@@ -53,7 +53,8 @@ import socket
 import struct
 import threading
 import time
-from typing import TYPE_CHECKING
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, NamedTuple
 
 from openfollow.packet_chunking import MAX_DATAGRAM_BYTES, chunk_to_datagrams
 from openfollow.psn.marker import is_marker_stale
@@ -163,9 +164,16 @@ def encode_rttrpm_trackable_module(name: str, centroid: bytes) -> bytes:
     return struct.pack("!BH", _PKT_TYPE_TRACKABLE, total) + body
 
 
+class _FrozenMarker(NamedTuple):
+    """One frame's view of a marker: what the encoder reads, read once."""
+
+    name: str
+    pos: tuple[float, float, float]
+
+
 def encode_rttrpm_packet(
     pkt_id: int,
-    markers: list[Marker],
+    markers: Sequence[Marker | _FrozenMarker],
     context: int = 0,
 ) -> bytes:
     """Encode a complete RTTrPM UDP payload.
@@ -354,8 +362,13 @@ class RttrpmServer:
             if self._socket is None:
                 # Still down: skip encoding a packet _send() would only drop.
                 return
+        # Freeze name and position before sizing anything. The trackable module
+        # is 34 octets plus the name, and the size the split budgets against is
+        # read separately from the size the datagram is encoded at - a rename
+        # landing between the two would put a chunk over the MTU.
+        frozen = [_FrozenMarker(marker.name, marker.pos) for marker in markers]
         pkt_id = self._next_pkt_id()
-        payload = encode_rttrpm_packet(pkt_id, markers, self._context)
+        payload = encode_rttrpm_packet(pkt_id, frozen, self._context)
         if len(payload) <= MAX_DATAGRAM_BYTES:
             self._warn_if_capped(len(markers), payload)
             self._send(payload, stop_event)
@@ -364,7 +377,7 @@ class RttrpmServer:
         # complete in the packet that carries it - so one oversize packet
         # becomes several independent ones rather than needing reassembly.
         chunks = chunk_to_datagrams(
-            markers,
+            frozen,
             lambda subset: len(encode_rttrpm_packet(pkt_id, list(subset), self._context)),
             MAX_DATAGRAM_BYTES,
         )

--- a/openfollow/rttrpm/server.py
+++ b/openfollow/rttrpm/server.py
@@ -55,6 +55,7 @@ import threading
 import time
 from typing import TYPE_CHECKING
 
+from openfollow.packet_chunking import MAX_DATAGRAM_BYTES, chunk_to_datagrams
 from openfollow.psn.marker import is_marker_stale
 
 if TYPE_CHECKING:
@@ -353,11 +354,32 @@ class RttrpmServer:
             if self._socket is None:
                 # Still down: skip encoding a packet _send() would only drop.
                 return
+        pkt_id = self._next_pkt_id()
+        payload = encode_rttrpm_packet(pkt_id, markers, self._context)
+        if len(payload) <= MAX_DATAGRAM_BYTES:
+            self._warn_if_capped(len(markers), payload)
+            self._send(payload, stop_event)
+            return
+        # Over the MTU. RTTrPM groups nothing across packets - a trackable is
+        # complete in the packet that carries it - so one oversize packet
+        # becomes several independent ones rather than needing reassembly.
+        chunks = chunk_to_datagrams(
+            markers,
+            lambda subset: len(encode_rttrpm_packet(pkt_id, list(subset), self._context)),
+            MAX_DATAGRAM_BYTES,
+        )
+        for index, chunk in enumerate(chunks):
+            chunk_markers = list(chunk)
+            chunk_id = pkt_id if index == 0 else self._next_pkt_id()
+            payload = encode_rttrpm_packet(chunk_id, chunk_markers, self._context)
+            self._warn_if_capped(len(chunk_markers), payload)
+            self._send(payload, stop_event)
+
+    def _next_pkt_id(self) -> int:
+        """Take the next packet sequence number. Send-thread only, like ``_pkt_id``."""
         pkt_id = self._pkt_id
         self._pkt_id = (self._pkt_id + 1) & 0xFFFFFFFF
-        payload = encode_rttrpm_packet(pkt_id, markers, self._context)
-        self._warn_if_capped(len(markers), payload)
-        self._send(payload, stop_event)
+        return pkt_id
 
     def _warn_if_withheld(self, withheld: int) -> None:
         """Warn once per episode while trackables are being withheld as stale.

--- a/scripts/hw_validation/README.md
+++ b/scripts/hw_validation/README.md
@@ -15,6 +15,7 @@ to grow into a fuller two-Pi validation suite (see the tracking issue).
 | `analyze_results.py` | anywhere | Asserts every functionality from the receiver JSON; exits non-zero on failure. |
 | `raw_udp_probe.py` | both | Dependency-free UDP reachability preflight – tells a network drop apart from an app bug. |
 | `psn_packet_size_probe.py` | DUT | Builds real multi-tracker PSN datagrams with the deployed encoder, round-trips them through a loopback socket at 1500 vs 65535, and guards the receiver's `recvfrom` buffer (#463). |
+| `output_protocol_driver.py` | DUT | Drives N moving markers out of the deployed PSN / OTP / RTTrPM servers so real consumer software (PSNView, OTPAnalyzer, OTPView) can be pointed at the live output. `--markers 40` splits every stream; `--markers 13` is the control where nothing splits. Classifies datagrams by their own header bytes and reports per-stream counts and largest size. |
 | `output_datagram_size_probe.py` | DUT | Drives the deployed PSN / OTP / RTTrPM send paths at 4-100 markers and asserts no stream emits a datagram past the 1472 B MTU budget - the size at which IP fragments and a loaded show network starts dropping frames. Exits `0` (PASS) / `1` (FAIL). |
 | `osc_socket_options_probe.py` | DUT | Builds clients via the deployed `OscService._make_client` and asserts the broadcast/multicast socket options (#482). |
 | `eos_console_probe.py` | workstation | Drives the deployed `OscTransmitterManager` at an Eos console / ETCnomad. `verify` reads Eos's own parameter values back and asserts the bundled ETC Eos templates' X/Y/Z mapping, exiting `0` (mapping correct) / `1` (mismatch or setup fault). `test` / `sweep` / `stream` drive the console for an operator to watch; their exit code reports only whether the sends reached the socket. |
@@ -38,6 +39,22 @@ poetry run python scripts/hw_validation/osc_socket_options_probe.py
   `recvfrom(1500)` receiver then silently drops the tail markers every frame.
   The probe confirms the deployed receiver's buffer covers a realistic packet
   (40 trackers ≈ 2.1 kB).
+- **Live consumers** – `output_protocol_driver.py` is the one that needs a
+  second machine, but only as a *viewer*: it transmits and you watch. Point the
+  consumer at a **wired** interface. PSN and OTP are multicast at 60 Hz, and
+  60 Hz multicast is routinely dropped over Wi-Fi while low-rate advertisement
+  traffic survives - which looks exactly like a broken split. RTTrPM is unicast,
+  so it needs `--rttrpm-host <consumer IP>`.
+
+  OTPView and OTPAnalyzer both bind UDP `*:5568` without `SO_REUSEPORT`, so only
+  one of them can run at a time; the second silently shows nothing. A packet
+  capture has to bind the group address rather than the wildcard to coexist.
+
+  The paging boundary is where to look: at 40 markers the OTP transform splits
+  31 + 9, so **points 32-40 are the ones that only appear if paging works**, and
+  the name advertisement splits 35 + 5, so **names 36-40 are the second paged
+  stream's proof**. Everything below those numbers rides on page 0 and looks
+  identical either way.
 - **Output sizes** – every marker-carrying output splits a large set across
   datagrams rather than emitting one oversize datagram. The probe walks the
   marker counts where each stream used to cross the line (PSN data 14, OTP

--- a/scripts/hw_validation/README.md
+++ b/scripts/hw_validation/README.md
@@ -57,9 +57,9 @@ poetry run python scripts/hw_validation/osc_socket_options_probe.py
   identical either way.
 - **Output sizes** – every marker-carrying output splits a large set across
   datagrams rather than emitting one oversize datagram. The probe walks the
-  marker counts where each stream used to cross the line (PSN data 14, OTP
-  transform 32, RTTrPM 35, OTP name advertisement 36, PSN info 85) and reports
-  the largest datagram per stream.
+  marker counts that straddle each stream's boundary (PSN data 14, OTP transform
+  32, RTTrPM 35, OTP name advertisement 36, PSN info 85 with short labels) and
+  reports the largest datagram per stream.
 - **OSC** – a plain `SimpleUDPClient` to `255.255.255.255` raises `EACCES`; the
   probe confirms the deployed `_make_client` sets `SO_BROADCAST` (and reports the
   multicast TTL/loop) so broadcast/multicast rows actually transmit.

--- a/scripts/hw_validation/README.md
+++ b/scripts/hw_validation/README.md
@@ -15,6 +15,7 @@ to grow into a fuller two-Pi validation suite (see the tracking issue).
 | `analyze_results.py` | anywhere | Asserts every functionality from the receiver JSON; exits non-zero on failure. |
 | `raw_udp_probe.py` | both | Dependency-free UDP reachability preflight – tells a network drop apart from an app bug. |
 | `psn_packet_size_probe.py` | DUT | Builds real multi-tracker PSN datagrams with the deployed encoder, round-trips them through a loopback socket at 1500 vs 65535, and guards the receiver's `recvfrom` buffer (#463). |
+| `output_datagram_size_probe.py` | DUT | Drives the deployed PSN / OTP / RTTrPM send paths at 4-100 markers and asserts no stream emits a datagram past the 1472 B MTU budget - the size at which IP fragments and a loaded show network starts dropping frames. Exits `0` (PASS) / `1` (FAIL). |
 | `osc_socket_options_probe.py` | DUT | Builds clients via the deployed `OscService._make_client` and asserts the broadcast/multicast socket options (#482). |
 | `eos_console_probe.py` | workstation | Drives the deployed `OscTransmitterManager` at an Eos console / ETCnomad. `verify` reads Eos's own parameter values back and asserts the bundled ETC Eos templates' X/Y/Z mapping, exiting `0` (mapping correct) / `1` (mismatch or setup fault). `test` / `sweep` / `stream` drive the console for an operator to watch; their exit code reports only whether the sends reached the socket. |
 | `marker_catalog_two_station.py` | workstation | Reproduces the clock-skew marker-rename revert across two stations: steps station B's clock ahead, renames on A, asserts the rename holds on both. Exits `0` (PASS) / `1` (FAIL). |
@@ -29,12 +30,19 @@ no second device, no service stop. Each exits `0` (PASS) / `1` (FAIL):
 ```sh
 # On the DUT, from the repo root
 poetry run python scripts/hw_validation/psn_packet_size_probe.py
+poetry run python scripts/hw_validation/output_datagram_size_probe.py
 poetry run python scripts/hw_validation/osc_socket_options_probe.py
 ```
 
-- **PSN** – a PSN data packet crosses 1500 B at ~15 trackers; a `recvfrom(1500)`
-  receiver then silently drops the tail markers every frame. The probe confirms
-  the deployed receiver's buffer covers a realistic packet (40 trackers ≈ 2.1 kB).
+- **PSN receive** – a PSN data packet crosses 1500 B at ~15 trackers; a
+  `recvfrom(1500)` receiver then silently drops the tail markers every frame.
+  The probe confirms the deployed receiver's buffer covers a realistic packet
+  (40 trackers ≈ 2.1 kB).
+- **Output sizes** – every marker-carrying output splits a large set across
+  datagrams rather than emitting one oversize datagram. The probe walks the
+  marker counts where each stream used to cross the line (PSN data 14, OTP
+  transform 32, RTTrPM 35, OTP name advertisement 36, PSN info 85) and reports
+  the largest datagram per stream.
 - **OSC** – a plain `SimpleUDPClient` to `255.255.255.255` raises `EACCES`; the
   probe confirms the deployed `_make_client` sets `SO_BROADCAST` (and reports the
   multicast TTL/loop) so broadcast/multicast rows actually transmit.

--- a/scripts/hw_validation/output_datagram_size_probe.py
+++ b/scripts/hw_validation/output_datagram_size_probe.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""Output datagram sizes vs the MTU – DUT-local, no companion.
+
+A UDP datagram larger than 1472 B (a 1500 B Ethernet MTU less the 20 B IPv4 and
+8 B UDP headers) is fragmented by IP. A quiet bench LAN reassembles the
+fragments and everything looks fine; a loaded show network drops one and the
+whole datagram is lost, so the failure only appears where it cannot be
+debugged. Each output protocol spreads a large marker set over several
+datagrams instead: PSN over the packets of one frame, OTP over the pages of one
+folio, RTTrPM over independent packets.
+
+This drives the *deployed* send paths (``PsnServer._send_data_packet``,
+``OtpServer._send_transform_packet``, ``RttrpmServer._send_packet`` and the
+advertisement/info streams) with the send seam captured, so what is measured is
+what the unit under test would put on the wire. Run on the DUT, from the repo
+root::
+
+    poetry run python scripts/hw_validation/output_datagram_size_probe.py
+
+Exit 0 = PASS (no stream exceeds the MTU at any tested marker count), 1 = FAIL.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+from openfollow.otp.server import OtpServer
+from openfollow.packet_chunking import MAX_DATAGRAM_BYTES
+from openfollow.psn.marker import Marker
+from openfollow.psn.server import PsnServer
+from openfollow.rttrpm.server import RttrpmServer
+
+# Spans every stream's historical crossing point: PSN data at 14, OTP transform
+# at 32, RTTrPM at 35, OTP name advertisement at 36, PSN info at 85.
+MARKER_COUNTS = (4, 14, 32, 36, 64, 100)
+
+# Operator labels are what push the name-carrying streams over first.
+NAME_TEMPLATE = "Followspot Operator Position {:02d}"
+
+
+def _markers(count: int) -> list[Marker]:
+    markers = []
+    for index in range(1, count + 1):
+        marker = Marker(index, NAME_TEMPLATE.format(index))
+        marker.set_pos(float(index), float(index) * -2.0, float(index) * 0.5)
+        markers.append(marker)
+    return markers
+
+
+def _psn(count: int) -> dict[str, list[bytes]]:
+    server = PsnServer(mcast_ip=None)
+    sent: list[bytes] = []
+    server._send = lambda data, stop_event=None: sent.append(data)
+    for marker in _markers(count):
+        server._markers[marker.marker_id] = marker
+    server._send_data_packet()
+    data = list(sent)
+    sent.clear()
+    server._send_info_packet()
+    return {"PSN data": data, "PSN info": list(sent)}
+
+
+def _otp(count: int) -> dict[str, list[bytes]]:
+    server = OtpServer(system_number=1)
+    sent: list[bytes] = []
+    server._send = lambda data, dest_ip, stop_event=None: sent.append(data)
+    for marker in _markers(count):
+        server.register_marker(marker)
+    server._send_transform_packet()
+    transform = list(sent)
+    sent.clear()
+    server._send_advertisement_packets()
+    return {"OTP transform": transform, "OTP advertisement": list(sent)}
+
+
+def _rttrpm(count: int) -> dict[str, list[bytes]]:
+    server = RttrpmServer(host="127.0.0.1")
+    server._socket = MagicMock()
+    sent: list[bytes] = []
+    server._send = lambda data, stop_event=None: sent.append(data)
+    for marker in _markers(count):
+        server.register_marker(marker)
+    server._send_packet()
+    return {"RTTrPM": sent}
+
+
+def _streams(count: int) -> dict[str, list[bytes]]:
+    return {**_psn(count), **_otp(count), **_rttrpm(count)}
+
+
+def main() -> int:
+    print(f"Output datagram sizes against the {MAX_DATAGRAM_BYTES} B MTU budget:\n", flush=True)
+    failures = []
+    for count in MARKER_COUNTS:
+        print(f"  {count:>4} markers", flush=True)
+        for stream, datagrams in _streams(count).items():
+            if not datagrams:
+                failures.append(f"{stream} sent nothing at {count} markers")
+                print(f"      {stream:<20} NOTHING SENT", flush=True)
+                continue
+            largest = max(len(datagram) for datagram in datagrams)
+            over = largest > MAX_DATAGRAM_BYTES
+            if over:
+                failures.append(f"{stream} emitted {largest} B at {count} markers")
+            note = "  <- FRAGMENTS" if over else ""
+            print(
+                f"      {stream:<20} {len(datagrams):>2} datagram(s)  largest={largest:>5} B{note}",
+                flush=True,
+            )
+
+    if failures:
+        print("\nFAIL: a stream exceeded the MTU budget:", flush=True)
+        for failure in failures:
+            print(f"  - {failure}", flush=True)
+        return 1
+    print("\nPASS: every stream stays inside the MTU at every tested marker count.", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hw_validation/output_protocol_driver.py
+++ b/scripts/hw_validation/output_protocol_driver.py
@@ -38,6 +38,7 @@ import struct
 import sys
 import threading
 import time
+from collections.abc import Callable
 from types import FrameType
 
 import pypsn
@@ -56,16 +57,6 @@ from openfollow.rttrpm.server import RttrpmServer
 
 FRAME_HZ = 60.0
 STATUS_INTERVAL_S = 5.0
-
-# Where each stream starts needing more than one datagram, at the operator
-# label lengths this driver generates.
-SPLIT_THRESHOLDS = {
-    "PSN data": 14,
-    "PSN info": 85,
-    "OTP transform": 32,
-    "OTP advertisement": 36,
-    "RTTrPM": 34,
-}
 
 
 def _classify(data: bytes) -> str | None:
@@ -109,6 +100,10 @@ class Wire:
         with self.lock:
             return {name: dict(row) for name, row in self.streams.items()}
 
+    def reset(self) -> None:
+        with self.lock:
+            self.streams.clear()
+
 
 def _count_sends(server: object, wire: Wire, dest_arg: bool) -> None:
     """Tally every datagram a server hands its socket, then send it as usual."""
@@ -139,19 +134,35 @@ def _positions(count: int, elapsed: float, radius: float, period_s: float) -> li
     return out
 
 
-def _report(wire: Wire, markers: int, elapsed: float) -> bool:
+def _probe_datagrams_per_frame(wire: Wire, send_one_frame: Callable[[], None]) -> dict[str, int]:
+    """Run one frame through the real send paths to count datagrams per stream.
+
+    The servers are not started yet, so ``_send`` drops the payload after the
+    tally sees it. Measuring beats a table of thresholds: the split point moves
+    with the marker names, and every one of these streams carries them.
+    """
+    before = {name: row["datagrams"] for name, row in wire.snapshot().items()}
+    send_one_frame()
+    return {
+        name: row["datagrams"] - before.get(name, 0)
+        for name, row in wire.snapshot().items()
+        if row["datagrams"] - before.get(name, 0) > 0
+    }
+
+
+def _report(wire: Wire, per_frame: dict[str, int], elapsed: float) -> bool:
     """Print the per-stream tally; return True if anything exceeded the MTU."""
     over = False
     for stream, row in sorted(wire.snapshot().items()):
-        threshold = SPLIT_THRESHOLDS.get(stream, 0)
-        state = "split" if markers >= threshold else "single"
+        count = per_frame.get(stream, 0)
+        state = "split" if count > 1 else "single"
         rate = row["datagrams"] / elapsed if elapsed > 0 else 0.0
         flag = ""
         if row["largest"] > MAX_DATAGRAM_BYTES:
             over = True
             flag = "  <- OVER MTU"
         print(
-            f"    {stream:<18} {state:>6}  largest={row['largest']:>5} B  "
+            f"    {stream:<18} {state:>6} {count}/frame  largest={row['largest']:>5} B  "
             f"{row['datagrams']:>7} dgram  {rate:6.1f}/s{flag}",
             flush=True,
         )
@@ -210,16 +221,26 @@ def main() -> int:
     if not servers:
         parser.error("every output disabled; nothing to drive")
 
+    def _one_frame() -> None:
+        for server in servers:
+            for path in (
+                "_send_data_packet",
+                "_send_info_packet",
+                "_send_transform_packet",
+                "_send_advertisement_packets",
+                "_send_packet",
+            ):
+                send = getattr(server, path, None)
+                if send is not None:
+                    send()
+
+    per_frame = _probe_datagrams_per_frame(wire, _one_frame)
+    wire.reset()
+
     print(f"Driving {args.markers} markers at {FRAME_HZ:.0f} Hz.\n", flush=True)
     print("  stream             at this marker count", flush=True)
-    for stream, threshold in SPLIT_THRESHOLDS.items():
-        if stream == "RTTrPM" and not args.rttrpm_host:
-            continue
-        if stream.startswith("PSN") and args.no_psn:
-            continue
-        if stream.startswith("OTP") and args.no_otp:
-            continue
-        note = "SPLITS across datagrams" if args.markers >= threshold else f"one datagram (splits at {threshold})"
+    for stream, count in sorted(per_frame.items()):
+        note = f"SPLITS across {count} datagrams" if count > 1 else "one datagram"
         print(f"  {stream:<18} {note}", flush=True)
     print(flush=True)
     if psn is not None:
@@ -268,7 +289,7 @@ def main() -> int:
             if now >= next_status:
                 next_status = now + STATUS_INTERVAL_S
                 print(f"[{elapsed:6.1f}s]", flush=True)
-                _report(wire, args.markers, elapsed)
+                _report(wire, per_frame, elapsed)
                 print(flush=True)
             stopping.wait(1.0 / FRAME_HZ)
     finally:
@@ -277,7 +298,7 @@ def main() -> int:
 
     elapsed = time.monotonic() - start
     print(f"\nStopped after {elapsed:.1f}s.", flush=True)
-    over = _report(wire, args.markers, elapsed)
+    over = _report(wire, per_frame, elapsed)
     if over:
         print(f"\nFAIL: a stream exceeded {MAX_DATAGRAM_BYTES} B.", flush=True)
         return 1

--- a/scripts/hw_validation/output_protocol_driver.py
+++ b/scripts/hw_validation/output_protocol_driver.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""Drive N moving markers out of the deployed PSN / OTP / RTTrPM servers.
+
+A DUT-side traffic generator for validating the outputs against real consumer
+software (PSNView, OTPAnalyzer, OTPView, a BlackTrax receiver) rather than
+against our own decoders. It starts the deployed server classes - not a
+re-implementation - so what leaves the NIC is what the app would send::
+
+    # 40 markers: every stream splits (PSN data 4 packets, OTP transform 2
+    # pages, OTP name advertisement 2, RTTrPM 2)
+    poetry run python scripts/hw_validation/output_protocol_driver.py --markers 40
+
+    # 13 markers: the control - every stream fits one datagram, nothing splits
+    poetry run python scripts/hw_validation/output_protocol_driver.py --markers 13
+
+    # RTTrPM is unicast, so it needs the consumer's address
+    poetry run python scripts/hw_validation/output_protocol_driver.py \\
+        --markers 40 --rttrpm-host 192.168.178.20
+
+Markers orbit a shared centre so a consumer can be judged on motion rather than
+a single static write, and every marker is rewritten every frame: a marker the
+loop stops writing goes stale, which PSN publishes as an invalid tracker and
+RTTrPM answers by withholding the trackable entirely.
+
+Datagrams are classified by their own header bytes on the way out, so the
+per-stream counts reported are what a consumer has to reassemble. Runs until
+``--duration`` elapses or Ctrl-C.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import signal
+import struct
+import sys
+import threading
+import time
+from types import FrameType
+
+import pypsn
+
+from openfollow.otp.server import (
+    OTP_PACKET_IDENTIFIER,
+    VECTOR_OTP_ADVERTISEMENT_MESSAGE,
+    VECTOR_OTP_ADVERTISEMENT_NAME,
+    VECTOR_OTP_TRANSFORM_MESSAGE,
+    OtpServer,
+)
+from openfollow.packet_chunking import MAX_DATAGRAM_BYTES
+from openfollow.psn.marker import Marker
+from openfollow.psn.server import PsnServer
+from openfollow.rttrpm.server import RttrpmServer
+
+FRAME_HZ = 60.0
+STATUS_INTERVAL_S = 5.0
+
+# Where each stream starts needing more than one datagram, at the operator
+# label lengths this driver generates.
+SPLIT_THRESHOLDS = {
+    "PSN data": 14,
+    "PSN info": 85,
+    "OTP transform": 32,
+    "OTP advertisement": 36,
+    "RTTrPM": 34,
+}
+
+
+def _classify(data: bytes) -> str | None:
+    """Name the stream a datagram belongs to, from its own header."""
+    if data.startswith(OTP_PACKET_IDENTIFIER):
+        vector = struct.unpack("!H", data[12:14])[0]
+        if vector == VECTOR_OTP_TRANSFORM_MESSAGE:
+            return "OTP transform"
+        if vector == VECTOR_OTP_ADVERTISEMENT_MESSAGE:
+            # Only the name advertisement grows with the marker count.
+            inner = struct.unpack("!H", data[79:81])[0]
+            return "OTP advertisement" if inner == VECTOR_OTP_ADVERTISEMENT_NAME else None
+        return None
+    if len(data) >= 2:
+        chunk = struct.unpack("<H", data[:2])[0]
+        if chunk == pypsn.PsnV2Chunck.PSN_DATA_PACKET:
+            return "PSN data"
+        if chunk == pypsn.PsnV2Chunck.PSN_INFO_PACKET:
+            return "PSN info"
+    return "RTTrPM"
+
+
+class Wire:
+    """Per-stream datagram tally, written from the servers' send threads."""
+
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.streams: dict[str, dict[str, int]] = {}
+
+    def record(self, data: bytes) -> None:
+        stream = _classify(data)
+        if stream is None:
+            return
+        with self.lock:
+            row = self.streams.setdefault(stream, {"datagrams": 0, "octets": 0, "largest": 0})
+            row["datagrams"] += 1
+            row["octets"] += len(data)
+            row["largest"] = max(row["largest"], len(data))
+
+    def snapshot(self) -> dict[str, dict[str, int]]:
+        with self.lock:
+            return {name: dict(row) for name, row in self.streams.items()}
+
+
+def _count_sends(server: object, wire: Wire, dest_arg: bool) -> None:
+    """Tally every datagram a server hands its socket, then send it as usual."""
+    original = server._send  # type: ignore[attr-defined]
+
+    if dest_arg:
+
+        def wrapped(data: bytes, dest_ip: str, stop_event: object = None) -> None:
+            wire.record(data)
+            original(data, dest_ip, stop_event)
+    else:
+
+        def wrapped(data: bytes, stop_event: object = None) -> None:  # type: ignore[misc]
+            wire.record(data)
+            original(data, stop_event)
+
+    server._send = wrapped  # type: ignore[attr-defined]
+
+
+def _positions(count: int, elapsed: float, radius: float, period_s: float) -> list[tuple[float, float, float]]:
+    """Markers evenly spaced around one slow orbit, at staggered heights."""
+    out = []
+    for index in range(count):
+        phase = index / count
+        angle = (elapsed / period_s + phase) * 2.0 * math.pi
+        height = 1.2 + 0.8 * math.sin((elapsed / 7.0 + phase) * 2.0 * math.pi)
+        out.append((radius * math.cos(angle), radius * math.sin(angle), height))
+    return out
+
+
+def _report(wire: Wire, markers: int, elapsed: float) -> bool:
+    """Print the per-stream tally; return True if anything exceeded the MTU."""
+    over = False
+    for stream, row in sorted(wire.snapshot().items()):
+        threshold = SPLIT_THRESHOLDS.get(stream, 0)
+        state = "split" if markers >= threshold else "single"
+        rate = row["datagrams"] / elapsed if elapsed > 0 else 0.0
+        flag = ""
+        if row["largest"] > MAX_DATAGRAM_BYTES:
+            over = True
+            flag = "  <- OVER MTU"
+        print(
+            f"    {stream:<18} {state:>6}  largest={row['largest']:>5} B  "
+            f"{row['datagrams']:>7} dgram  {rate:6.1f}/s{flag}",
+            flush=True,
+        )
+    return over
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--markers", type=int, default=40, help="marker count (13 = nothing splits, 40 = all split)")
+    parser.add_argument("--duration", type=float, default=0.0, help="seconds to run; 0 = until Ctrl-C")
+    parser.add_argument("--iface-ip", default="", help="source interface IPv4 to bind the multicast senders to")
+    parser.add_argument("--psn-mcast", default="236.10.10.10", help="PSN multicast group")
+    parser.add_argument("--otp-system", type=int, default=1, help="OTP System Number (transform group 239.159.1.N)")
+    parser.add_argument("--rttrpm-host", default="", help="RTTrPM unicast target; omitted = RTTrPM not started")
+    parser.add_argument("--rttrpm-port", type=int, default=36700, help="RTTrPM target port")
+    parser.add_argument("--radius", type=float, default=3.0, help="orbit radius in metres")
+    parser.add_argument("--period", type=float, default=12.0, help="seconds per orbit")
+    parser.add_argument("--no-psn", action="store_true", help="do not start the PSN server")
+    parser.add_argument("--no-otp", action="store_true", help="do not start the OTP server")
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+    if args.markers < 1:
+        parser.error("--markers must be at least 1")
+
+    wire = Wire()
+    servers: list[object] = []
+    # OTP and RTTrPM read shared Marker objects; PSN owns its own registrations.
+    shared = [Marker(index, f"Followspot Operator Position {index:02d}") for index in range(1, args.markers + 1)]
+    for marker in shared:
+        marker.set_pos(0.0, 0.0, 1.2)
+
+    psn = None
+    if not args.no_psn:
+        psn = PsnServer(mcast_ip=args.psn_mcast, source_ip=args.iface_ip)
+        for marker in shared:
+            psn.add_marker(marker.marker_id, marker.name)
+        _count_sends(psn, wire, dest_arg=False)
+        servers.append(psn)
+    if not args.no_otp:
+        otp = OtpServer(system_number=args.otp_system, source_ip=args.iface_ip)
+        for marker in shared:
+            otp.register_marker(marker)
+        _count_sends(otp, wire, dest_arg=True)
+        servers.append(otp)
+    if args.rttrpm_host:
+        rttrpm = RttrpmServer(host=args.rttrpm_host, port=args.rttrpm_port)
+        for marker in shared:
+            rttrpm.register_marker(marker)
+        _count_sends(rttrpm, wire, dest_arg=False)
+        servers.append(rttrpm)
+
+    if not servers:
+        parser.error("every output disabled; nothing to drive")
+
+    print(f"Driving {args.markers} markers at {FRAME_HZ:.0f} Hz.\n", flush=True)
+    print("  stream             at this marker count", flush=True)
+    for stream, threshold in SPLIT_THRESHOLDS.items():
+        if stream == "RTTrPM" and not args.rttrpm_host:
+            continue
+        if stream.startswith("PSN") and args.no_psn:
+            continue
+        if stream.startswith("OTP") and args.no_otp:
+            continue
+        note = "SPLITS across datagrams" if args.markers >= threshold else f"one datagram (splits at {threshold})"
+        print(f"  {stream:<18} {note}", flush=True)
+    print(flush=True)
+    if psn is not None:
+        print(f"  PSN    -> {args.psn_mcast}:56565 multicast", flush=True)
+    if not args.no_otp:
+        print(
+            f"  OTP    -> 239.159.1.{args.otp_system}:5568 transform, 239.159.2.1:5568 advertisement",
+            flush=True,
+        )
+    if args.rttrpm_host:
+        print(f"  RTTrPM -> {args.rttrpm_host}:{args.rttrpm_port} unicast", flush=True)
+    print("\nCtrl-C to stop.\n", flush=True)
+
+    for server in servers:
+        server.start()  # type: ignore[attr-defined]
+
+    stopping = threading.Event()
+
+    def _stop(signum: int, frame: FrameType | None) -> None:
+        stopping.set()
+
+    signal.signal(signal.SIGINT, _stop)
+    signal.signal(signal.SIGTERM, _stop)
+
+    start = time.monotonic()
+    next_status = start + STATUS_INTERVAL_S
+    speed = 2.0 * math.pi * args.radius / args.period
+    try:
+        while not stopping.is_set():
+            now = time.monotonic()
+            elapsed = now - start
+            if args.duration and elapsed >= args.duration:
+                break
+            # Rewrite every marker every frame: one the loop stops writing ages
+            # out and drops off the wire on all three protocols.
+            for marker, position in zip(
+                shared, _positions(args.markers, elapsed, args.radius, args.period), strict=True
+            ):
+                marker.set_pos(*position)
+                marker.set_speed(speed, 0.0, 0.0)
+                if psn is not None:
+                    live = psn.get_marker(marker.marker_id)
+                    if live is not None:
+                        live.set_pos(*position)
+                        live.set_speed(speed, 0.0, 0.0)
+            if now >= next_status:
+                next_status = now + STATUS_INTERVAL_S
+                print(f"[{elapsed:6.1f}s]", flush=True)
+                _report(wire, args.markers, elapsed)
+                print(flush=True)
+            stopping.wait(1.0 / FRAME_HZ)
+    finally:
+        for server in servers:
+            server.stop()  # type: ignore[attr-defined]
+
+    elapsed = time.monotonic() - start
+    print(f"\nStopped after {elapsed:.1f}s.", flush=True)
+    over = _report(wire, args.markers, elapsed)
+    if over:
+        print(f"\nFAIL: a stream exceeded {MAX_DATAGRAM_BYTES} B.", flush=True)
+        return 1
+    print(f"\nPASS: every stream stayed inside {MAX_DATAGRAM_BYTES} B.", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_otp.py
+++ b/tests/test_otp.py
@@ -1226,52 +1226,53 @@ class TestOtpRestartFailureRaises:
                 )
 
 
-class TestOtpSendOversizePacketSkipped:
-    def _server_with_oversize_load(self) -> OtpServer:
+class TestOtpFolioPageCap:
+    """A folio too long for its uint16 Last Page cannot describe itself, so the
+    tail is dropped rather than left to ``struct.pack``. Only reachable in the
+    millions of markers, so the cap is lowered here to reach the path at all."""
+
+    def _server_with_capped_load(self, monkeypatch: pytest.MonkeyPatch) -> OtpServer:
         srv = OtpServer(system_number=1)
         srv._socket = MagicMock()
-        # 70 markers blow the 1472-octet cap.
+        # 70 markers need 3 pages; a 2-page ceiling drops the third.
+        monkeypatch.setattr("openfollow.otp.server._MAX_FOLIO_LAST_PAGE", 1)
         for i in range(1, 71):
             srv.register_marker(_marker(i, name=f"T{i}"))
         return srv
 
-    def test_oversize_payload_drops_packet_with_warning(self, caplog) -> None:
+    def test_pages_past_the_cap_are_dropped_with_a_warning(self, monkeypatch: pytest.MonkeyPatch, caplog) -> None:
         import logging as _logging
 
-        srv = self._server_with_oversize_load()
+        srv = self._server_with_capped_load(monkeypatch)
         with caplog.at_level(_logging.WARNING, logger="openfollow.otp.server"):
             srv._send_transform_packet()
-        srv._socket.sendto.assert_not_called()
-        assert any("transform packet skipped" in r.message for r in caplog.records)
+        assert srv._socket.sendto.call_count == 2
+        assert any("transform folio needs 3 pages" in r.message for r in caplog.records)
         assert srv._oversize_drops == 1
 
-    def test_oversize_log_throttles_after_5_drops(self, caplog) -> None:
-        """Length-cap drops are throttled with the same first-5-then-
-        every-100 pattern as ``_send``'s OSError counter, so a misconfigured
-        install pushing too many markers doesn't flood the log at the
+    def test_cap_log_throttles_after_5_drops(self, monkeypatch: pytest.MonkeyPatch, caplog) -> None:
+        """Throttled with the same first-5-then-every-100 pattern as ``_send``'s
+        OSError counter, so a misconfigured install doesn't flood the log at the
         transform fps."""
         import logging as _logging
 
-        srv = self._server_with_oversize_load()
+        srv = self._server_with_capped_load(monkeypatch)
         with caplog.at_level(_logging.WARNING, logger="openfollow.otp.server"):
             for _ in range(20):
                 srv._send_transform_packet()
-        # 20 calls → first 5 log, then nothing until the 100th – so
-        # exactly 5 warnings hit the buffer.
-        warnings = [r for r in caplog.records if "transform packet skipped" in r.message]
+        warnings = [r for r in caplog.records if "transform folio needs" in r.message]
         assert len(warnings) == 5
         assert srv._oversize_drops == 20
 
-    def test_oversize_log_resumes_at_100th_drop(self, caplog) -> None:
+    def test_cap_log_resumes_at_100th_drop(self, monkeypatch: pytest.MonkeyPatch, caplog) -> None:
         import logging as _logging
 
-        srv = self._server_with_oversize_load()
+        srv = self._server_with_capped_load(monkeypatch)
         # Simulate having already passed the first-5 burst.
         srv._oversize_drops = 99
         with caplog.at_level(_logging.WARNING, logger="openfollow.otp.server"):
             srv._send_transform_packet()
-        # Next drop is the 100th → must log.
-        assert any("transform packet skipped" in r.message for r in caplog.records)
+        assert any("transform folio needs" in r.message for r in caplog.records)
         assert srv._oversize_drops == 100
 
 

--- a/tests/test_output_packet_splitting.py
+++ b/tests/test_output_packet_splitting.py
@@ -39,6 +39,43 @@ pytestmark = pytest.mark.unit
 _LONG_NAME = "Followspot Operator Position {:02d}"
 
 
+class _SteppingClock:
+    """Microsecond clock that advances by ``step`` on every read."""
+
+    def __init__(self, now: int, step: int = 0) -> None:
+        self.now = now
+        self.step = step
+
+    def __call__(self) -> int:
+        value = self.now
+        self.now += self.step
+        return value
+
+
+class _RenamingMarker(Marker):
+    """A marker whose name grows on every read, as a live rename would.
+
+    ``set_name`` is called at runtime by the catalog sync and the web UI, and
+    an RTTrPM trackable module is 34 octets plus the name - so a name read once
+    to size a chunk and again to encode it is a datagram that can outgrow its
+    budget.
+    """
+
+    def __init__(self, marker_id: int, base: str) -> None:
+        super().__init__(marker_id, base)
+        self._base = base
+        self._reads = 0
+
+    @property  # type: ignore[override]
+    def name(self) -> str:
+        self._reads += 1
+        return self._base + "x" * (20 * self._reads)
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._base = value
+
+
 def _markers(count: int, name_template: str = "Marker {}") -> list[Marker]:
     markers = []
     for index in range(1, count + 1):
@@ -125,8 +162,36 @@ def _otp_transform_body(datagram: bytes) -> tuple[int, list[int]]:
     return options, points
 
 
+def _otp_sampled_timestamps(datagram: bytes) -> list[int]:
+    """Each Point Layer's Section 9.6 sampled timestamp from a transform page."""
+    inner = datagram[16:][63:]
+    length = struct.unpack("!H", inner[2:4])[0]
+    rest = inner[4 : 4 + length][14:]
+    stamps = []
+    while rest:
+        point_length = struct.unpack("!H", rest[2:4])[0]
+        body = rest[4 : 4 + point_length]
+        stamps.append(struct.unpack("!Q", body[7:15])[0])  # Priority(1)+Group(2)+Point(4)
+        rest = rest[4 + point_length :]
+    return stamps
+
+
 def _is_otp_name_advertisement(datagram: bytes) -> bool:
     return struct.unpack("!H", datagram[79:81])[0] == VECTOR_OTP_ADVERTISEMENT_NAME
+
+
+def _otp_name_points(datagram: bytes) -> list[int]:
+    """Point numbers from a name advertisement page's Address Point Descriptions."""
+    inner = datagram[16:][63:]
+    length = struct.unpack("!H", inner[2:4])[0]
+    advertisement = inner[4 : 4 + length][4:]  # past the Advertisement Layer's Reserved(4)
+    list_length = struct.unpack("!H", advertisement[2:4])[0]
+    entries = advertisement[4 : 4 + list_length][5:]  # past Options(1) + Reserved(4)
+    points = []
+    while len(entries) >= 39:  # System(1) + Group(2) + Point(4) + Name(32)
+        points.append(struct.unpack("!I", entries[3:7])[0])
+        entries = entries[39:]
+    return points
 
 
 def _rttrpm_module_count(datagram: bytes) -> int:
@@ -139,7 +204,7 @@ def _rttrpm_pkt_id(datagram: bytes) -> int:
 
 # --- the invariant every output shares ---------------------------------------
 
-_MARKER_COUNTS = [1, 13, 14, 15, 31, 32, 34, 36, 64, 100]
+_MARKER_COUNTS = [1, 13, 14, 15, 31, 32, 34, 35, 36, 64, 100]
 
 
 def _all_datagrams(count: int, name_template: str) -> dict[str, list[bytes]]:
@@ -159,8 +224,9 @@ def _all_datagrams(count: int, name_template: str) -> dict[str, list[bytes]]:
 def test_no_output_protocol_emits_a_datagram_past_the_mtu(count: int, name_template: str) -> None:
     """The whole point of the exercise, in one assertion per stream.
 
-    Before the split these crossed at 14 (PSN data), 32 (OTP transform), 34
-    (RTTrPM), 36 (OTP name advertisement) and 85 (PSN info) markers.
+    One datagram holds 13 PSN trackers, 31 OTP points, 34 RTTrPM trackables and
+    35 OTP names at these label lengths, so the counts below straddle every one
+    of those boundaries.
     """
     for stream, datagrams in _all_datagrams(count, name_template).items():
         assert datagrams, f"{stream} sent nothing"
@@ -334,8 +400,8 @@ class TestOtpFolioPaging:
 
     @pytest.mark.parametrize("count", [36, 64, 100])
     def test_the_name_advertisement_pages_too(self, count: int) -> None:
-        """It carries a 32-octet name per point and had no length check at all,
-        so it crossed the MTU silently at 36 markers."""
+        """It carries a fixed 32-octet name per point, so it needs a second page
+        from 36 markers - a different boundary from the transform's."""
         _, advertisement = _otp_datagrams(count)
         name_pages = [datagram for datagram in advertisement if _is_otp_name_advertisement(datagram)]
         assert len(name_pages) > 1
@@ -343,6 +409,91 @@ class TestOtpFolioPaging:
         assert len({folio for folio, _, _ in headers}) == 1
         assert [page for _, page, _ in headers] == list(range(len(name_pages)))
         assert {last for _, _, last in headers} == {len(name_pages) - 1}
+
+    def test_the_name_advertisement_stays_ascending_across_its_pages(self) -> None:
+        """Section 13.5 wants one ascending list per folio, and a page can only
+        sort what it is handed - so a marker set registered in the operator's
+        order, not id order, is the case that catches a per-page sort."""
+        server = OtpServer(system_number=1)
+        sent: list[bytes] = []
+        server._send = lambda data, dest_ip, stop_event=None: sent.append(data)  # type: ignore[method-assign]
+        for marker in reversed(_markers(60)):  # registration order 60..1
+            server.register_marker(marker)
+
+        server._send_advertisement_packets()
+        name_pages = [datagram for datagram in sent if _is_otp_name_advertisement(datagram)]
+        assert len(name_pages) > 1
+        points = [point for datagram in name_pages for point in _otp_name_points(datagram)]
+        assert points == sorted(points)
+        assert points == list(range(1, 61))
+
+    def test_a_folio_whose_pages_cannot_be_encoded_is_dropped_not_fatal(self, caplog) -> None:
+        """The transform loop calls this bare, so an escaping encode error ends
+        OTP output for the life of the process rather than one frame of it."""
+        server = OtpServer(system_number=1)
+        sent: list[bytes] = []
+        server._send = lambda data, dest_ip, stop_event=None: sent.append(data)  # type: ignore[method-assign]
+        for marker in _markers(4):
+            server.register_marker(marker)
+        server._cid = b"too short"  # rejected by the OTP Layer on every page
+
+        with caplog.at_level("ERROR", logger="openfollow.otp.server"):
+            server._send_transform_packet()
+
+        assert sent == []
+        assert server._oversize_drops == 1
+        assert any("folio dropped" in record.message for record in caplog.records)
+
+    def test_repeated_folio_drops_are_throttled_but_not_silenced(self, caplog) -> None:
+        """The condition needs operator action and recurs at the transform fps,
+        so it is logged like the send-error counter: the opening burst, then a
+        periodic reminder rather than silence for the rest of the process."""
+        server = OtpServer(system_number=1)
+        server._send = lambda data, dest_ip, stop_event=None: None  # type: ignore[method-assign]
+        for marker in _markers(4):
+            server.register_marker(marker)
+        server._cid = b"too short"
+
+        with caplog.at_level("ERROR", logger="openfollow.otp.server"):
+            for _ in range(20):
+                server._send_transform_packet()
+            burst = len([r for r in caplog.records if "folio dropped" in r.message])
+            server._oversize_drops = 99  # already past the opening burst
+            server._send_transform_packet()
+
+        assert burst == 5
+        assert server._oversize_drops == 100
+        assert len([r for r in caplog.records if "folio dropped" in r.message]) == 6
+
+    def test_every_point_in_a_folio_ages_against_one_instant(self) -> None:
+        """Section 9.6's sampled timestamp is read against the folio's own
+        Transform Layer timestamp, which the pages share. Ageing each page
+        against its own clock read reports identically-fresh points on a later
+        page as older, so the clock is driven here rather than left to run at
+        whatever speed the host happens to encode at.
+        """
+        clock = _SteppingClock(1_000_000)
+        markers = [Marker(index, f"Marker {index}", clock=clock) for index in range(1, 65)]
+        for marker in markers:
+            marker.set_pos(1.0, 2.0, 3.0)  # every marker stamped at the same instant
+        clock.step = 50_000  # 50 ms of apparent time per read from here on
+
+        server = OtpServer(system_number=1)
+        # A Transform Layer timestamp of a freshly-built server is a few
+        # microseconds, and the sampled stamp is clamped at zero - so every age
+        # would floor to the same 0 and hide the difference. Ten seconds of
+        # apparent uptime puts the arithmetic in the range a running one uses.
+        server._start_time_us -= 10_000_000
+        sent: list[bytes] = []
+        server._send = lambda data, dest_ip, stop_event=None: sent.append(data)  # type: ignore[method-assign]
+        for marker in markers:
+            server.register_marker(marker)
+        server._send_transform_packet()
+
+        assert len(sent) > 1
+        sampled = {stamp for datagram in sent for stamp in _otp_sampled_timestamps(datagram)}
+        assert sampled != {0}, "clamped flat - the test would pass either way"
+        assert len(sampled) == 1
 
     def test_a_transform_folio_advances_once_per_folio_not_once_per_page(self) -> None:
         server = OtpServer(system_number=1)
@@ -385,8 +536,27 @@ class TestRttrpmPacketSplitting:
         for datagram in _rttrpm_datagrams(count):
             assert struct.unpack("!H", datagram[11:13])[0] == len(datagram)
 
-    def test_a_large_set_is_no_longer_truncated(self) -> None:
-        """299 trackables used to hit the uint8 module cap and lose the tail
-        silently; they now ride across as many packets as they need."""
+    def test_a_rename_between_sizing_and_encoding_cannot_burst_the_mtu(self) -> None:
+        """The split budgets a chunk from one reading of each name and the
+        datagram is built from another; a rename landing between the two is
+        what turns a sized-to-fit chunk into the fragmenting datagram this
+        exists to prevent."""
+        server = RttrpmServer(host="127.0.0.1")
+        server._socket = MagicMock()
+        sent: list[bytes] = []
+        server._send = lambda data, stop_event=None: sent.append(data)  # type: ignore[method-assign]
+        for index in range(1, 41):
+            marker = _RenamingMarker(index, f"Marker {index}")
+            marker.set_pos(1.5, -2.5, 3.5)
+            server.register_marker(marker)
+
+        server._send_packet()
+
+        assert sent
+        assert max(len(datagram) for datagram in sent) <= MAX_DATAGRAM_BYTES
+
+    def test_a_set_larger_than_the_module_count_field_still_ships_whole(self) -> None:
+        """299 trackables exceed the uint8 ``numModules`` a single packet can
+        count, so they can only ship at all by riding across several."""
         datagrams = _rttrpm_datagrams(299)
         assert sum(_rttrpm_module_count(datagram) for datagram in datagrams) == 299

--- a/tests/test_output_packet_splitting.py
+++ b/tests/test_output_packet_splitting.py
@@ -1,0 +1,392 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""Every output protocol keeps its datagrams inside the MTU as markers scale.
+
+A datagram past the UDP payload of a 1500-octet Ethernet MTU is fragmented by
+IP, which a quiet bench LAN reassembles and a loaded show network drops - so the
+failure appears only where it cannot be debugged. Each protocol spreads a large
+marker set differently: PSN over the packets of one frame, OTP over the pages of
+one folio, RTTrPM over independent packets. What none of them may do is emit an
+oversize datagram or lose a marker in the split.
+
+Datagrams are captured at each server's send seam and read back as bytes,
+because the bytes are what a receiver has to make sense of.
+"""
+
+from __future__ import annotations
+
+import struct
+from unittest.mock import MagicMock
+
+import pypsn
+import pytest
+
+from openfollow.otp.server import (
+    OTP_PACKET_IDENTIFIER,
+    VECTOR_OTP_ADVERTISEMENT_NAME,
+    OtpServer,
+)
+from openfollow.packet_chunking import MAX_DATAGRAM_BYTES
+from openfollow.psn.marker import Marker
+from openfollow.psn.receiver import PsnReceiver
+from openfollow.psn.server import PsnServer
+from openfollow.rttrpm.server import RttrpmServer
+
+pytestmark = pytest.mark.unit
+
+# Long enough to be an ordinary operator label, which is what pushes the
+# name-carrying packets over the line well before the position-carrying ones.
+_LONG_NAME = "Followspot Operator Position {:02d}"
+
+
+def _markers(count: int, name_template: str = "Marker {}") -> list[Marker]:
+    markers = []
+    for index in range(1, count + 1):
+        marker = Marker(index, name_template.format(index))
+        marker.set_pos(1.5, -2.5, 3.5)
+        markers.append(marker)
+    return markers
+
+
+# --- capture helpers: drive the real send paths, keep the datagrams ----------
+
+
+def _psn_datagrams(count: int, name_template: str = "Marker {}") -> tuple[list[bytes], list[bytes]]:
+    """Return the (data, info) datagrams one frame of each stream puts on the wire."""
+    server = PsnServer(mcast_ip=None)
+    sent: list[bytes] = []
+    server._send = lambda data, stop_event=None: sent.append(data)  # type: ignore[method-assign]
+    for marker in _markers(count, name_template):
+        server._markers[marker.marker_id] = marker
+    server._send_data_packet()
+    data = list(sent)
+    sent.clear()
+    server._send_info_packet()
+    return data, list(sent)
+
+
+def _otp_datagrams(count: int, name_template: str = "Marker {}") -> tuple[list[bytes], list[bytes]]:
+    """Return the (transform, advertisement) datagrams the OTP server emits."""
+    server = OtpServer(system_number=1)
+    sent: list[bytes] = []
+    server._send = lambda data, dest_ip, stop_event=None: sent.append(data)  # type: ignore[method-assign]
+    for marker in _markers(count, name_template):
+        server.register_marker(marker)
+    server._send_transform_packet()
+    transform = list(sent)
+    sent.clear()
+    server._send_advertisement_packets()
+    return transform, list(sent)
+
+
+def _rttrpm_datagrams(count: int, name_template: str = "Marker {}") -> list[bytes]:
+    server = RttrpmServer(host="127.0.0.1")
+    server._socket = MagicMock()
+    sent: list[bytes] = []
+    server._send = lambda data, stop_event=None: sent.append(data)  # type: ignore[method-assign]
+    for marker in _markers(count, name_template):
+        server.register_marker(marker)
+    server._send_packet()
+    return sent
+
+
+# --- byte readers ------------------------------------------------------------
+
+
+def _psn_packets(datagrams: list[bytes]) -> list[object]:
+    parsed = [pypsn.parse_psn_packet(datagram) for datagram in datagrams]
+    # parse_psn_packet returns None on an unrecognised chunk id, which would
+    # otherwise read as "no trackers" rather than as a serialisation regression.
+    assert None not in parsed
+    return parsed
+
+
+def _otp_folio_and_pages(datagram: bytes) -> tuple[int, int, int]:
+    """(folio, page, last_page) from the OTP Layer (Sections 6.7-6.9)."""
+    assert datagram.startswith(OTP_PACKET_IDENTIFIER)
+    folio = struct.unpack("!I", datagram[34:38])[0]
+    page, last_page = struct.unpack("!HH", datagram[38:42])
+    return folio, page, last_page
+
+
+def _otp_transform_body(datagram: bytes) -> tuple[int, list[int]]:
+    """(Transform Layer options, point numbers) from a transform datagram."""
+    inner = datagram[16:][63:]  # past the OTP Layer's fixed fields + component name
+    length = struct.unpack("!H", inner[2:4])[0]
+    body = inner[4 : 4 + length]
+    options = body[9]  # System Number(1) + Timestamp(8), then Options
+    rest = body[14:]  # ... then Reserved(4), then the Point PDUs
+    points = []
+    while rest:
+        point_length = struct.unpack("!H", rest[2:4])[0]
+        point_body = rest[4 : 4 + point_length]
+        points.append(struct.unpack("!I", point_body[3:7])[0])  # Priority(1) + Group(2)
+        rest = rest[4 + point_length :]
+    return options, points
+
+
+def _is_otp_name_advertisement(datagram: bytes) -> bool:
+    return struct.unpack("!H", datagram[79:81])[0] == VECTOR_OTP_ADVERTISEMENT_NAME
+
+
+def _rttrpm_module_count(datagram: bytes) -> int:
+    return datagram[17]  # numModules, the uint8 at the end of the 18-octet header
+
+
+def _rttrpm_pkt_id(datagram: bytes) -> int:
+    return struct.unpack("!I", datagram[6:10])[0]
+
+
+# --- the invariant every output shares ---------------------------------------
+
+_MARKER_COUNTS = [1, 13, 14, 15, 31, 32, 34, 36, 64, 100]
+
+
+def _all_datagrams(count: int, name_template: str) -> dict[str, list[bytes]]:
+    psn_data, psn_info = _psn_datagrams(count, name_template)
+    otp_transform, otp_advertisement = _otp_datagrams(count, name_template)
+    return {
+        "psn data": psn_data,
+        "psn info": psn_info,
+        "otp transform": otp_transform,
+        "otp advertisement": otp_advertisement,
+        "rttrpm": _rttrpm_datagrams(count, name_template),
+    }
+
+
+@pytest.mark.parametrize("count", _MARKER_COUNTS)
+@pytest.mark.parametrize("name_template", ["Marker {}", _LONG_NAME])
+def test_no_output_protocol_emits_a_datagram_past_the_mtu(count: int, name_template: str) -> None:
+    """The whole point of the exercise, in one assertion per stream.
+
+    Before the split these crossed at 14 (PSN data), 32 (OTP transform), 34
+    (RTTrPM), 36 (OTP name advertisement) and 85 (PSN info) markers.
+    """
+    for stream, datagrams in _all_datagrams(count, name_template).items():
+        assert datagrams, f"{stream} sent nothing"
+        oversize = [len(datagram) for datagram in datagrams if len(datagram) > MAX_DATAGRAM_BYTES]
+        assert not oversize, f"{stream} emitted {oversize} octet datagram(s) at {count} markers"
+
+
+@pytest.mark.parametrize("count", _MARKER_COUNTS)
+def test_a_single_marker_set_needs_no_more_datagrams_than_the_payload_requires(count: int) -> None:
+    """Guards the other direction: a split that emitted one datagram per marker
+    would satisfy the size invariant and destroy the wire rate."""
+    psn_data, _ = _psn_datagrams(count)
+    assert len(psn_data) == -(-count // 13)  # 13 trackers is a full PSN data packet
+
+
+# --- PSN: the packets of one frame -------------------------------------------
+
+
+class TestPsnFrameSplitting:
+    @pytest.mark.parametrize("count", _MARKER_COUNTS)
+    def test_every_tracker_ships_exactly_once_across_the_frame(self, count: int) -> None:
+        data, info = _psn_datagrams(count)
+        for datagrams in (data, info):
+            shipped = [t.tracker_id for packet in _psn_packets(datagrams) for t in packet.trackers]
+            assert sorted(shipped) == list(range(1, count + 1))
+            assert len(shipped) == len(set(shipped))
+
+    @pytest.mark.parametrize("count", [14, 32, 64, 100])
+    def test_a_split_frame_shares_one_id_and_declares_its_packet_count(self, count: int) -> None:
+        """A receiver buffers a frame's trackers until it has ``packet_count``
+        packets carrying that ``frame_id``; a per-packet id reassembles nothing."""
+        data, _ = _psn_datagrams(count)
+        assert len(data) > 1
+        packets = _psn_packets(data)
+        assert len({packet.info.frame_id for packet in packets}) == 1
+        assert {packet.info.packet_count for packet in packets} == {len(data)}
+
+    @pytest.mark.parametrize("count", [14, 64])
+    def test_every_packet_of_a_frame_carries_one_timestamp(self, count: int) -> None:
+        """The frame was sampled once; a per-packet clock read would let a
+        receiver age two trackers of one frame differently."""
+        data, _ = _psn_datagrams(count)
+        assert len({packet.info.timestamp for packet in _psn_packets(data)}) == 1
+
+    def test_frame_ids_advance_once_per_frame_not_once_per_packet(self) -> None:
+        """Splitting must not reintroduce the gap that made a receiver read a
+        dropped frame - the id belongs to the frame, not to the datagram."""
+        server = PsnServer(mcast_ip=None)
+        sent: list[bytes] = []
+        server._send = lambda data, stop_event=None: sent.append(data)  # type: ignore[method-assign]
+        for marker in _markers(64):
+            server._markers[marker.marker_id] = marker
+
+        frame_ids = []
+        for _ in range(4):
+            sent.clear()
+            server._send_data_packet()
+            ids = {packet.info.frame_id for packet in _psn_packets(sent)}
+            assert len(ids) == 1
+            frame_ids.append(ids.pop())
+        assert frame_ids == [0, 1, 2, 3]
+
+    def test_a_split_frame_reassembles_through_the_receiver(self) -> None:
+        """Our own receiver accumulates a frame's trackers packet by packet, so
+        a station receiving a peer's split frame needs no reassembly buffer."""
+        data, _ = _psn_datagrams(64)
+        assert len(data) > 1
+        receiver = PsnReceiver()
+        for datagram in data:
+            receiver._on_packet(pypsn.parse_psn_packet(datagram))
+        assert sorted(receiver._markers) == list(range(1, 65))
+
+    def test_a_stale_marker_still_declares_itself_stale_inside_a_chunk(self) -> None:
+        """Splitting reshuffles which packet a tracker rides in; it must not
+        disturb the validity flag that says the position stopped being live."""
+        server = PsnServer(mcast_ip=None)
+        sent: list[bytes] = []
+        server._send = lambda data, stop_event=None: sent.append(data)  # type: ignore[method-assign]
+        fresh = _markers(64)
+        for marker in fresh:
+            server._markers[marker.marker_id] = marker
+        stale = Marker(99, "Stale")  # registered, never written → unaged → stale
+        server._markers[99] = stale
+
+        server._send_data_packet()
+        by_id = {t.tracker_id: t for packet in _psn_packets(sent) for t in packet.trackers}
+        assert by_id[99].status == pytest.approx(0.0)
+        assert by_id[1].status == pytest.approx(1.0)
+
+    def test_a_frame_past_the_packet_count_ceiling_drops_its_tail(
+        self, monkeypatch: pytest.MonkeyPatch, caplog
+    ) -> None:
+        """``frame_packet_count`` is a uint8, so a frame needing more packets
+        than that cannot describe itself. Thousands of markers away in practice;
+        the cap is lowered to reach the path rather than registering them."""
+        monkeypatch.setattr("openfollow.psn.server._MAX_FRAME_PACKETS", 2)
+        server = PsnServer(mcast_ip=None)
+        sent: list[bytes] = []
+        server._send = lambda data, stop_event=None: sent.append(data)  # type: ignore[method-assign]
+        for marker in _markers(64):
+            server._markers[marker.marker_id] = marker
+
+        with caplog.at_level("WARNING", logger="openfollow.psn.server"):
+            server._send_data_packet()
+
+        assert len(sent) == 2
+        assert {packet.info.packet_count for packet in _psn_packets(sent)} == {2}
+        assert any("capped at 2" in record.message for record in caplog.records)
+        assert server._oversize_drops == 1
+
+    def _capped_server(self, monkeypatch: pytest.MonkeyPatch) -> PsnServer:
+        monkeypatch.setattr("openfollow.psn.server._MAX_FRAME_PACKETS", 2)
+        server = PsnServer(mcast_ip=None)
+        server._send = lambda data, stop_event=None: None  # type: ignore[method-assign]
+        for marker in _markers(64):
+            server._markers[marker.marker_id] = marker
+        return server
+
+    def test_the_cap_warning_throttles_after_five_episodes(self, monkeypatch: pytest.MonkeyPatch, caplog) -> None:
+        """Same first-5-then-every-100 shape as the send-error counter: the
+        condition needs operator action, so at 60 fps it would flood the log."""
+        server = self._capped_server(monkeypatch)
+        with caplog.at_level("WARNING", logger="openfollow.psn.server"):
+            for _ in range(20):
+                server._send_data_packet()
+        assert len([r for r in caplog.records if "capped at 2" in r.message]) == 5
+        assert server._oversize_drops == 20
+
+    def test_the_cap_warning_resumes_at_the_hundredth_episode(self, monkeypatch: pytest.MonkeyPatch, caplog) -> None:
+        server = self._capped_server(monkeypatch)
+        server._oversize_drops = 99  # already past the opening burst
+        with caplog.at_level("WARNING", logger="openfollow.psn.server"):
+            server._send_data_packet()
+        assert any("capped at 2" in r.message for r in caplog.records)
+        assert server._oversize_drops == 100
+
+
+# --- OTP: the pages of one folio ---------------------------------------------
+
+
+class TestOtpFolioPaging:
+    @pytest.mark.parametrize("count", _MARKER_COUNTS)
+    def test_every_point_ships_exactly_once_across_the_folio(self, count: int) -> None:
+        transform, _ = _otp_datagrams(count)
+        points = [point for datagram in transform for point in _otp_transform_body(datagram)[1]]
+        assert points == list(range(1, count + 1))
+
+    @pytest.mark.parametrize("count", [32, 64, 120])
+    def test_pages_share_a_folio_and_number_themselves_in_order(self, count: int) -> None:
+        """Sections 6.7-6.9: a Consumer collects pages 0..last_page of one
+        Folio Number, so a page that renumbered the folio joins nothing."""
+        transform, _ = _otp_datagrams(count)
+        assert len(transform) > 1
+        headers = [_otp_folio_and_pages(datagram) for datagram in transform]
+        folios = {folio for folio, _, _ in headers}
+        assert len(folios) == 1
+        assert [page for _, page, _ in headers] == list(range(len(transform)))
+        assert {last for _, _, last in headers} == {len(transform) - 1}
+
+    @pytest.mark.parametrize("count", [32, 120])
+    def test_full_point_set_is_declared_identically_on_every_page(self, count: int) -> None:
+        """Section 8.5's flag describes the folio, not the datagram: a page
+        claiming a different point set than its siblings describes none."""
+        transform, _ = _otp_datagrams(count)
+        assert len({_otp_transform_body(datagram)[0] for datagram in transform}) == 1
+        assert _otp_transform_body(transform[0])[0] & 0x80
+
+    def test_a_single_page_folio_still_names_itself_page_zero_of_zero(self) -> None:
+        transform, _ = _otp_datagrams(4)
+        assert [_otp_folio_and_pages(datagram)[1:] for datagram in transform] == [(0, 0)]
+
+    @pytest.mark.parametrize("count", [36, 64, 100])
+    def test_the_name_advertisement_pages_too(self, count: int) -> None:
+        """It carries a 32-octet name per point and had no length check at all,
+        so it crossed the MTU silently at 36 markers."""
+        _, advertisement = _otp_datagrams(count)
+        name_pages = [datagram for datagram in advertisement if _is_otp_name_advertisement(datagram)]
+        assert len(name_pages) > 1
+        headers = [_otp_folio_and_pages(datagram) for datagram in name_pages]
+        assert len({folio for folio, _, _ in headers}) == 1
+        assert [page for _, page, _ in headers] == list(range(len(name_pages)))
+        assert {last for _, _, last in headers} == {len(name_pages) - 1}
+
+    def test_a_transform_folio_advances_once_per_folio_not_once_per_page(self) -> None:
+        server = OtpServer(system_number=1)
+        sent: list[bytes] = []
+        server._send = lambda data, dest_ip, stop_event=None: sent.append(data)  # type: ignore[method-assign]
+        for marker in _markers(120):
+            server.register_marker(marker)
+
+        folios = []
+        for _ in range(3):
+            sent.clear()
+            server._send_transform_packet()
+            page_folios = {_otp_folio_and_pages(datagram)[0] for datagram in sent}
+            assert len(page_folios) == 1
+            folios.append(page_folios.pop())
+        assert folios == [0, 1, 2]
+
+
+# --- RTTrPM: independent packets ---------------------------------------------
+
+
+class TestRttrpmPacketSplitting:
+    @pytest.mark.parametrize("count", _MARKER_COUNTS)
+    def test_every_trackable_ships_exactly_once(self, count: int) -> None:
+        datagrams = _rttrpm_datagrams(count)
+        assert sum(_rttrpm_module_count(datagram) for datagram in datagrams) == count
+
+    @pytest.mark.parametrize("count", [35, 64, 100])
+    def test_each_packet_carries_its_own_sequence_number(self, count: int) -> None:
+        """RTTrPM groups nothing across packets, so a split is several ordinary
+        packets - sharing one sequence number would look like a retransmit."""
+        datagrams = _rttrpm_datagrams(count)
+        assert len(datagrams) > 1
+        assert [_rttrpm_pkt_id(datagram) for datagram in datagrams] == list(range(len(datagrams)))
+
+    @pytest.mark.parametrize("count", [35, 100])
+    def test_the_declared_size_matches_each_packet(self, count: int) -> None:
+        """``size`` covers the whole packet including the header; a split that
+        left the original total in place would desynchronise every reader."""
+        for datagram in _rttrpm_datagrams(count):
+            assert struct.unpack("!H", datagram[11:13])[0] == len(datagram)
+
+    def test_a_large_set_is_no_longer_truncated(self) -> None:
+        """299 trackables used to hit the uint8 module cap and lose the tail
+        silently; they now ride across as many packets as they need."""
+        datagrams = _rttrpm_datagrams(299)
+        assert sum(_rttrpm_module_count(datagram) for datagram in datagrams) == 299

--- a/tests/test_packet_chunking.py
+++ b/tests/test_packet_chunking.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""The byte-budget split shared by the PSN, OTP and RTTrPM send paths.
+
+Sizes come from the caller's own encoder, so the properties that matter are
+about the split itself: it loses nothing, it keeps order, it stays inside the
+budget wherever that is possible at all, and it terminates on an item that never
+fits. The protocol wiring is covered in ``test_output_packet_splitting``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openfollow.packet_chunking import MAX_DATAGRAM_BYTES, chunk_to_datagrams
+
+pytestmark = pytest.mark.unit
+
+_OVERHEAD = 10
+
+
+def _sizer(per_item: dict[str, int]):
+    """Encoder stand-in: a fixed overhead plus each item's declared cost."""
+
+    def encoded_size(items) -> int:
+        return _OVERHEAD + sum(per_item[item] for item in items)
+
+    return encoded_size
+
+
+def _uniform(count: int, size: int) -> tuple[list[str], dict[str, int]]:
+    items = [f"i{index}" for index in range(count)]
+    return items, dict.fromkeys(items, size)
+
+
+def test_an_empty_list_produces_no_datagrams() -> None:
+    assert chunk_to_datagrams([], _sizer({})) == []
+
+
+def test_a_set_that_fits_stays_in_one_datagram() -> None:
+    items, sizes = _uniform(5, 20)
+    assert [list(chunk) for chunk in chunk_to_datagrams(items, _sizer(sizes), 200)] == [items]
+
+
+def test_a_set_at_the_exact_budget_stays_in_one_datagram() -> None:
+    """Off-by-one here silently halves the payload of every full datagram."""
+    items, sizes = _uniform(4, 25)  # 10 + 4*25 == 110
+    assert len(chunk_to_datagrams(items, _sizer(sizes), 110)) == 1
+    assert len(chunk_to_datagrams(items, _sizer(sizes), 109)) == 2
+
+
+@pytest.mark.parametrize("count", [2, 3, 7, 33, 100])
+def test_every_item_is_carried_exactly_once_and_in_order(count: int) -> None:
+    items, sizes = _uniform(count, 40)
+    chunks = chunk_to_datagrams(items, _sizer(sizes), 130)  # 3 items per chunk
+    assert [item for chunk in chunks for item in chunk] == items
+
+
+@pytest.mark.parametrize("budget", [50, 90, 130, 400])
+def test_no_chunk_exceeds_the_budget(budget: int) -> None:
+    items, sizes = _uniform(40, 37)
+    encoded_size = _sizer(sizes)
+    for chunk in chunk_to_datagrams(items, encoded_size, budget):
+        assert encoded_size(chunk) <= budget
+
+
+def test_items_of_differing_size_are_packed_to_the_budget() -> None:
+    items = ["small", "large", "small2", "large2"]
+    sizes = {"small": 10, "large": 80, "small2": 10, "large2": 80}
+    chunks = [list(chunk) for chunk in chunk_to_datagrams(items, _sizer(sizes), 100)]
+    assert chunks == [["small", "large"], ["small2", "large2"]]
+
+
+def test_an_item_too_large_for_any_datagram_is_emitted_alone() -> None:
+    """The alternative is dropping it or spinning forever; the protocol layer
+    decides what an unsendable item means, so it has to arrive there."""
+    items = ["huge", "a", "b"]
+    sizes = {"huge": 5_000, "a": 10, "b": 10}
+    chunks = [list(chunk) for chunk in chunk_to_datagrams(items, _sizer(sizes), 100)]
+    assert chunks == [["huge"], ["a", "b"]]
+
+
+def test_consecutive_oversize_items_each_get_their_own_datagram() -> None:
+    items, sizes = _uniform(3, 5_000)
+    assert [list(chunk) for chunk in chunk_to_datagrams(items, _sizer(sizes), 100)] == [[i] for i in items]
+
+
+def test_the_encoder_is_called_once_per_item_plus_once() -> None:
+    """Sizing by re-encoding each candidate chunk would be quadratic, which at
+    the transform fps is the difference between free and not."""
+    items, sizes = _uniform(50, 40)
+    calls = 0
+    inner = _sizer(sizes)
+
+    def counting(chunk) -> int:
+        nonlocal calls
+        calls += 1
+        return inner(chunk)
+
+    chunk_to_datagrams(items, counting, 130)
+    assert calls == len(items) + 1
+
+
+def test_the_default_budget_is_the_udp_payload_of_an_ethernet_mtu() -> None:
+    """1500 less the 20-octet IPv4 and 8-octet UDP headers. Fragmentation
+    starts here, below every one of these protocols' own packet limits."""
+    assert MAX_DATAGRAM_BYTES == 1472
+    items, sizes = _uniform(2, 1_000)
+    assert len(chunk_to_datagrams(items, _sizer(sizes))) == 2

--- a/tests/test_psn_timestamps.py
+++ b/tests/test_psn_timestamps.py
@@ -108,23 +108,38 @@ class TestTrackerFieldsReachTheWire:
 
 
 class TestHeaderSharesTheTrackerClock:
-    def test_header_reads_the_injected_clock(self) -> None:
-        clock = _StepClock(555_000)
-        server = PsnServer(clock=clock)
-        assert server._next_data_header().timestamp == 555_000
+    """Read off the wire rather than off the header builder: what a receiver
+    compares is what arrives, and the builder is free to be restructured."""
 
-    def test_header_and_tracker_stamps_share_one_time_base(self) -> None:
+    @staticmethod
+    def _sent_data_packets(server: PsnServer, monkeypatch: pytest.MonkeyPatch) -> list[bytes]:
+        sent: list[bytes] = []
+        monkeypatch.setattr(server, "_send", lambda data, stop_event=None: sent.append(data))
+        return sent
+
+    def _one_packet(self, server: PsnServer, monkeypatch: pytest.MonkeyPatch) -> pypsn.PsnDataPacket:
+        sent = self._sent_data_packets(server, monkeypatch)
+        server._send_data_packet()
+        packet = pypsn.parse_psn_packet(sent[0])
+        assert isinstance(packet, pypsn.PsnDataPacket)
+        return packet
+
+    def test_header_reads_the_injected_clock(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        clock = _StepClock(555_000)
+        server = PsnServer(clock=clock, mcast_ip=None)
+        server.add_marker(301, "Marker 301").set_pos(1.0, 2.0, 3.0)
+        assert self._one_packet(server, monkeypatch).info.timestamp == 555_000
+
+    def test_header_and_tracker_stamps_share_one_time_base(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A receiver compares the two to judge tracker freshness, so they must
         come from the same clock - not one wall and one monotonic."""
         clock = _StepClock(1_000)
-        server = PsnServer(clock=clock)
-        marker = server.add_marker(301, "Marker 301")
-        marker.set_pos(1.0, 2.0, 3.0)
+        server = PsnServer(clock=clock, mcast_ip=None)
+        server.add_marker(301, "Marker 301").set_pos(1.0, 2.0, 3.0)
         clock.now = 4_000
-        info = server._next_data_header()
-        assert marker.to_psn_marker().timestamp == 1_000
-        assert info.timestamp == 4_000
-        assert info.timestamp - marker.timestamp == 3_000
+        packet = self._one_packet(server, monkeypatch)
+        assert packet.trackers[0].timestamp == 1_000
+        assert packet.info.timestamp == 4_000
 
     def test_a_write_during_the_snapshot_cannot_outrun_the_header(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The header and the trackers are read at different instants while the
@@ -136,26 +151,29 @@ class TestHeaderSharesTheTrackerClock:
         marker = server.add_marker(301, "Marker 301")
         marker.set_pos(1.0, 2.0, 3.0)
 
-        sent: list[bytes] = []
-        monkeypatch.setattr(server, "_send", lambda data, stop_event=None: sent.append(data))
-        real_make = server._next_data_header
+        sent = self._sent_data_packets(server, monkeypatch)
+        real_next_id = server._next_data_frame_id
 
-        def _make_then_write() -> pypsn.PsnInfo:
-            info = real_make()
+        def _take_id_then_write() -> int:
+            frame_id = real_next_id()
             clock.now += 5_000
             marker.set_pos(9.0, 9.0, 9.0)  # a write lands between the two reads
-            return info
+            return frame_id
 
-        monkeypatch.setattr(server, "_next_data_header", _make_then_write)
+        monkeypatch.setattr(server, "_next_data_frame_id", _take_id_then_write)
         server._send_data_packet()
 
         packet = pypsn.parse_psn_packet(sent[0])
         assert isinstance(packet, pypsn.PsnDataPacket)
         assert packet.trackers[0].timestamp <= packet.info.timestamp
 
-    def test_header_advances_between_packets(self) -> None:
+    def test_header_advances_between_packets(self, monkeypatch: pytest.MonkeyPatch) -> None:
         clock = _StepClock(1_000)
-        server = PsnServer(clock=clock)
-        first = server._next_data_header().timestamp
+        server = PsnServer(clock=clock, mcast_ip=None)
+        server.add_marker(301, "Marker 301").set_pos(1.0, 2.0, 3.0)
+        sent = self._sent_data_packets(server, monkeypatch)
+        server._send_data_packet()
         clock.now = 17_667
-        assert server._next_data_header().timestamp > first
+        server._send_data_packet()
+        stamps = [pypsn.parse_psn_packet(datagram).info.timestamp for datagram in sent]
+        assert stamps[1] > stamps[0]

--- a/tests/test_rttrpm.py
+++ b/tests/test_rttrpm.py
@@ -753,14 +753,19 @@ class TestRttrpmCapWarning:
     """Cap warning must surface a recurring/newly-introduced cap condition,
     not be suppressed once-ever for the whole process lifetime."""
 
-    def _capping_markers(self) -> list[Marker]:
-        return [_marker(i, name="T") for i in range(1, 300)]  # 299 > 255
+    # The byte split keeps a packet near 33 trackables, well under the uint8
+    # ``numModules`` ceiling, so the module cap is only reachable by lowering
+    # it - which is the point: it is a backstop behind the split, and this is
+    # what fires if the split ever stops holding.
+    def _cap_modules_at(self, monkeypatch: pytest.MonkeyPatch, limit: int) -> None:
+        monkeypatch.setattr("openfollow.rttrpm.server._MAX_MODULES", limit)
 
-    def test_warns_once_within_a_cap_episode(self, caplog) -> None:
+    def test_warns_once_within_a_cap_episode(self, monkeypatch: pytest.MonkeyPatch, caplog) -> None:
+        self._cap_modules_at(monkeypatch, 2)
         srv = RttrpmServer(host="127.0.0.1")
         srv._socket = MagicMock()
-        for t in self._capping_markers():
-            srv.register_marker(t)
+        for i in range(1, 6):
+            srv.register_marker(_marker(i, name="T"))
 
         with caplog.at_level("WARNING", logger="openfollow.rttrpm.server"):
             srv._send_packet()
@@ -769,12 +774,13 @@ class TestRttrpmCapWarning:
         warns = [r for r in caplog.records if "RTTrPM packet capped" in r.message]
         assert len(warns) == 1  # one log line per episode, not every frame
 
-    def test_rearms_after_cap_clears_and_returns(self, caplog) -> None:
+    def test_rearms_after_cap_clears_and_returns(self, monkeypatch: pytest.MonkeyPatch, caplog) -> None:
         # Cap, then drop back under the limit (re-arm), then cap again: the
         # second cap episode must log again rather than stay silent forever.
+        self._cap_modules_at(monkeypatch, 2)
         srv = RttrpmServer(host="127.0.0.1")
         srv._socket = MagicMock()
-        capping = self._capping_markers()
+        capping = [_marker(i, name="T") for i in range(1, 6)]
         for t in capping:
             srv.register_marker(t)
 


### PR DESCRIPTION
Closes #91.

## The problem

Every marker-carrying output emitted one datagram per frame carrying every registered marker. Measured through the deployed encoders, each crossed the **1472 B** UDP payload of a 1500 B Ethernet MTU at a different marker count:

| Output | overhead | per marker | crossed at | behaviour past it |
|---|---|---|---|---|
| PSN data | 24 B | 104 B | **14** (1480 B) | silently fragments, declares `packet_count=1` |
| PSN info | 38 B | 8 + name | **85** (1474 B) | same |
| OTP transform | 97 B | 43 B | **32** (1473 B) | raises → whole frame dropped |
| OTP name advertisement | 96 B | 39 B | **36** (1500 B) | **silently fragments** |
| RTTrPM | 18 B | ~43 B | **34** | silently fragments; truncates past 65507 B |

IP fragmentation usually still delivers on a quiet bench LAN and starts dropping frames under show-network load — it works in the shop and fails on site.

**Found while fixing this, not in the issue:** the Section 6.3.1 length cap was enforced at exactly one call site — the OTP transform builder. `encode_otp_name_advertisement_packet` had no check at all, so it crossed the MTU silently at 36 markers.

## The fix

A shared `chunk_to_datagrams` helper answers "where to cut" once, measuring through the caller's own encoder so a field added later moves the split instead of silently pushing the datagram over. Each protocol then applies its own grouping — all three already had the mechanism, none used it:

- **PSN** — packets of one frame: the header is built **once per frame**, so every packet repeats one `frame_id` and one timestamp and declares the real `frame_packet_count`. Building it per packet would land each chunk in a different frame and no client could reassemble.
- **OTP** — pages of one folio (§6.7-6.9): shared Folio Number, `page` 0..`last_page`. The fields existed and were hardcoded to zero. Replaces the old "drop the whole frame past 31 markers". The Transform Layer's **Full Point Set** flag is repeated on every page — it describes the folio, so a page contradicting its siblings would describe no coherent point set.
- **RTTrPM** — independent packets, each with its own `pkt_id`. RTTrPM groups nothing across packets. Also removes the silent truncation past the old 65507 B budget.

`PsnReceiver` needs no change — it already reads 65535 and applies each packet's trackers independently, so a peer's split frame accumulates without a reassembly buffer.

Chunking also closes a latent overflow nobody had hit: PSN chunk-length fields are 15-bit, so a data packet silently corrupted past ~315 markers and an info packet past ~2000.

## Testing

The load-bearing test is cross-protocol: **no stream may emit a datagram past 1472 at any marker count**, over all five encoders × 10 marker counts × two name lengths. That single assertion would have caught all five thresholds, and it is what stops a future field from quietly re-crossing the line.

Every new test was **mutation-checked** against the plausible reverts — no split, hardcoded packet count, per-packet frame id, per-packet folio, per-packet clock read, dropped tail chunk, per-page Full Point Set, shared sequence number, off-by-one budget, dropped ≥1-item guarantee. All 15 mutations were caught.

The OTP and RTTrPM suites lost their oversize-drop and cap-warning triggers, since neither condition is reachable through the send path any more. Both keep their throttle coverage by lowering the respective cap to reach the backstop — which is exactly what fires if a split ever stops holding.

`make ci-remote` green on pi66 (aarch64 / Python 3.13 / trixie) at 100% line + branch coverage. No new pragmas.

## Hardware acceptance — PASSED

Reassembly is receiver-side behaviour, so it was confirmed against real consumer software rather than our own decoders:

- [x] **PSN** — PSNView, 40 markers (4 packets/frame): reassembles correctly
- [x] **OTP** — OTPAnalyzer, 40 markers: all 40 points present, named and moving, with Errors logging on and no error emitted. Points 32-40 and names 36-40 ride on a second page, so their presence *is* the paging proof
- [x] **RTTrPM** — size probe; packets are independent, so there is no reassembly to validate

Full results in the acceptance comment below. Two environment gotchas found and documented in the hw-validation README: OTPView and OTPAnalyzer cannot run simultaneously (both bind `*:5568` without `SO_REUSEPORT`, the second silently shows nothing), and consumers must be on a **wired** interface since 60 Hz multicast is routinely dropped over Wi-Fi.

The probe drives the deployed send paths and asserts the MTU budget at 4-100 markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
