### PR TITLE
build(deps): bump pillow and audit the export extra

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # Include indirect dependencies. By default Dependabot bumps only what
+    # pyproject.toml names, so a CVE in a transitive dependency produces no PR
+    # at all - which is how pillow and setuptools sat on known advisories for
+    # two months with both this and pip-audit switched on.
+    allow:
+      - dependency-type: "all"
     labels:
       - "dependencies"
     groups:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,8 +209,9 @@ jobs:
       # ``-E detection`` so onnxruntime + opencv are in the audited closure;
       # ``mido`` + ``python-rtmidi`` come in as base deps. ``sync`` (not
       # ``install``) so a fuzzy restore-key hit can only ever shrink back to the
-      # lock's closure: this audit gates a release, so it must fail on the CVEs
-      # a release actually ships and on nothing else.
+      # lock's closure. The ``dev`` group is deliberately inside that closure:
+      # ruff, pytest and bandit run inside this pipeline, so a CVE there is in
+      # scope for the gate in a way one in the export toolchain is not.
       - name: Install dependencies
         run: poetry sync --no-interaction -E detection
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,9 +189,12 @@ jobs:
             venv-${{ runner.os }}-py3.13-
 
       # ``-E detection`` so onnxruntime + opencv are in the audited closure;
-      # ``mido`` + ``python-rtmidi`` come in as base deps.
+      # ``mido`` + ``python-rtmidi`` come in as base deps. ``sync`` (not
+      # ``install``) because the export step below adds to this same venv and
+      # the cache is saved after it - without the prune, a cache hit would put
+      # the export toolchain inside the gating closure.
       - name: Install dependencies
-        run: poetry install --no-interaction -E detection
+        run: poetry sync --no-interaction -E detection
 
       # pip is installed inside the venv being audited, so a vulnerable pip
       # fails this job even when every project dependency is clean. Keep it
@@ -201,4 +204,19 @@ jobs:
         run: poetry run python -m pip install --upgrade pip
 
       - name: pip-audit (supply-chain)
+        run: make audit
+
+      # The export toolchain (ultralytics + torch) is workstation-only: the
+      # .deb build refuses to bundle it and no show device ever loads it, so a
+      # CVE there must not block a release. It must not be invisible either -
+      # an extra outside the audited closure drifts silently, with both
+      # pip-audit and Dependabot (which only bumps what pyproject names)
+      # reporting nothing. Audited last, reported, never gating.
+      - name: Install export toolchain
+        run: |
+          poetry install --no-interaction -E detection -E export
+          poetry run python -m pip install --upgrade pip
+
+      - name: pip-audit (export toolchain, report-only)
+        continue-on-error: true
         run: make audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
   pull_request:
+  # The audit jobs below are PR-skipped, so an edit to them lands on ``main``
+  # untested. This makes a manual run of the branch possible beforehand.
+  workflow_dispatch:
   schedule:
     # Weekly supply-chain audit (Mondays 06:00 UTC) – drives the `audit` job so
     # a newly-disclosed CVE is surfaced even when no code has changed.
@@ -15,9 +18,12 @@ on:
 
 # Cancel in-progress run when a newer commit is pushed to same ref.
 # Latest commit is the only one that matters; superseded runs just burn runner
-# minutes. ``main`` pushes are serialized per ref.
+# minutes. ``main`` pushes are serialized per ref. The event name is part of the
+# key because a ``schedule`` run and a ``main`` push both resolve ``github.ref``
+# to ``refs/heads/main`` – without it, any Monday-morning merge cancels the
+# week's supply-chain audit and leaves no CVE report at all.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:
@@ -65,9 +71,15 @@ jobs:
             gstreamer1.0-plugins-bad \
             libasound2-dev
 
+      # Pinned to the version stamped in ``poetry.lock``'s header. Unpinned,
+      # ``snok/install-poetry@v1`` installs whatever resolves as latest at run
+      # time, and the audit job's ``poetry sync`` does not exist before 2.0 – a
+      # drift off that line breaks one job, on ``main``, where the PR that
+      # caused it ran no audit at all. Bump with the lock.
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: "2.4.1"
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
@@ -176,23 +188,29 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: "2.4.1"
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
 
+      # Own key prefix. Both jobs cache ``.venv``, and on a ``poetry.lock``
+      # change both miss and both save concurrently – with one shared key
+      # whichever post-step wins the race decides what the other job starts
+      # from, and ``test`` installs with ``poetry install``, which computes no
+      # uninstalls and would carry the surplus forward on every later run.
       - name: Cache Poetry virtualenv
         uses: actions/cache@v6
         with:
           path: .venv
-          key: venv-${{ runner.os }}-py3.13-${{ hashFiles('poetry.lock') }}
+          key: venv-audit-${{ runner.os }}-py3.13-${{ hashFiles('poetry.lock') }}
           restore-keys: |
-            venv-${{ runner.os }}-py3.13-
+            venv-audit-${{ runner.os }}-py3.13-
 
       # ``-E detection`` so onnxruntime + opencv are in the audited closure;
       # ``mido`` + ``python-rtmidi`` come in as base deps. ``sync`` (not
-      # ``install``) because the export step below adds to this same venv and
-      # the cache is saved after it - without the prune, a cache hit would put
-      # the export toolchain inside the gating closure.
+      # ``install``) so a fuzzy restore-key hit can only ever shrink back to the
+      # lock's closure: this audit gates a release, so it must fail on the CVEs
+      # a release actually ships and on nothing else.
       - name: Install dependencies
         run: poetry sync --no-interaction -E detection
 
@@ -206,17 +224,79 @@ jobs:
       - name: pip-audit (supply-chain)
         run: make audit
 
-      # The export toolchain (ultralytics + torch) is workstation-only: the
-      # .deb build refuses to bundle it and no show device ever loads it, so a
-      # CVE there must not block a release. It must not be invisible either -
-      # an extra outside the audited closure drifts silently, with both
-      # pip-audit and Dependabot (which only bumps what pyproject names)
-      # reporting nothing. Audited last, reported, never gating.
+  # The export toolchain (ultralytics + torch) is workstation-only: the .deb
+  # build refuses to bundle it and no show device ever loads it, so a CVE there
+  # must not block a release. It must not be invisible either – an extra outside
+  # the audited closure drifts silently, with both pip-audit and Dependabot
+  # reporting nothing. Hence its own job with its own throwaway venv: ~6 GB of
+  # torch + CUDA wheels must never reach the `.venv` cache the gating jobs
+  # restore from, and caching it here would put a ~3 GB entry in a 10 GB
+  # per-repository budget and evict every other job's venv by LRU.
+  audit-export:
+    if: github.event_name != 'pull_request'
+    # Report-only down to the install: a PyPI hiccup, a hash mismatch or a full
+    # disk while unpacking the CUDA wheels must not make the supply-chain audit
+    # read red for a reason that is not a CVE.
+    continue-on-error: true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            python3-gi \
+            python3-gi-cairo \
+            gir1.2-gstreamer-1.0 \
+            gir1.2-gst-plugins-base-1.0 \
+            gir1.2-gtk-3.0 \
+            gir1.2-rsvg-2.0 \
+            libgirepository-2.0-dev \
+            libcairo2-dev \
+            libgstreamer1.0-0 \
+            gstreamer1.0-tools \
+            gstreamer1.0-plugins-base \
+            gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-bad \
+            libasound2-dev
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: "2.4.1"
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      # Deliberately uncached – see the job comment. pip lives inside the venv
+      # being audited, so it is upgraded here too rather than reported on.
       - name: Install export toolchain
         run: |
-          poetry install --no-interaction -E detection -E export
+          poetry sync --no-interaction -E detection -E export
           poetry run python -m pip install --upgrade pip
 
+      # The report goes to the step summary instead of being left to an exit
+      # code. This closure carries known advisories today, so a pass/fail signal
+      # here would be permanently red, and the next genuinely new finding would
+      # read exactly like the noise it was buried in. The listing is the signal:
+      # a row that was not there last week is the drift this job exists to show.
       - name: pip-audit (export toolchain, report-only)
-        continue-on-error: true
-        run: make audit
+        run: |
+          set +e
+          report="$(make audit 2>&1)"
+          set -e
+          {
+            echo "## Export toolchain audit (report-only, non-gating)"
+            echo
+            echo '```'
+            echo "$report"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/poetry.lock
+++ b/poetry.lock
@@ -438,7 +438,7 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["dev"]
-markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
+markers = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -2515,104 +2515,100 @@ files = [
 
 [[package]]
 name = "pillow"
-version = "12.1.1"
+version = "12.3.0"
 description = "Python Imaging Library (fork)"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"export\""
 files = [
-    {file = "pillow-12.1.1-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1f1625b72740fdda5d77b4def688eb8fd6490975d06b909fd19f13f391e077e0"},
-    {file = "pillow-12.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:178aa072084bd88ec759052feca8e56cbb14a60b39322b99a049e58090479713"},
-    {file = "pillow-12.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b66e95d05ba806247aaa1561f080abc7975daf715c30780ff92a20e4ec546e1b"},
-    {file = "pillow-12.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:89c7e895002bbe49cdc5426150377cbbc04767d7547ed145473f496dfa40408b"},
-    {file = "pillow-12.1.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a5cbdcddad0af3da87cb16b60d23648bc3b51967eb07223e9fed77a82b457c4"},
-    {file = "pillow-12.1.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9f51079765661884a486727f0729d29054242f74b46186026582b4e4769918e4"},
-    {file = "pillow-12.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:99c1506ea77c11531d75e3a412832a13a71c7ebc8192ab9e4b2e355555920e3e"},
-    {file = "pillow-12.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:36341d06738a9f66c8287cf8b876d24b18db9bd8740fa0672c74e259ad408cff"},
-    {file = "pillow-12.1.1-cp310-cp310-win32.whl", hash = "sha256:6c52f062424c523d6c4db85518774cc3d50f5539dd6eed32b8f6229b26f24d40"},
-    {file = "pillow-12.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:c6008de247150668a705a6338156efb92334113421ceecf7438a12c9a12dab23"},
-    {file = "pillow-12.1.1-cp310-cp310-win_arm64.whl", hash = "sha256:1a9b0ee305220b392e1124a764ee4265bd063e54a751a6b62eff69992f457fa9"},
-    {file = "pillow-12.1.1-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:e879bb6cd5c73848ef3b2b48b8af9ff08c5b71ecda8048b7dd22d8a33f60be32"},
-    {file = "pillow-12.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:365b10bb9417dd4498c0e3b128018c4a624dc11c7b97d8cc54effe3b096f4c38"},
-    {file = "pillow-12.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d4ce8e329c93845720cd2014659ca67eac35f6433fd3050393d85f3ecef0dad5"},
-    {file = "pillow-12.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc354a04072b765eccf2204f588a7a532c9511e8b9c7f900e1b64e3e33487090"},
-    {file = "pillow-12.1.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e7976bf1910a8116b523b9f9f58bf410f3e8aa330cd9a2bb2953f9266ab49af"},
-    {file = "pillow-12.1.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:597bd9c8419bc7c6af5604e55847789b69123bbe25d65cc6ad3012b4f3c98d8b"},
-    {file = "pillow-12.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2c1fc0f2ca5f96a3c8407e41cca26a16e46b21060fe6d5b099d2cb01412222f5"},
-    {file = "pillow-12.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:578510d88c6229d735855e1f278aa305270438d36a05031dfaae5067cc8eb04d"},
-    {file = "pillow-12.1.1-cp311-cp311-win32.whl", hash = "sha256:7311c0a0dcadb89b36b7025dfd8326ecfa36964e29913074d47382706e516a7c"},
-    {file = "pillow-12.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:fbfa2a7c10cc2623f412753cddf391c7f971c52ca40a3f65dc5039b2939e8563"},
-    {file = "pillow-12.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:b81b5e3511211631b3f672a595e3221252c90af017e399056d0faabb9538aa80"},
-    {file = "pillow-12.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ab323b787d6e18b3d91a72fc99b1a2c28651e4358749842b8f8dfacd28ef2052"},
-    {file = "pillow-12.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:adebb5bee0f0af4909c30db0d890c773d1a92ffe83da908e2e9e720f8edf3984"},
-    {file = "pillow-12.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bb66b7cc26f50977108790e2456b7921e773f23db5630261102233eb355a3b79"},
-    {file = "pillow-12.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aee2810642b2898bb187ced9b349e95d2a7272930796e022efaf12e99dccd293"},
-    {file = "pillow-12.1.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a0b1cd6232e2b618adcc54d9882e4e662a089d5768cd188f7c245b4c8c44a397"},
-    {file = "pillow-12.1.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7aac39bcf8d4770d089588a2e1dd111cbaa42df5a94be3114222057d68336bd0"},
-    {file = "pillow-12.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ab174cd7d29a62dd139c44bf74b698039328f45cb03b4596c43473a46656b2f3"},
-    {file = "pillow-12.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:339ffdcb7cbeaa08221cd401d517d4b1fe7a9ed5d400e4a8039719238620ca35"},
-    {file = "pillow-12.1.1-cp312-cp312-win32.whl", hash = "sha256:5d1f9575a12bed9e9eedd9a4972834b08c97a352bd17955ccdebfeca5913fa0a"},
-    {file = "pillow-12.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:21329ec8c96c6e979cd0dfd29406c40c1d52521a90544463057d2aaa937d66a6"},
-    {file = "pillow-12.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:af9a332e572978f0218686636610555ae3defd1633597be015ed50289a03c523"},
-    {file = "pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d242e8ac078781f1de88bf823d70c1a9b3c7950a44cdf4b7c012e22ccbcd8e4e"},
-    {file = "pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:02f84dfad02693676692746df05b89cf25597560db2857363a208e393429f5e9"},
-    {file = "pillow-12.1.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:e65498daf4b583091ccbb2556c7000abf0f3349fcd57ef7adc9a84a394ed29f6"},
-    {file = "pillow-12.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6c6db3b84c87d48d0088943bf33440e0c42370b99b1c2a7989216f7b42eede60"},
-    {file = "pillow-12.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8b7e5304e34942bf62e15184219a7b5ad4ff7f3bb5cca4d984f37df1a0e1aee2"},
-    {file = "pillow-12.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:18e5bddd742a44b7e6b1e773ab5db102bd7a94c32555ba656e76d319d19c3850"},
-    {file = "pillow-12.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc44ef1f3de4f45b50ccf9136999d71abb99dca7706bc75d222ed350b9fd2289"},
-    {file = "pillow-12.1.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a8eb7ed8d4198bccbd07058416eeec51686b498e784eda166395a23eb99138e"},
-    {file = "pillow-12.1.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47b94983da0c642de92ced1702c5b6c292a84bd3a8e1d1702ff923f183594717"},
-    {file = "pillow-12.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:518a48c2aab7ce596d3bf79d0e275661b846e86e4d0e7dec34712c30fe07f02a"},
-    {file = "pillow-12.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a550ae29b95c6dc13cf69e2c9dc5747f814c54eeb2e32d683e5e93af56caa029"},
-    {file = "pillow-12.1.1-cp313-cp313-win32.whl", hash = "sha256:a003d7422449f6d1e3a34e3dd4110c22148336918ddbfc6a32581cd54b2e0b2b"},
-    {file = "pillow-12.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:344cf1e3dab3be4b1fa08e449323d98a2a3f819ad20f4b22e77a0ede31f0faa1"},
-    {file = "pillow-12.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c0dd1636633e7e6a0afe7bf6a51a14992b7f8e60de5789018ebbdfae55b040a"},
-    {file = "pillow-12.1.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0330d233c1a0ead844fc097a7d16c0abff4c12e856c0b325f231820fee1f39da"},
-    {file = "pillow-12.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5dae5f21afb91322f2ff791895ddd8889e5e947ff59f71b46041c8ce6db790bc"},
-    {file = "pillow-12.1.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2e0c664be47252947d870ac0d327fea7e63985a08794758aa8af5b6cb6ec0c9c"},
-    {file = "pillow-12.1.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:691ab2ac363b8217f7d31b3497108fb1f50faab2f75dfb03284ec2f217e87bf8"},
-    {file = "pillow-12.1.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9e8064fb1cc019296958595f6db671fba95209e3ceb0c4734c9baf97de04b20"},
-    {file = "pillow-12.1.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:472a8d7ded663e6162dafdf20015c486a7009483ca671cece7a9279b512fcb13"},
-    {file = "pillow-12.1.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:89b54027a766529136a06cfebeecb3a04900397a3590fd252160b888479517bf"},
-    {file = "pillow-12.1.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:86172b0831b82ce4f7877f280055892b31179e1576aa00d0df3bb1bbf8c3e524"},
-    {file = "pillow-12.1.1-cp313-cp313t-win32.whl", hash = "sha256:44ce27545b6efcf0fdbdceb31c9a5bdea9333e664cda58a7e674bb74608b3986"},
-    {file = "pillow-12.1.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a285e3eb7a5a45a2ff504e31f4a8d1b12ef62e84e5411c6804a42197c1cf586c"},
-    {file = "pillow-12.1.1-cp313-cp313t-win_arm64.whl", hash = "sha256:cc7d296b5ea4d29e6570dabeaed58d31c3fea35a633a69679fb03d7664f43fb3"},
-    {file = "pillow-12.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:417423db963cb4be8bac3fc1204fe61610f6abeed1580a7a2cbb2fbda20f12af"},
-    {file = "pillow-12.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:b957b71c6b2387610f556a7eb0828afbe40b4a98036fc0d2acfa5a44a0c2036f"},
-    {file = "pillow-12.1.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:097690ba1f2efdeb165a20469d59d8bb03c55fb6621eb2041a060ae8ea3e9642"},
-    {file = "pillow-12.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2815a87ab27848db0321fb78c7f0b2c8649dee134b7f2b80c6a45c6831d75ccd"},
-    {file = "pillow-12.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f7ed2c6543bad5a7d5530eb9e78c53132f93dfa44a28492db88b41cdab885202"},
-    {file = "pillow-12.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:652a2c9ccfb556235b2b501a3a7cf3742148cd22e04b5625c5fe057ea3e3191f"},
-    {file = "pillow-12.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d6e4571eedf43af33d0fc233a382a76e849badbccdf1ac438841308652a08e1f"},
-    {file = "pillow-12.1.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b574c51cf7d5d62e9be37ba446224b59a2da26dc4c1bb2ecbe936a4fb1a7cb7f"},
-    {file = "pillow-12.1.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a37691702ed687799de29a518d63d4682d9016932db66d4e90c345831b02fb4e"},
-    {file = "pillow-12.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f95c00d5d6700b2b890479664a06e754974848afaae5e21beb4d83c106923fd0"},
-    {file = "pillow-12.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:559b38da23606e68681337ad74622c4dbba02254fc9cb4488a305dd5975c7eeb"},
-    {file = "pillow-12.1.1-cp314-cp314-win32.whl", hash = "sha256:03edcc34d688572014ff223c125a3f77fb08091e4607e7745002fc214070b35f"},
-    {file = "pillow-12.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:50480dcd74fa63b8e78235957d302d98d98d82ccbfac4c7e12108ba9ecbdba15"},
-    {file = "pillow-12.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:5cb1785d97b0c3d1d1a16bc1d710c4a0049daefc4935f3a8f31f827f4d3d2e7f"},
-    {file = "pillow-12.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1f90cff8aa76835cba5769f0b3121a22bd4eb9e6884cfe338216e557a9a548b8"},
-    {file = "pillow-12.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1f1be78ce9466a7ee64bfda57bdba0f7cc499d9794d518b854816c41bf0aa4e9"},
-    {file = "pillow-12.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:42fc1f4677106188ad9a55562bbade416f8b55456f522430fadab3cef7cd4e60"},
-    {file = "pillow-12.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:98edb152429ab62a1818039744d8fbb3ccab98a7c29fc3d5fcef158f3f1f68b7"},
-    {file = "pillow-12.1.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d470ab1178551dd17fdba0fef463359c41aaa613cdcd7ff8373f54be629f9f8f"},
-    {file = "pillow-12.1.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6408a7b064595afcab0a49393a413732a35788f2a5092fdc6266952ed67de586"},
-    {file = "pillow-12.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5d8c41325b382c07799a3682c1c258469ea2ff97103c53717b7893862d0c98ce"},
-    {file = "pillow-12.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c7697918b5be27424e9ce568193efd13d925c4481dd364e43f5dff72d33e10f8"},
-    {file = "pillow-12.1.1-cp314-cp314t-win32.whl", hash = "sha256:d2912fd8114fc5545aa3a4b5576512f64c55a03f3ebcca4c10194d593d43ea36"},
-    {file = "pillow-12.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4ceb838d4bd9dab43e06c363cab2eebf63846d6a4aeaea283bbdfd8f1a8ed58b"},
-    {file = "pillow-12.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:7b03048319bfc6170e93bd60728a1af51d3dd7704935feb228c4d4faab35d334"},
-    {file = "pillow-12.1.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:600fd103672b925fe62ed08e0d874ea34d692474df6f4bf7ebe148b30f89f39f"},
-    {file = "pillow-12.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:665e1b916b043cef294bc54d47bf02d87e13f769bc4bc5fa225a24b3a6c5aca9"},
-    {file = "pillow-12.1.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:495c302af3aad1ca67420ddd5c7bd480c8867ad173528767d906428057a11f0e"},
-    {file = "pillow-12.1.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8fd420ef0c52c88b5a035a0886f367748c72147b2b8f384c9d12656678dfdfa9"},
-    {file = "pillow-12.1.1-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f975aa7ef9684ce7e2c18a3aa8f8e2106ce1e46b94ab713d156b2898811651d3"},
-    {file = "pillow-12.1.1-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8089c852a56c2966cf18835db62d9b34fef7ba74c726ad943928d494fa7f4735"},
-    {file = "pillow-12.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cb9bb857b2d057c6dfc72ac5f3b44836924ba15721882ef103cecb40d002d80e"},
-    {file = "pillow-12.1.1.tar.gz", hash = "sha256:9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4"},
+    {file = "pillow-12.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:6c0016e7b354317c4e9e525b937ac8596c38d2d232b419529b9cd7a1cd46e39a"},
+    {file = "pillow-12.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bcc33feacfaefce60c12fd500a277533bdc02b10a19f7f6d348763d8140bbba7"},
+    {file = "pillow-12.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5594fc43d548a7ed94949d139aa1341b270f1863f11cfd37f5a6c8b778a6b67f"},
+    {file = "pillow-12.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0606c8bf2cdefea14a43530f7657cbbb7ecf1c4222512492ef4a4434a9501ec"},
+    {file = "pillow-12.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:85f998ea1848bc6757289e739cfbdda3a04adfd58b02fc018ce54d754a5ce468"},
+    {file = "pillow-12.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:25b9b82bb22e6e2b3cd07b39c68b7b862001226cb3dff7130d1cb914121b39ed"},
+    {file = "pillow-12.3.0-cp310-cp310-win32.whl", hash = "sha256:37dc8f7bbb66efe481bb60defacef820c950c24713fb44962ed6aa2a50966de1"},
+    {file = "pillow-12.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:300557495eb45ebb8aec96c2da9c4be642fbf7cd937278b4013ba894ea8eb0eb"},
+    {file = "pillow-12.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:514435a37670e3e5e08f3945b68718b6ed329bb84367777e16f9f4dfe1e61a0f"},
+    {file = "pillow-12.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:00808c5e14ef63ac5161091d242999076604ff74b883423a11e5d7bbb38bf756"},
+    {file = "pillow-12.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:37d6d0a00072fd2948eb22bce7e1475f34569d90c87c59f7a2ec59541b77f7a6"},
+    {file = "pillow-12.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bcb46e2f9feff8d06323983bd83ed00c201fdcab3d74973e7072a889b3979fcd"},
+    {file = "pillow-12.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23d27a3e0307ec2244cc51e7287b919aa68d097504ebe19df4e76a98a3eea5bd"},
+    {file = "pillow-12.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4f883547d4b7f0495ebe7056b0cc2aea76094e7a4abc8e933540f3271df27d9c"},
+    {file = "pillow-12.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:236ff70b9312fb68943c703aa842ca6a758abfa45ac187a5e7c1452e96ef72b5"},
+    {file = "pillow-12.3.0-cp311-cp311-win32.whl", hash = "sha256:10e41f0fbf1eec8cfd234b8fe17a4caac7c9d0db4c204d3c173a8f9f6ef3232b"},
+    {file = "pillow-12.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:8e95e1385e4998ae9694eeaa4730ba5457ff61185b3a55e2e7bea0880aef452a"},
+    {file = "pillow-12.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:ebaea975e03d3141d9d3a507df75c9b3ec90fa9d2ffd07567b3a978d9d790b26"},
+    {file = "pillow-12.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ba09209fbe443b4acccebe845d8a138b89a8f4fbaeedd44953490b5315d5e965"},
+    {file = "pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7"},
+    {file = "pillow-12.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9c7f76c0673154f044e9d78c8655fb4213f6ca31a836df48b40fe5d187717b9"},
+    {file = "pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91"},
+    {file = "pillow-12.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e491916b378fba47242221bb9ead245211b70d504f495d105d17b14a24b4907c"},
+    {file = "pillow-12.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0dd2064cbc55aaec028ef5fbb60fa47bb6c3e7918e07ff17935284b227a9d2df"},
+    {file = "pillow-12.3.0-cp312-cp312-win32.whl", hash = "sha256:dbce0b29841537a2fa4a214c2bbf14de3587c9680caa9b4e217568472490b28f"},
+    {file = "pillow-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09"},
+    {file = "pillow-12.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:331b624368d4f1d069149002f25f44bc61c8919ce8ddb3c45bdad8f6e2d89510"},
+    {file = "pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:21900ce7ba264168cd50defae43cd75d25c833ad4ad6e73ffc5596d12e25ac89"},
+    {file = "pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4e8c2a84d977f50b9daed6eeaf3baef67d00d5d74d932288f02cb94518ee3ace"},
+    {file = "pillow-12.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:ae26d61dfa7a47befdc7572b521024e8745f3d809bd95ca9505a7bba9ef849ec"},
+    {file = "pillow-12.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7a743ff716f746fc19a9557f60dab1600d4613255f8a7aeb3cdde4db7eb15a66"},
+    {file = "pillow-12.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d69141514cc30b774ceea5e3ed3a6635c8d8a96edf664689b890f4089111fb35"},
+    {file = "pillow-12.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7401aebd7f581d7f83a439d87d474999317ee099218e5ad25d125290990ba65"},
+    {file = "pillow-12.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0847a763afefb695bc912d7c131e7e0632d4edc1d8698f58ddabec8e46b8b6d3"},
+    {file = "pillow-12.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:571b9fcb07b97ef3a492028fb3d2dc0993ca23a06138b0315286566d29ef718a"},
+    {file = "pillow-12.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:756c768d0c9c2955feb7a56c37ea24aea2e369f8d36a88da270b6a9f19e62b5e"},
+    {file = "pillow-12.3.0-cp313-cp313-win32.whl", hash = "sha256:a876864214e136f0eb367788dbd7df045f4806801518e2cfe9e13229cfe06d8f"},
+    {file = "pillow-12.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:1cca606cd25738df4ed873d5ad46bbdb3d83b5cbca291f6b4ff13a4df6b0bbe8"},
+    {file = "pillow-12.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:b629de27fda84b42cde7edef0d85f13b958b47f6e9bbcbba9b673c562a89bd8b"},
+    {file = "pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9cf95fe4d0f84c82d282745d9bb08ad9f926efa00be4697e767b814ce40d4330"},
+    {file = "pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:8728f216dcdb6e6d555cf971cb34076139ad74b31fc2c14da4fafc741c5f6217"},
+    {file = "pillow-12.3.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a45650e8ce7fafffd731db8550230db6b0d306d181a90b67d3e6bca2f1990930"},
+    {file = "pillow-12.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ba54cfebe86920a559a7c4d6b9050791c20513650a1952ebe3368c7dc70306f8"},
+    {file = "pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e158cb00350dc278f3b91551101aa7d12415a66ebf2c91d8d5ac14e56ddd3ad0"},
+    {file = "pillow-12.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9aeb04d6aef139de265b29683e119b638208f88cf73cdd1658aa07221165321"},
+    {file = "pillow-12.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:251bf95b67017e27b13d82f5b326234ca62d70f9cf4c2b9032de2358a3b12c7b"},
+    {file = "pillow-12.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fe3cca2e4e8a592be0f269a1ca4835c25199d9f3ce815c8491048f785b0a0198"},
+    {file = "pillow-12.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:23aceaa007d6172b02c277f0cd359c79492bbb14f7072b4ede9fbcaf20648130"},
+    {file = "pillow-12.3.0-cp314-cp314-win32.whl", hash = "sha256:af8d94b0db561cf68b88a267c5c44b49e134f525d0dc2cb7ed413a66bc23559a"},
+    {file = "pillow-12.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:fdafc9cce40277e0f7a0feabce0ee50dd2fa1800f3b38015e51296b5e814048d"},
+    {file = "pillow-12.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:e91206ee562682b51b98ef4b26a6ef48fd84e15fd4c4bc5ec768eb641d206838"},
+    {file = "pillow-12.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:164b31cd1a0490ab6efae01aa5df49da7061be0af1b30e035b6e9a1bfe34ee6e"},
+    {file = "pillow-12.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5afb51d599ea772b8365ae807ae557f18bccfe46ab261fd1c2a9ed700fc6eb17"},
+    {file = "pillow-12.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3edce1d53195db527e0191f84b71d02022de0540bf43a16ed734ed7537b07385"},
+    {file = "pillow-12.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf16ba1b4d0b6b7c8e534936632270cf70eb00dbe09005bc345b2677b726855c"},
+    {file = "pillow-12.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:24870b09b224f7ae3c39ed07d10e819d06f8720bc551847b1d623832b5b0e28d"},
+    {file = "pillow-12.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:30f2aa603c41533cc25c05acd0da21636e84a315768feb631c937177db558931"},
+    {file = "pillow-12.3.0-cp314-cp314t-win32.whl", hash = "sha256:4b0a7fe987b14c31ebda6083f74f22b561fd3739bc0ac51e019622e3d72668c7"},
+    {file = "pillow-12.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:962864dc93511324d51ddbb5b9f8731bf71675b93ca612a07441896f4688fb8c"},
+    {file = "pillow-12.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0740a512dc522224c77d9aa5a8d70d8b7d73fb91f2c21125d8d025d3b8990e45"},
+    {file = "pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:0feb2e9d6ad6c9e3c06effe9d00f3f1e618a6643273576b016f591e9315a7139"},
+    {file = "pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:9e881fca225083806662a5c43d627d215f258ff43c890f831966c7d7ba9c7402"},
+    {file = "pillow-12.3.0-cp315-cp315-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:4998562bf62a445225f22e07c896bb04b35b1b1f2eb6d760584c9c51d7a5f78c"},
+    {file = "pillow-12.3.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:dc624f6bc473dacdf7ef7eb8678d0d08edf15cd94fad6ae5c7d6cc67a4e4902f"},
+    {file = "pillow-12.3.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:71d6097b330eea8fd15097780c8e89cb1a8ce7838669f48c5bacd6f663dd4701"},
+    {file = "pillow-12.3.0-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28ce87c5ab450a9dd970b52e5aca5fe63ed432d18a2eaddd1979a00a1ba24ace"},
+    {file = "pillow-12.3.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b02afb9b97f65fbca5f31db6a2a3ba21aa93030225f150fa3f249717e938fb4"},
+    {file = "pillow-12.3.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:1182d52bc2d5e5d7d0949503aa7e36d12f42205dc287e4883f407b1988820d39"},
+    {file = "pillow-12.3.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e795b7eb908249c4e43c7c99fac7c2c75dab0c43566e37db472a355f63693d71"},
+    {file = "pillow-12.3.0-cp315-cp315-win32.whl", hash = "sha256:57b3d78c95ba9059768b10e28b813002261d3f3dfc55cc48b0c988f625175827"},
+    {file = "pillow-12.3.0-cp315-cp315-win_amd64.whl", hash = "sha256:fa4ecea169a355be7a3ade2c783e2ed12f0e40d2c5621cda8b3297faf7fbb9f5"},
+    {file = "pillow-12.3.0-cp315-cp315-win_arm64.whl", hash = "sha256:877c3f311ff35410f690861c4409e7ccbf0cd2f878e50628a28e5a0bb689e658"},
+    {file = "pillow-12.3.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:e9871b1ffbfa9656b60aeee92ed5136a5742696006fa322b29ea3d8da0ecc9cf"},
+    {file = "pillow-12.3.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:53aa02d20d10c3d814d536aa4e5ac9b84ca0ff5a88377963b085ad6822f93e64"},
+    {file = "pillow-12.3.0-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:446c34dcc4324b084a53b705127dc15717b22c5e140ae0a3c38349d4efec071e"},
+    {file = "pillow-12.3.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf1845d02ad822a369a49f2bb9345b1614744267682e7a03527dc3bf6eea1777"},
+    {file = "pillow-12.3.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:186941b6aef820ad110fb01fb06eb925374dc3a21b17e37ec9a53b250c6fe2d1"},
+    {file = "pillow-12.3.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:f13c32a3abd6079a66d9526e18dad9b6d280384d49d7c54040cd57b6424041d9"},
+    {file = "pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8"},
+    {file = "pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418"},
+    {file = "pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59"},
+    {file = "pillow-12.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:b3c777e849237620b022f7f297dd67705f9f5cf1685f09f02e46f93e92725468"},
+    {file = "pillow-12.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b343699e8308bdc51978310e1c959c584e7869cc8c40780058c87da7781a1e94"},
+    {file = "pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbd139c8447d25dd750ab79ee274cc5e1fe80fc56340ab10b18a195e1b6eca3e"},
+    {file = "pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7e480451b9fa137494bccd3a7d69adbe8ac65a87d97be61e11f1b1050a5bac3"},
+    {file = "pillow-12.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:04f01d28a6aaff387bf842a13be313df23ba0597a44f1a976c9feb3c6ff4711a"},
+    {file = "pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce"},
 ]
 
 [package.extras]
@@ -2620,7 +2616,7 @@ docs = ["furo", "olefile", "sphinx (>=8.2)", "sphinx-autobuild", "sphinx-copybut
 fpx = ["olefile"]
 mic = ["olefile"]
 test-arrow = ["arro3-compute", "arro3-core", "nanoarrow", "pyarrow"]
-tests = ["check-manifest", "coverage (>=7.4.2)", "defusedxml", "markdown2", "olefile", "packaging", "pyroma (>=5)", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "trove-classifiers (>=2024.10.12)"]
+tests = ["coverage (>=7.4.2)", "defusedxml", "markdown2", "olefile", "packaging", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "setuptools", "trove-classifiers (>=2024.10.12)"]
 xmp = ["defusedxml"]
 
 [[package]]
@@ -3584,25 +3580,25 @@ test = ["pytest"]
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "84.0.0"
 description = "Most extensible Python build backend with support for C/C++ extension modules"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main", "package-macos"]
 files = [
-    {file = "setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb"},
-    {file = "setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9"},
+    {file = "setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670"},
+    {file = "setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73"},
 ]
 markers = {main = "extra == \"export\" and python_version >= \"3.12\" or extra == \"export\" and platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 
 [package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.13.0) ; sys_platform != \"cygwin\""]
+check = ["pytest-checkdocs (>=2.14)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.13.0) ; sys_platform != \"cygwin\""]
 core = ["importlib_metadata (>=6) ; python_version < \"3.10\"", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging (>=24.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
 cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
-enabler = ["pytest-enabler (>=2.2)"]
+enabler = ["pytest-enabler (>=3.4)"]
 test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
-type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.18.*)", "pytest-mypy"]
+type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.18.*)", "pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 
 [[package]]
 name = "six"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4047,4 +4047,4 @@ export = ["ultralytics"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "d9c495991c3c3c8aaa9cc631a98f4f2cc9d728497b1bcfe45fcc287cb7a21023"
+content-hash = "361bee61c3b0fe429c2a3f94d737c177a43002ef4a9d0babbd840789fe8e26ac"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,10 @@ hypothesis = "^6"
 bandit = {extras = ["toml"], version = "^1.9.4"}
 pip-audit = "^2.10.1"
 
+# Used by the workflow-guard tests. Declared because it is otherwise only a
+# transitive dep of pre-commit/bandit - losing that edge fails collection.
+pyyaml = "^6.0"
+
 # Build-only tooling for the macOS .app / .dmg (packaging/macos/). Optional and
 # off by default; ``make dmg`` pulls it in with ``--with package-macos``. Kept
 # out of the runtime deps so the offline Pi / .deb build never carries

--- a/tests/test_supply_chain_audit.py
+++ b/tests/test_supply_chain_audit.py
@@ -1,17 +1,23 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 OpenFollow Project
-"""Guard tests for the supply-chain audit job's dependency closure.
+"""Guard tests for the supply-chain audit jobs' dependency closures.
 
-``pip-audit`` reports on what is installed, so an optional extra the audit job
-never installs is not audited - it reports clean while the lock carries known
-CVEs. Dependabot does not cover the gap either: it opens version PRs only for
-packages ``pyproject.toml`` names, so a vulnerable transitive dependency of an
-un-audited extra is reported by neither guard.
+``pip-audit`` reports on what is installed, so an optional extra no audit job
+installs is not audited - it reports clean while the lock carries known CVEs,
+and nothing else in the tree notices. That is not hypothetical: it is how this
+file came to exist.
+
+*Which* audit sees an extra matters as much as whether one does. The gating
+audit blocks a release, so it must cover everything a show device installs and
+nothing that only ever runs on a build workstation: a CVE in the export
+toolchain holding up a Pi release is what gets an audit ignored or deleted.
 """
 
 from __future__ import annotations
 
 import re
+import shlex
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -24,51 +30,165 @@ pytestmark = pytest.mark.unit
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
 _PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_DEB_BUILD = _REPO_ROOT / "packaging" / "build-deb.sh"
+
+_AUDIT_COMMAND = re.compile(r"\b(?:make\s+audit|pip-audit)\b")
+_SHELL_SEPARATORS = frozenset({"&&", "||", ";", "|"})
 
 
-def _audit_job() -> dict[str, Any]:
-    doc = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
-    job = doc["jobs"].get("audit")
-    assert job, "ci.yml has no 'audit' job"
-    return dict(job)
+def _strip_comments(run: str) -> str:
+    return "\n".join(line.split("#", 1)[0] for line in run.splitlines())
 
 
-def _install_steps() -> list[tuple[str, str]]:
-    """``(step name, run command)`` for every poetry install/sync in the audit job."""
-    steps = []
-    for step in _audit_job()["steps"]:
-        run = str(step.get("run", ""))
-        if re.search(r"\bpoetry\s+(install|sync)\b", run):
-            steps.append((str(step.get("name", "")), run))
-    return steps
+def _shell_commands(run: str) -> list[list[str]]:
+    """Every command in a ``run:`` block, tokenised, shell comments dropped.
+
+    Regex over the raw block cannot tell a live install from a commented-out
+    one, and only matches whichever flag spelling it was written against.
+    """
+    commands: list[list[str]] = []
+    for line in run.replace("\\\n", " ").splitlines():
+        try:
+            tokens = shlex.split(line, comments=True)
+        except ValueError:  # unbalanced quoting in a step we don't care about
+            continue
+        current: list[str] = []
+        for token in tokens:
+            if token in _SHELL_SEPARATORS:
+                if current:
+                    commands.append(current)
+                current = []
+            else:
+                current.append(token)
+        if current:
+            commands.append(current)
+    return commands
+
+
+def _poetry_verb(command: list[str]) -> str | None:
+    """The subcommand of a ``poetry`` invocation, skipping global flags."""
+    if command[:1] != ["poetry"]:
+        return None
+    return next((token for token in command[1:] if not token.startswith("-")), None)
+
+
+def _extras_installed(run: str) -> set[str]:
+    """Extras a ``run:`` block installs, over every spelling poetry accepts."""
+    extras: set[str] = set()
+    for command in _shell_commands(run):
+        if _poetry_verb(command) not in {"install", "sync"}:
+            continue
+        expecting = False
+        for token in command:
+            if expecting:
+                extras.add(token)
+                expecting = False
+            elif token in {"-E", "--extras"}:
+                expecting = True
+            elif token.startswith("--extras="):
+                extras.add(token.split("=", 1)[1])
+            elif token.startswith("-E") and len(token) > 2:
+                extras.add(token[2:])
+    return extras
+
+
+@dataclass(frozen=True)
+class _AuditJob:
+    name: str
+    gating: bool
+    extras: frozenset[str]
+    caches_venv: bool
+
+
+def _audit_jobs() -> list[_AuditJob]:
+    """Every ci.yml job that runs pip-audit, with the closure it audits."""
+    doc: dict[str, Any] = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    jobs: list[_AuditJob] = []
+    for name, job in doc["jobs"].items():
+        steps = job.get("steps") or []
+        runs = [_strip_comments(str(step.get("run", ""))) for step in steps]
+        if not any(_AUDIT_COMMAND.search(run) for run in runs):
+            continue
+        extras: set[str] = set()
+        for run in runs:
+            extras |= _extras_installed(run)
+        caches_venv = any(
+            str(step.get("uses", "")).startswith("actions/cache")
+            and ".venv" in str((step.get("with") or {}).get("path", ""))
+            for step in steps
+        )
+        jobs.append(
+            _AuditJob(
+                name=str(name),
+                gating=not bool(job.get("continue-on-error", False)),
+                extras=frozenset(extras),
+                caches_venv=caches_venv,
+            )
+        )
+    assert jobs, "ci.yml has no job that runs pip-audit"
+    return jobs
 
 
 def _declared_extras() -> list[str]:
     pyproject = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
-    extras = list(pyproject["project"].get("optional-dependencies", {}))
+    extras = sorted(pyproject["project"].get("optional-dependencies", {}))
     assert extras, "pyproject declares no optional-dependencies to audit"
     return extras
 
 
+def _shipped_extras() -> frozenset[str]:
+    """Extras the .deb bundles onto a show device, read from its build script."""
+    script = _DEB_BUILD.read_text(encoding="utf-8")
+    found = set(re.findall(r'pip"?\s+install\s+"\$REPO_ROOT\[([^\]]+)\]"', script))
+    extras = {extra.strip() for group in found for extra in group.split(",")}
+    assert extras, "no bundled extra found in build-deb.sh - has the install line moved?"
+    return frozenset(extras)
+
+
 @pytest.mark.parametrize("extra", _declared_extras())
-def test_every_declared_extra_is_installed_somewhere_in_the_audit_job(extra: str) -> None:
-    commands = [run for _, run in _install_steps()]
-    assert any(re.search(rf"-E\s+{re.escape(extra)}\b", run) for run in commands), (
-        f"the '{extra}' extra is never installed in the audit job, so pip-audit "
-        f"never sees its dependencies - the job reports clean no matter what CVEs "
-        f"they carry. Add '-E {extra}' to an install step."
+def test_every_declared_extra_is_audited_somewhere(extra: str) -> None:
+    audited: set[str] = set().union(*(job.extras for job in _audit_jobs()))
+    assert extra in audited, (
+        f"the '{extra}' extra is installed by no audit job, so pip-audit never sees "
+        f"its dependencies - every audit reports clean no matter what CVEs they "
+        f"carry. Add '-E {extra}' to an audit job's install step."
     )
 
 
-def test_first_audit_install_prunes_when_a_later_step_widens_the_closure() -> None:
-    steps = _install_steps()
-    assert len(steps) >= 1, "audit job installs nothing"
-    if len(steps) == 1:
-        return
-    first_name, first_run = steps[0]
-    assert re.search(r"\bpoetry\s+sync\b", first_run), (
-        f"'{first_name}' must use 'poetry sync', not 'poetry install': a later step "
-        "widens this same venv and the venv cache is saved afterwards, so on a cache "
-        "hit the wider closure would be restored into the gating audit and fail it on "
-        "a CVE that does not gate a release."
+def test_extras_the_deb_ships_are_covered_by_a_gating_audit() -> None:
+    gated: set[str] = set()
+    for job in _audit_jobs():
+        if job.gating:
+            gated |= job.extras
+    missing = _shipped_extras() - gated
+    assert not missing, (
+        f"{sorted(missing)} ships to show devices in the .deb but is audited only by a "
+        "continue-on-error job, so a CVE in it no longer blocks a release. Being "
+        "audited somewhere is not enough - a shipped extra has to gate."
     )
+
+
+def test_extras_the_deb_does_not_ship_never_gate_a_release() -> None:
+    workstation_only = set(_declared_extras()) - _shipped_extras()
+    for job in _audit_jobs():
+        if not job.gating:
+            continue
+        leaked = workstation_only & job.extras
+        assert not leaked, (
+            f"the gating audit job '{job.name}' installs {sorted(leaked)}, which no show "
+            "device ever loads. A CVE in build-host-only tooling would block every "
+            "release - install it in a continue-on-error job instead."
+        )
+
+
+def test_the_workstation_closure_is_never_saved_into_a_venv_cache() -> None:
+    workstation_only = set(_declared_extras()) - _shipped_extras()
+    for job in _audit_jobs():
+        if not (workstation_only & job.extras):
+            continue
+        assert not job.caches_venv, (
+            f"audit job '{job.name}' installs {sorted(workstation_only & job.extras)} and "
+            "caches '.venv'. The export closure is multiple GB: it would evict every "
+            "other job's cache by LRU, and any job restoring it installs with a poetry "
+            "'install' that computes no uninstalls, carrying the surplus forward."
+        )

--- a/tests/test_supply_chain_audit.py
+++ b/tests/test_supply_chain_audit.py
@@ -8,9 +8,14 @@ and nothing else in the tree notices. That is not hypothetical: it is how this
 file came to exist.
 
 *Which* audit sees an extra matters as much as whether one does. The gating
-audit blocks a release, so it must cover everything a show device installs and
-nothing that only ever runs on a build workstation: a CVE in the export
-toolchain holding up a Pi release is what gets an audit ignored or deleted.
+audit blocks a release, so it must cover every extra a show device installs.
+
+It deliberately does not stop there: the ``dev`` group is in that closure too,
+because ruff, pytest and bandit execute inside the release pipeline itself, so a
+compromise there reaches what ships. The line is drawn at code that neither runs
+on a device nor takes part in producing the artifact - today that is the
+``export`` extra, several GB of ML tooling the .deb build never installs. A CVE
+in *that* holding up a Pi release is what gets an audit ignored or deleted.
 """
 
 from __future__ import annotations
@@ -92,12 +97,23 @@ def _extras_installed(run: str) -> set[str]:
     return extras
 
 
+def _install_flags(run: str) -> set[str]:
+    """Option flags passed to a poetry install/sync, ``--opt=value`` normalised."""
+    flags: set[str] = set()
+    for command in _shell_commands(run):
+        if _poetry_verb(command) not in {"install", "sync"}:
+            continue
+        flags |= {token.split("=", 1)[0] for token in command if token.startswith("-")}
+    return flags
+
+
 @dataclass(frozen=True)
 class _AuditJob:
     name: str
     gating: bool
     extras: frozenset[str]
     caches_venv: bool
+    install_flags: frozenset[str]
 
 
 def _audit_jobs() -> list[_AuditJob]:
@@ -110,8 +126,10 @@ def _audit_jobs() -> list[_AuditJob]:
         if not any(_AUDIT_COMMAND.search(run) for run in runs):
             continue
         extras: set[str] = set()
+        flags: set[str] = set()
         for run in runs:
             extras |= _extras_installed(run)
+            flags |= _install_flags(run)
         caches_venv = any(
             str(step.get("uses", "")).startswith("actions/cache")
             and ".venv" in str((step.get("with") or {}).get("path", ""))
@@ -123,6 +141,7 @@ def _audit_jobs() -> list[_AuditJob]:
                 gating=not bool(job.get("continue-on-error", False)),
                 extras=frozenset(extras),
                 caches_venv=caches_venv,
+                install_flags=frozenset(flags),
             )
         )
     assert jobs, "ci.yml has no job that runs pip-audit"
@@ -191,4 +210,24 @@ def test_the_workstation_closure_is_never_saved_into_a_venv_cache() -> None:
             "caches '.venv'. The export closure is multiple GB: it would evict every "
             "other job's cache by LRU, and any job restoring it installs with a poetry "
             "'install' that computes no uninstalls, carrying the surplus forward."
+        )
+
+
+def test_the_gating_audit_keeps_the_build_toolchain_in_its_closure() -> None:
+    """Poetry's ``dev`` group is non-optional, so the gate covers it. Keep it that way.
+
+    ruff, pytest, mypy and bandit run inside the release pipeline, so a CVE in one
+    of them is a CVE in what produces the artifact. Narrowing the gating install
+    to the runtime closure would read as tightening the boundary this file draws,
+    while actually dropping that coverage.
+    """
+    narrowing = {"--only", "--without", "--no-dev"}
+    for job in _audit_jobs():
+        if not job.gating:
+            continue
+        used = narrowing & job.install_flags
+        assert not used, (
+            f"the gating audit job '{job.name}' installs with {sorted(used)}, which drops "
+            "Poetry groups from the audited closure. The 'dev' group is meant to be in it: "
+            "its tooling runs in the pipeline that builds the release."
         )

--- a/tests/test_supply_chain_audit.py
+++ b/tests/test_supply_chain_audit.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 OpenFollow Project
+"""Guard tests for the supply-chain audit job's dependency closure.
+
+``pip-audit`` reports on what is installed, so an optional extra the audit job
+never installs is not audited - it reports clean while the lock carries known
+CVEs. Dependabot does not cover the gap either: it opens version PRs only for
+packages ``pyproject.toml`` names, so a vulnerable transitive dependency of an
+un-audited extra is reported by neither guard.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import tomllib
+import yaml
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+
+def _audit_job() -> dict[str, Any]:
+    doc = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    job = doc["jobs"].get("audit")
+    assert job, "ci.yml has no 'audit' job"
+    return dict(job)
+
+
+def _install_steps() -> list[tuple[str, str]]:
+    """``(step name, run command)`` for every poetry install/sync in the audit job."""
+    steps = []
+    for step in _audit_job()["steps"]:
+        run = str(step.get("run", ""))
+        if re.search(r"\bpoetry\s+(install|sync)\b", run):
+            steps.append((str(step.get("name", "")), run))
+    return steps
+
+
+def _declared_extras() -> list[str]:
+    pyproject = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    extras = list(pyproject["project"].get("optional-dependencies", {}))
+    assert extras, "pyproject declares no optional-dependencies to audit"
+    return extras
+
+
+@pytest.mark.parametrize("extra", _declared_extras())
+def test_every_declared_extra_is_installed_somewhere_in_the_audit_job(extra: str) -> None:
+    commands = [run for _, run in _install_steps()]
+    assert any(re.search(rf"-E\s+{re.escape(extra)}\b", run) for run in commands), (
+        f"the '{extra}' extra is never installed in the audit job, so pip-audit "
+        f"never sees its dependencies - the job reports clean no matter what CVEs "
+        f"they carry. Add '-E {extra}' to an install step."
+    )
+
+
+def test_first_audit_install_prunes_when_a_later_step_widens_the_closure() -> None:
+    steps = _install_steps()
+    assert len(steps) >= 1, "audit job installs nothing"
+    if len(steps) == 1:
+        return
+    first_name, first_run = steps[0]
+    assert re.search(r"\bpoetry\s+sync\b", first_run), (
+        f"'{first_name}' must use 'poetry sync', not 'poetry install': a later step "
+        "widens this same venv and the venv cache is saved afterwards, so on a cache "
+        "hit the wider closure would be restored into the gating audit and fail it on "
+        "a CVE that does not gate a release."
+    )


### PR DESCRIPTION
Closes #107.

Bumps `pillow` 12.1.1 → 12.3.0 and `setuptools` 82.0.1 → 84.0.0 (19 CVEs). Both are transitive deps of the `export` extra, which the `.deb` build refuses to bundle, so no show device was exposed – and the FITS decompression bomb in the report is unreachable anyway, since nothing in the tree imports PIL.

The more useful finding is why they sat there for two months with both guards on:

- the audit job installed `-E detection` only, so pip-audit never saw the export closure and reported clean
- Dependabot opens version PRs only for packages `pyproject.toml` names, so it skipped them too

Both halves are now closed. Dependabot is allowed to bump indirect dependencies, and the export toolchain is installed and audited in its own **report-only** job.

## Why the export audit is a separate job

It started as two extra steps on `audit`, which shared a venv and a cache key with the gating job. That was wrong three ways:

- **cache poisoning.** Both jobs cached `.venv` under the same key. On a lock change both miss and both save concurrently, so whichever post-step won decided what the other started from – and `test` installs with `poetry install`, which computes no uninstalls, so ~6 GB of torch + CUDA would survive in the test venv on every later run. `tests/test_thread_headroom.py` already documents the consequence: ultralytics ships a top-level `tests` package with its own `conftest.py`.
- **cache eviction.** A ~3 GB entry in a 10 GB per-repository budget evicts every other job's venv by LRU.
- **a gating install.** Only the audit step was `continue-on-error`, so a PyPI hiccup or a full disk while unpacking CUDA wheels failed the whole supply-chain job for a reason that was not a CVE.

`audit-export` is therefore its own uncached job, `continue-on-error` down to the install.

Its audit reports through the **step summary** rather than an exit code. torch's advisories are deferred (below), so a pass/fail signal there would be permanently red and the next genuinely new finding would read as more of the same noise. The listing is the signal: a row that was not there last week is the drift.

## What gates and what does not

The gating audit covers every extra a device installs, plus the `dev` group – ruff, pytest and bandit run inside the pipeline that builds the release, so a CVE there is in scope. The line is drawn at code that neither runs on a device nor helps produce the artifact: today, the `export` extra.

`tests/test_supply_chain_audit.py` pins that boundary – every declared extra is audited somewhere, shipped extras gate, workstation-only extras never gate or reach a `.venv` cache, and the gating install never drops a Poetry group. Every assertion was mutation-checked: each edit it exists to prevent fails, and the alternate flag spellings stay green.

## Also here

- Poetry pinned to the version stamped in `poetry.lock`; the audit job's `sync` subcommand does not exist before 2.0 and the action was unpinned.
- `github.event_name` added to the concurrency group – a `schedule` run and a `main` push both resolve `github.ref` to `refs/heads/main`, so a Monday merge silently cancelled the week's audit.
- `workflow_dispatch`, so a future workflow edit can be run manually against its branch.
- `pyyaml` declared as a dev dep rather than relied on as a transitive of pre-commit/bandit, where losing that edge fails collection for the whole suite.

**Not included:** `torch` 2.7.1 (9 CVEs, same export-only reach). `torchvision` pins it, and the macOS PyInstaller build that collects it has no CI coverage – that one needs a manual DMG build to verify, so it gets its own PR.

## Verification

`make ci-remote` green on the aarch64 Pi (not the Mac fallback): full suite at 100% coverage, e2e smoke, build.

Note that `audit` and `audit-export` show **skipped** on this PR – they are PR-skipped by design so a new third-party CVE cannot block unrelated work, which means this PR's own CI changes first run on `main`. That gap is tracked in #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
