### PR TITLE
fix(osc): name the real cause when a placeholder can't resolve

### DIFF
--- a/openfollow/osc/template.py
+++ b/openfollow/osc/template.py
@@ -478,19 +478,6 @@ def unresolved_placeholders(
     )
 
 
-def token_has_explicit_index(token: str) -> bool:
-    """True when ``token`` – a bracketed form like ``"[x:7]"`` /
-    ``"[x:c1]"`` vs the default ``"[x]"`` – names an explicit target
-    (a marker index or a ``:cN`` controller reference) rather than the
-    row's default marker.
-
-    Parses via the grammar rather than sniffing for ``":"`` so a colon
-    carried by a transform can't be mistaken for the index separator."""
-    inner = token[1:-1] if len(token) >= 2 and token[0] == "[" and token[-1] == "]" else token
-    slot = _slot_from_name(inner)
-    return slot is not None and (slot.ref_index is not None or slot.controller_index is not None)
-
-
 # ---------------------------------------------------------------------------
 # Parser – [source(:index)(.transform)*]
 # ---------------------------------------------------------------------------

--- a/openfollow/osc/template.py
+++ b/openfollow/osc/template.py
@@ -146,9 +146,8 @@ _EDIT_TIME_SOURCES: frozenset[str] = _POSITION_SOURCES | frozenset({"markerid"})
 # honest by ``tests/test_web_osc_placeholder_recognition.py``.
 PLACEHOLDERS: frozenset[str] = _SOURCES
 
-# Why an edit-time placeholder can't resolve. The web layer words one
-# message per reason; inferring the cause from the token's shape instead
-# misreports a ``[z.frac]`` that only needs the grid height.
+# Why an edit-time placeholder can't resolve. Each surface words one
+# remediation per reason.
 UnresolvedReason = Literal["default_marker", "explicit_marker", "grid_height"]
 
 # ``int:min-max`` / ``scale:min-max`` range bounds – signed, optionally
@@ -388,8 +387,8 @@ def unresolved_placeholder_reasons(
     ``token`` is the operator-facing form (``"[x]"`` / ``"[x:5]"`` /
     ``"[z.frac]"``); ``reason`` names the actionable fix, so a caller can
     word its message per cause instead of inferring one from the token's
-    shape. Inferring is what reported "needs a default marker" for a
-    ``[z.frac]`` blocked only on the grid height.
+    shape: a grid-blocked ``[z.frac]`` and a marker-blocked one are
+    indistinguishable by shape.
 
     Only position + ``markerid`` slots are surfaced
     (:data:`_EDIT_TIME_SOURCES`); fader / ``markerfader`` slots surface
@@ -402,10 +401,10 @@ def unresolved_placeholder_reasons(
       ``default_marker_id is None`` OR not in ``registered_marker_ids``
       (``"default_marker"``).
     - **Explicit slot** (``ref_index=N``): unresolved when ``N`` is not
-      registered (``"explicit_marker"``) - except ``[markerid:N]``,
+      registered (``"explicit_marker"``) – except ``[markerid:N]``,
       which substitutes ``N`` directly and so never misses.
     - **``z`` carrying ``frac``**: additionally unresolved when
-      ``grid_max_height <= 0`` (no denominator, the renderer raises),
+      ``grid_max_height <= 0`` (no denominator – the renderer raises),
       reported as ``"grid_height"``.
 
     A token blocked by both its marker and the grid height reports the
@@ -429,7 +428,7 @@ def unresolved_placeholder_reasons(
         if p.source not in _EDIT_TIME_SOURCES:
             continue
         if p.controller_index is not None:
-            # ``:cN`` resolves live - runtime skip, never an edit-time pill.
+            # ``:cN`` resolves live – runtime skip, never an edit-time pill.
             continue
         is_z_frac = p.source == "z" and any(t.kind == "frac" for t in p.transforms)
         grid_unresolved = is_z_frac and grid_max_height <= 0.0
@@ -460,7 +459,7 @@ def unresolved_placeholders(
     grid_max_height: float = 0.0,
 ) -> tuple[str, ...]:
     """Bracketed placeholder tokens in ``parts`` that can't be resolved,
-    in stable order - the web UI pill renderer compares each pill's
+    in stable order – the web UI pill renderer compares each pill's
     textContent against this list.
 
     The token projection of :func:`unresolved_placeholder_reasons`; see

--- a/openfollow/osc/template.py
+++ b/openfollow/osc/template.py
@@ -52,7 +52,7 @@ import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Any
+from typing import Any, Literal
 
 from openfollow.osc.parser import classify_osc_literal
 
@@ -145,6 +145,11 @@ _EDIT_TIME_SOURCES: frozenset[str] = _POSITION_SOURCES | frozenset({"markerid"})
 # set; the ``base.tpl`` client recogniser mirrors it with regexes, kept
 # honest by ``tests/test_web_osc_placeholder_recognition.py``.
 PLACEHOLDERS: frozenset[str] = _SOURCES
+
+# Why an edit-time placeholder can't resolve. The web layer words one
+# message per reason; inferring the cause from the token's shape instead
+# misreports a ``[z.frac]`` that only needs the grid height.
+UnresolvedReason = Literal["default_marker", "explicit_marker", "grid_height"]
 
 # ``int:min-max`` / ``scale:min-max`` range bounds – signed, optionally
 # decimal. ``min > max`` inverts the mapping naturally. Matched as a
@@ -370,19 +375,21 @@ def requires_default_fader(parts: CompiledTemplate) -> bool:
     return any(isinstance(p, _Slot) and p.ref_index is None and p.source == "fader" for p in parts)
 
 
-def unresolved_placeholders(
+def unresolved_placeholder_reasons(
     parts: CompiledTemplate,
     *,
     default_marker_id: int | None,
     registered_marker_ids: frozenset[int],
     grid_max_height: float = 0.0,
-) -> tuple[str, ...]:
-    """Return the bracketed placeholder tokens in ``parts`` that can't
-    be resolved given the current row + registry + grid state.
+) -> tuple[tuple[str, UnresolvedReason], ...]:
+    """Return ``(token, reason)`` for each placeholder in ``parts`` that
+    can't be resolved given the current row + registry + grid state.
 
-    Each entry is the operator-facing token (``"[x]"`` / ``"[y:5]"`` /
-    ``"[z.frac]"`` / ``"[markerid]"``), in stable order – the web UI pill
-    renderer compares each pill's textContent against this list.
+    ``token`` is the operator-facing form (``"[x]"`` / ``"[x:5]"`` /
+    ``"[z.frac]"``); ``reason`` names the actionable fix, so a caller can
+    word its message per cause instead of inferring one from the token's
+    shape. Inferring is what reported "needs a default marker" for a
+    ``[z.frac]`` blocked only on the grid height.
 
     Only position + ``markerid`` slots are surfaced
     (:data:`_EDIT_TIME_SOURCES`); fader / ``markerfader`` slots surface
@@ -392,52 +399,83 @@ def unresolved_placeholders(
     Resolution rules:
 
     - **Default slot** (``ref_index is None``): unresolved when
-      ``default_marker_id is None`` OR not in ``registered_marker_ids``.
+      ``default_marker_id is None`` OR not in ``registered_marker_ids``
+      (``"default_marker"``).
     - **Explicit slot** (``ref_index=N``): unresolved when ``N`` is not
-      registered – except ``[markerid:N]``, which substitutes ``N``
-      directly and so never misses.
+      registered (``"explicit_marker"``) - except ``[markerid:N]``,
+      which substitutes ``N`` directly and so never misses.
     - **``z`` carrying ``frac``**: additionally unresolved when
-      ``grid_max_height <= 0`` (no denominator – the renderer raises).
+      ``grid_max_height <= 0`` (no denominator, the renderer raises),
+      reported as ``"grid_height"``.
 
-    Duplicates collapse.
+    A token blocked by both its marker and the grid height reports the
+    marker cause; resolving that surfaces the grid one on the next pass,
+    so each message names a single next step.
+
+    Duplicates collapse on the token, which keeps the first reason seen.
     """
-    out: list[str] = []
+    out: list[tuple[str, UnresolvedReason]] = []
     seen: set[str] = set()
+
+    def _add(slot: _Slot, reason: UnresolvedReason) -> None:
+        token = _slot_token(slot)
+        if token not in seen:
+            out.append((token, reason))
+            seen.add(token)
+
     for p in parts:
         if not isinstance(p, _Slot):
             continue
         if p.source not in _EDIT_TIME_SOURCES:
             continue
         if p.controller_index is not None:
-            # ``:cN`` resolves live – runtime skip, never an edit-time pill.
+            # ``:cN`` resolves live - runtime skip, never an edit-time pill.
             continue
         is_z_frac = p.source == "z" and any(t.kind == "frac" for t in p.transforms)
+        grid_unresolved = is_z_frac and grid_max_height <= 0.0
         if p.ref_index is None:
-            marker_unresolved = default_marker_id is None or default_marker_id not in registered_marker_ids
-            grid_unresolved = is_z_frac and grid_max_height <= 0.0
-            if marker_unresolved or grid_unresolved:
-                token = _slot_token(p)
-                if token not in seen:
-                    out.append(token)
-                    seen.add(token)
+            if default_marker_id is None or default_marker_id not in registered_marker_ids:
+                _add(p, "default_marker")
+            elif grid_unresolved:
+                _add(p, "grid_height")
         else:
             # ``[markerid:N]`` substitutes the literal id ``N`` directly,
             # so it resolves regardless of whether marker ``N`` exists.
             if p.source == "markerid":
                 continue
             if p.ref_index not in registered_marker_ids:
-                token = _slot_token(p)
-                if token not in seen:
-                    out.append(token)
-                    seen.add(token)
-            elif is_z_frac and grid_max_height <= 0.0:
+                _add(p, "explicit_marker")
+            elif grid_unresolved:
                 # ``[z:N.frac]`` resolves the marker but still needs
                 # ``max_height`` to render.
-                token = _slot_token(p)
-                if token not in seen:
-                    out.append(token)
-                    seen.add(token)
+                _add(p, "grid_height")
     return tuple(out)
+
+
+def unresolved_placeholders(
+    parts: CompiledTemplate,
+    *,
+    default_marker_id: int | None,
+    registered_marker_ids: frozenset[int],
+    grid_max_height: float = 0.0,
+) -> tuple[str, ...]:
+    """Bracketed placeholder tokens in ``parts`` that can't be resolved,
+    in stable order - the web UI pill renderer compares each pill's
+    textContent against this list.
+
+    The token projection of :func:`unresolved_placeholder_reasons`; see
+    it for the resolution rules. Callers wording an operator-facing
+    message want that function instead, so the message names the cause.
+    """
+    return tuple(
+        token
+        for token, _ in unresolved_placeholder_reasons(
+            parts,
+            default_marker_id=default_marker_id,
+            registered_marker_ids=registered_marker_ids,
+            grid_max_height=grid_max_height,
+        )
+    )
 
 
 def token_has_explicit_index(token: str) -> bool:

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -5596,16 +5596,15 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         chips, unresolved pills, and status dots appear at first paint, not
         only after the operator saves a row."""
         registered = frozenset(cfg.controlled_marker_ids)
+        # Scan each row once; the token list is the reason map's keys.
+        reasons_by_row = {
+            row.id: _row_unresolved_reasons(row, registered, grid_max_height=cfg.grid.max_height)
+            for row in cfg.osc_transmitters.transmitters
+        }
         return {
             "registered_marker_ids": sorted(registered),
-            "unresolved_by_row": {
-                row.id: _row_unresolved_placeholders(row, registered, grid_max_height=cfg.grid.max_height)
-                for row in cfg.osc_transmitters.transmitters
-            },
-            "unresolved_reasons_by_row": {
-                row.id: _row_unresolved_reasons(row, registered, grid_max_height=cfg.grid.max_height)
-                for row in cfg.osc_transmitters.transmitters
-            },
+            "unresolved_by_row": {row_id: tuple(reasons) for row_id, reasons in reasons_by_row.items()},
+            "unresolved_reasons_by_row": reasons_by_row,
             "marker_display_by_row": _osc_binding_marker_display(cfg, server.get_marker_catalog()),
         }
 

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -1935,9 +1935,15 @@ def _osc_binding_marker_display(
     return out
 
 
+# Causes the ``markers`` field can actually fix.
+_MARKER_BLUR_REASONS: frozenset[str] = frozenset({"default_marker", "explicit_marker"})
+
+
 def _osc_binding_unresolved_blur_error(
     query: Mapping[str, Any],
     cfg: AppConfig,
+    *,
+    field_name: str = "osc_message",
 ) -> str | None:
     """Surface inline blur errors for unresolved placeholders on the
     ``osc_binding`` form.
@@ -1978,15 +1984,9 @@ def _osc_binding_unresolved_blur_error(
             if token not in seen:
                 by_reason.setdefault(reason, []).append(token)
                 seen.add(token)
-    if not seen:
-        return None
-    # One sentence per cause, so each names the fix it actually wants.
-    # The cause comes from the resolver, never from the token's shape: a
-    # grid-blocked ``[z.frac]`` carries no explicit index and a
-    # ``[z:2.frac]`` carries one, so classifying by shape sent both to a
-    # marker sentence that couldn't resolve them. Order is fixed rather
-    # than first-seen so the message reads the same however the operator
-    # ordered the arguments.
+    # One sentence per cause, each naming the control that fixes it.
+    # Order is fixed rather than first-seen so the message reads the same
+    # however the operator ordered the arguments.
     templates: tuple[tuple[UnresolvedReason, str], ...] = (
         (
             "default_marker",
@@ -1996,9 +1996,18 @@ def _osc_binding_unresolved_blur_error(
         ("explicit_marker", "{tokens} references a marker that isn't registered."),
         ("grid_height", "{tokens} needs Grid → Maximum Height set to a non-zero value."),
     )
+    # The markers field can only act on the marker causes; a grid-height
+    # sentence there would describe a control it has no bearing on.
+    actionable = _MARKER_BLUR_REASONS if field_name == "markers" else None
     parts: list[str] = [
-        text.format(tokens=", ".join(by_reason[reason])) for reason, text in templates if reason in by_reason
+        text.format(tokens=", ".join(by_reason[reason]))
+        for reason, text in templates
+        if reason in by_reason and (actionable is None or reason in actionable)
     ]
+    # Guard the join, not the token set: a reason with no entry above
+    # would otherwise render an empty warning span.
+    if not parts:
+        return None
     return " ".join(parts)
 
 
@@ -2099,6 +2108,37 @@ def _render_midi_fader_capture_status(
     )
 
 
+def _row_unresolved_reasons(
+    row: OscTransmitterConfig,
+    registered_marker_ids: frozenset[int],
+    *,
+    grid_max_height: float = 0.0,
+) -> dict[str, str]:
+    """Token -> cause for every placeholder in ``row``'s address + args
+    that can't resolve, in address-then-args appearance order.
+
+    The pill tooltip and the blur message word a remediation per cause,
+    so the cause travels with the token rather than being re-derived
+    from its shape at each surface.
+    """
+    from openfollow.osc.template import (
+        compile_template,
+        unresolved_placeholder_reasons,
+    )
+
+    effective_marker_id = _effective_default_marker_id(row.markers, registered_marker_ids)
+    out: dict[str, str] = {}
+    for tpl in (row.address, *row.args):
+        for token, reason in unresolved_placeholder_reasons(
+            compile_template(tpl),
+            default_marker_id=effective_marker_id,
+            registered_marker_ids=registered_marker_ids,
+            grid_max_height=grid_max_height,
+        ):
+            out.setdefault(token, reason)
+    return out
+
+
 def _row_unresolved_placeholders(
     row: OscTransmitterConfig,
     registered_marker_ids: frozenset[int],
@@ -2118,28 +2158,9 @@ def _row_unresolved_placeholders(
       (it keys off ``aria-invalid``), keeping the "Save with enabled=False"
       workflow available.
 
-    Order is address-then-args appearance, duplicates collapsed across the
-    row; see :func:`openfollow.osc.template.unresolved_placeholders`.
+    The token half of :func:`_row_unresolved_reasons`.
     """
-    from openfollow.osc.template import (
-        compile_template,
-        unresolved_placeholders,
-    )
-
-    effective_marker_id = _effective_default_marker_id(row.markers, registered_marker_ids)
-    out: list[str] = []
-    seen: set[str] = set()
-    for tpl in (row.address, *row.args):
-        for token in unresolved_placeholders(
-            compile_template(tpl),
-            default_marker_id=effective_marker_id,
-            registered_marker_ids=registered_marker_ids,
-            grid_max_height=grid_max_height,
-        ):
-            if token not in seen:
-                out.append(token)
-                seen.add(token)
-    return tuple(out)
+    return tuple(_row_unresolved_reasons(row, registered_marker_ids, grid_max_height=grid_max_height))
 
 
 def _apply_osc_binding_fields(
@@ -5581,6 +5602,10 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
                 row.id: _row_unresolved_placeholders(row, registered, grid_max_height=cfg.grid.max_height)
                 for row in cfg.osc_transmitters.transmitters
             },
+            "unresolved_reasons_by_row": {
+                row.id: _row_unresolved_reasons(row, registered, grid_max_height=cfg.grid.max_height)
+                for row in cfg.osc_transmitters.transmitters
+            },
             "marker_display_by_row": _osc_binding_marker_display(cfg, server.get_marker_catalog()),
         }
 
@@ -6951,6 +6976,7 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
             err_msg = _osc_binding_unresolved_blur_error(
                 request.query,
                 _request_scoped_config(),
+                field_name=field_name,
             )
             if err_msg is not None:
                 # Unresolved-placeholder rows are intentionally save-able (the

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -1961,45 +1961,44 @@ def _osc_binding_unresolved_blur_error(
     markers = _coerce_marker_tokens(query.get("markers", ""))
     marker_id = _effective_default_marker_id(markers, registered)
     from openfollow.osc.template import (
+        UnresolvedReason,
         compile_template,
-        token_has_explicit_index,
-        unresolved_placeholders,
+        unresolved_placeholder_reasons,
     )
 
     seen: set[str] = set()
-    unresolved: list[str] = []
+    by_reason: dict[UnresolvedReason, list[str]] = {}
     for tpl in (address, *args):
-        for token in unresolved_placeholders(
+        for token, reason in unresolved_placeholder_reasons(
             compile_template(tpl),
             default_marker_id=marker_id,
             registered_marker_ids=registered,
             grid_max_height=cfg.grid.max_height,
         ):
             if token not in seen:
-                unresolved.append(token)
+                by_reason.setdefault(reason, []).append(token)
                 seen.add(token)
-    if not unresolved:
+    if not seen:
         return None
-    # Split into "needs default" vs "explicit-target missing" so the
-    # message names the actionable fix per category. ``unresolved`` is
-    # already the operator-facing token form (``"[x]"`` / ``"[x:7]"``).
-    # Classify via the grammar, not a ``:`` sniff – a transform can carry
-    # a colon. Per-token validity (malformed / non-controlled entries) is
-    # surfaced by the field-level ``markers`` validator; this arm only flags
-    # the cross-field "you use [x] but name no usable default marker".
-    # Every unresolved token is either explicit-index or not, so the two
-    # lists partition the (non-empty) ``unresolved`` set: at least one is
-    # non-empty here, so ``parts`` below is never empty.
-    default_tokens = [t for t in unresolved if not token_has_explicit_index(t)]
-    explicit_tokens = [t for t in unresolved if token_has_explicit_index(t)]
-    parts: list[str] = []
-    if default_tokens:
-        parts.append(
-            f"{', '.join(default_tokens)} needs a default marker. Set 'Default markers' to a controlled id, "
-            "a controller alias (c1, c2, …), or 'all'."
-        )
-    if explicit_tokens:
-        parts.append(f"{', '.join(explicit_tokens)} references a marker that isn't registered.")
+    # One sentence per cause, so each names the fix it actually wants.
+    # The cause comes from the resolver, never from the token's shape: a
+    # grid-blocked ``[z.frac]`` carries no explicit index and a
+    # ``[z:2.frac]`` carries one, so classifying by shape sent both to a
+    # marker sentence that couldn't resolve them. Order is fixed rather
+    # than first-seen so the message reads the same however the operator
+    # ordered the arguments.
+    templates: tuple[tuple[UnresolvedReason, str], ...] = (
+        (
+            "default_marker",
+            "{tokens} needs a default marker. Set 'Default markers' to a controlled id, "
+            "a controller alias (c1, c2, …), or 'all'.",
+        ),
+        ("explicit_marker", "{tokens} references a marker that isn't registered."),
+        ("grid_height", "{tokens} needs Grid → Maximum Height set to a non-zero value."),
+    )
+    parts: list[str] = [
+        text.format(tokens=", ".join(by_reason[reason])) for reason, text in templates if reason in by_reason
+    ]
     return " ".join(parts)
 
 

--- a/openfollow/web/templates/base.tpl
+++ b/openfollow/web/templates/base.tpl
@@ -3832,9 +3832,10 @@
  if (helpSpan) {
  helpSpan.textContent = unresolved.length > 0
  ? 'Will save disabled: this row uses placeholder values'
- + ' that are not resolved yet (no default marker, or an'
+ + ' that are not resolved yet (no default marker, an'
  + ' explicit marker reference targets an unregistered'
- + ' marker).'
+ + ' marker, or a fractional height needs Grid →'
+ + ' Maximum Height set).'
  : '';
  }
  }

--- a/openfollow/web/templates/base.tpl
+++ b/openfollow/web/templates/base.tpl
@@ -3569,6 +3569,16 @@
  // Parse editor's data attributes to get "unresolved-placeholders" set for pill rendering.
  // Source: server-supplied attr at first render, then derived from marker IDs + editor text.
  // JSON failures degrade gracefully to prevent wedging the editor.
+ function oscEditorParseJsonMapAttr(editor, attr) {
+ const raw = editor.dataset[attr];
+ if (!raw) return {};
+ try {
+ const v = JSON.parse(raw);
+ return (v && typeof v === 'object' && !Array.isArray(v)) ? v : {};
+ } catch (_e) {
+ return {};
+ }
+ }
  function oscEditorParseJsonAttr(editor, attr, fallback) {
  const raw = editor.dataset[attr];
  if (!raw) return fallback;
@@ -3579,6 +3589,12 @@
  return fallback;
  }
  }
+ // Keyed by ``UnresolvedReason`` (openfollow/osc/template.py).
+ const OSC_UNRESOLVED_REMEDIATION = {
+ default_marker: "set the row's Default marker to a registered id",
+ explicit_marker: 'register that marker or change :N to a registered id',
+ grid_height: 'set Grid \u2192 Maximum Height to a non-zero value',
+ };
  function oscEditorUnresolvedSet(editor) {
  return new Set(
  oscEditorParseJsonAttr(editor, 'oscUnresolvedPlaceholders', []),
@@ -3645,21 +3661,12 @@
  }
  if (unresolved.has(match[0])) {
  pill.dataset.unresolved = 'true';
- // ): the tooltip used to suggest both
- // remediations every time, but only one applies per token.
- // ``[x]`` (default-marker slot) is fixed by setting the
- // row's Default marker; ``[x:N]`` (explicit-marker
- // slot) is fixed by registering marker N (or pointing the
- // reference at a registered id). Match an index ``:N`` that
- // sits immediately after the source name (before any
- // ``.transform``) – not a bare ``/:\d/``, which would also
- // fire on a transform range bound like ``.scale:0-1`` (mirrors
- // the server's ``ref_index is not None``).
- const isExplicit = /^\[[a-z]+:\d/.test(match[0]);
- const remediation = isExplicit
- ? 'register that marker or change :N to a'
- + ' registered id'
- : 'set the row\'s Default marker to a registered id';
+ // One remediation per cause, keyed by the cause the server or
+ // the client mirror resolved. A token's shape cannot tell a
+ // grid-blocked ``[z.frac]`` from a marker-blocked one.
+ const reasons = oscEditorParseJsonMapAttr(editor, 'oscUnresolvedReasons');
+ const remediation = OSC_UNRESOLVED_REMEDIATION[reasons[match[0]]]
+ || 'resolve its dependency';
  pill.title = 'Unresolved: ' + match[0]
  + ' – ' + remediation + '. Click to edit.';
  } else if (isRecognised) {
@@ -3773,26 +3780,32 @@
  const index = parsed[2]; // undefined when bare
  const chain = parsed[3] || '';
  const isZFrac = source === 'z' && chain.indexOf('.frac') !== -1;
- let unresolved = false;
+ // Mirrors ``unresolved_placeholder_reasons``: marker cause before
+ // grid cause, so each pill names a single next step.
+ let reason = null;
  if (index === undefined) {
- unresolved = !hasDefaultMarker;
- if (!unresolved && isZFrac && gridUnset) {
- unresolved = true;
+ if (!hasDefaultMarker) {
+ reason = 'default_marker';
+ } else if (isZFrac && gridUnset) {
+ reason = 'grid_height';
  }
  } else if (source !== 'markerid') {
  // ``[markerid:N]`` substitutes ``N`` directly – never a miss.
- const id = Number(index);
- unresolved = !registered.has(id);
- if (!unresolved && isZFrac && gridUnset) {
- unresolved = true;
+ if (!registered.has(Number(index))) {
+ reason = 'explicit_marker';
+ } else if (isZFrac && gridUnset) {
+ reason = 'grid_height';
  }
  }
- if (unresolved) {
- out.push(token);
+ if (reason !== null) {
+ out.push({token: token, reason: reason});
  seen.add(token);
  }
  }
- editor.dataset.oscUnresolvedPlaceholders = JSON.stringify(out);
+ editor.dataset.oscUnresolvedPlaceholders = JSON.stringify(out.map(e => e.token));
+ editor.dataset.oscUnresolvedReasons = JSON.stringify(
+ Object.fromEntries(out.map(e => [e.token, e.reason])),
+ );
  }
  // Update the row's Enabled-checkbox unresolved-flag to match
  // the just-recomputed unresolved set. Mirrors the server-side

--- a/openfollow/web/templates/partials/osc_bindings.tpl
+++ b/openfollow/web/templates/partials/osc_bindings.tpl
@@ -20,6 +20,7 @@
 % # JS re-evaluate dependencies as the operator edits without a
 % # round-trip to the server.
 % _unresolved_by_row = defined('unresolved_by_row') and unresolved_by_row or {}
+% _unresolved_reasons_by_row = defined('unresolved_reasons_by_row') and unresolved_reasons_by_row or {}
 % _registered_marker_ids = defined('registered_marker_ids') and registered_marker_ids or []
 % # per-row marker display: {row_id: {"header": <single-marker label|None>,
 % #   "nested": [<chip>...], "markers_unusable": <bool>}}. Built server-side
@@ -50,6 +51,7 @@
  % is_focus = (defined('focus_id') and focus_id == row.id)
  % trigger_kind = getattr(row.trigger, 'kind', 'stream')
  % row_unresolved = _unresolved_by_row.get(row.id, ())
+ % row_unresolved_reasons = _unresolved_reasons_by_row.get(row.id, {})
  % has_unresolved = bool(row_unresolved)
  % _row_marker = _marker_display_by_row.get(row.id, {})
  % _marker_header = _row_marker.get('header')
@@ -132,7 +134,7 @@
  % # (visual-only) + aria-describedby to hidden span
  % # for a11y. oscEditorSyncEnabledUnresolved keeps
  % # span in sync; aria-live="polite" announces changes.
- <div class="checkbox-wrap"><input type="checkbox" name="enabled" {{'checked' if row.enabled else ''}} {{!'data-osc-unresolved="true"' if has_unresolved else ''}} aria-describedby="enabled-{{row.id}}-unresolved-help"><span id="enabled-{{row.id}}-unresolved-help" class="visually-hidden" aria-live="polite">{{'Will save disabled: this row uses placeholder values that are not resolved yet (no default marker, or an explicit marker reference targets an unregistered marker).' if has_unresolved else ''}}</span></div>
+ <div class="checkbox-wrap"><input type="checkbox" name="enabled" {{'checked' if row.enabled else ''}} {{!'data-osc-unresolved="true"' if has_unresolved else ''}} aria-describedby="enabled-{{row.id}}-unresolved-help"><span id="enabled-{{row.id}}-unresolved-help" class="visually-hidden" aria-live="polite">{{'Will save disabled: this row uses placeholder values that are not resolved yet (no default marker, an explicit marker reference targets an unregistered marker, or a fractional height needs Grid → Maximum Height set).' if has_unresolved else ''}}</span></div>
  </div>
  <div class="field">
  <label>Name</label>
@@ -269,6 +271,7 @@
  data-osc-message-editor="{{row.id}}"
  data-osc-message-placeholder="/eos/chan/[markerid]/xyz [x] [y] [z]"
  data-osc-unresolved-placeholders="{{json.dumps(list(row_unresolved))}}"
+ data-osc-unresolved-reasons="{{json.dumps(row_unresolved_reasons)}}"
  data-osc-placeholder-names="{{json.dumps(list(placeholders))}}"
  data-osc-registered-marker-ids="{{json.dumps(list(_registered_marker_ids))}}"
  data-osc-row-markers="{{', '.join(row.markers)}}"

--- a/openfollow/web/templates/partials/osc_bindings.tpl
+++ b/openfollow/web/templates/partials/osc_bindings.tpl
@@ -304,7 +304,7 @@
  % # reference). Operators can also type any ``.transform``
  % # chain or a ``:cN`` reference by hand.
  <div class="row placeholder-buttons">
- % for ex in ('[x.frac]', '[y.frac]', '[fader.pct]', '[markerfader.pct]', '[markerid:c1]'):
+ % for ex in ('[x.frac]', '[y.frac]', '[z.frac]', '[fader.pct]', '[markerfader.pct]', '[markerid:c1]'):
  <button type="button"
  class="placeholder-chip"
  data-osc-placeholder="{{ex}}"

--- a/tests/test_osc_template.py
+++ b/tests/test_osc_template.py
@@ -187,23 +187,6 @@ def test_overlong_digit_run_compiles_to_literal_not_crash() -> None:
         assert _is_literal(bad), bad
 
 
-def test_token_has_explicit_index() -> None:
-    """Classifies tokens as explicit ``[x:7]`` vs default-marker ``[x]``
-    without colon-sniffing, so a transform-borne colon (range bound)
-    can't fool it."""
-    from openfollow.osc.template import token_has_explicit_index
-
-    assert token_has_explicit_index("[x:7]") is True
-    assert token_has_explicit_index("[markerfader:3]") is True
-    assert token_has_explicit_index("[x]") is False
-    assert token_has_explicit_index("[z.frac]") is False
-    # A hypothetical colon-bearing transform must NOT read as an index.
-    assert token_has_explicit_index("[fader.int:0-100]") is False
-    # Bracket-stripping is defensive – a bare inner name works too.
-    assert token_has_explicit_index("x:7") is True
-    assert token_has_explicit_index("bogus") is False
-
-
 def test_render_unknown_placeholder_passes_through_as_literal() -> None:
     ct = compile_template("/cue/[unknown]/[markerid]")
     assert render(ct, _ctx(marker_id=3)) == "/cue/[unknown]/3"
@@ -564,12 +547,6 @@ class TestControllerReference:
             )
             == ()
         )
-
-    def test_token_has_explicit_index_true_for_controller_ref(self) -> None:
-        from openfollow.osc.template import token_has_explicit_index
-
-        assert token_has_explicit_index("[markerid:c1]") is True
-        assert token_has_explicit_index("[x:c2]") is True
 
     def test_slot_inner_round_trips_controller_ref(self) -> None:
         # The RenderError label (built from _slot_inner) names the cN form,

--- a/tests/test_osc_template.py
+++ b/tests/test_osc_template.py
@@ -1207,22 +1207,20 @@ def test_reason_explicit_marker_when_target_unregistered() -> None:
 
 @pytest.mark.parametrize("tpl", ["[z.frac]", "[z.frac.inv]"])
 def test_reason_grid_height_when_marker_resolves_but_height_unset(tpl: str) -> None:
-    """The defect this API exists for: with the default marker set and
-    registered, a fractional-Z token is blocked only by the grid height.
-    Reported as a marker problem, it sent the operator to a control they
-    had already set."""
+    """With the default marker set and registered, a fractional-Z token
+    is blocked only by the grid height."""
     assert _reasons(tpl, marker=0, registered=frozenset({0}), grid=0.0) == ((tpl, "grid_height"),)
 
 
 def test_reason_grid_height_for_explicit_slot_whose_marker_is_registered() -> None:
-    """``[z:3.frac]`` with marker 3 registered is a grid problem, not the
-    "marker isn't registered" its explicit index would imply."""
+    """``[z:3.frac]`` with marker 3 registered is a grid problem; the
+    explicit index says nothing about which cause applies."""
     assert _reasons("[z:3.frac]", marker=None, registered=frozenset({3}), grid=0.0) == (("[z:3.frac]", "grid_height"),)
 
 
 def test_reason_marker_precedes_grid_on_default_slot() -> None:
     """Both causes apply; the marker one is reported so the message names
-    one next step. The grid cause surfaces once the marker resolves."""
+    one next step."""
     assert _reasons("[z.frac]", marker=None, registered=frozenset({0}), grid=0.0) == (("[z.frac]", "default_marker"),)
 
 
@@ -1232,7 +1230,7 @@ def test_reason_marker_precedes_grid_on_explicit_slot() -> None:
     )
 
 
-def test_reason_duplicate_token_collapses_to_first() -> None:
+def test_reason_repeated_token_reported_once() -> None:
     assert _reasons("[z.frac]/[z.frac]", marker=0, registered=frozenset({0}), grid=0.0) == (
         ("[z.frac]", "grid_height"),
     )
@@ -1249,25 +1247,3 @@ def test_reasons_preserve_appearance_order_across_causes() -> None:
 
 def test_reasons_empty_when_everything_resolves() -> None:
     assert _reasons("[x] [z.frac] [markerid]", marker=0, registered=frozenset({0}), grid=4.0) == ()
-
-
-@pytest.mark.parametrize(
-    ("tpl", "marker", "registered", "grid"),
-    [
-        ("[x]", None, frozenset({0}), 4.0),
-        ("[x:9]", 0, frozenset({0}), 4.0),
-        ("[z.frac]", 0, frozenset({0}), 0.0),
-        ("/p/[markerid]/[x:9]/[z.frac]", None, frozenset({0}), 0.0),
-        ("[x] [z.frac] [markerid]", 0, frozenset({0}), 4.0),
-    ],
-)
-def test_token_api_is_the_projection_of_the_reason_api(tpl, marker, registered, grid) -> None:  # noqa: ANN001
-    """``unresolved_placeholders`` must stay the token half of the same
-    computation – the pill renderer compares against it."""
-    tokens = unresolved_placeholders(
-        _ct(tpl),
-        default_marker_id=marker,
-        registered_marker_ids=registered,
-        grid_max_height=grid,
-    )
-    assert tokens == tuple(t for t, _ in _reasons(tpl, marker=marker, registered=registered, grid=grid))

--- a/tests/test_osc_template.py
+++ b/tests/test_osc_template.py
@@ -27,6 +27,7 @@ from openfollow.osc.template import (
     osc_arg_for,
     render,
     requires_default_marker,
+    unresolved_placeholder_reasons,
     unresolved_placeholders,
 )
 
@@ -1203,3 +1204,93 @@ def test_unresolved_explicit_z_frac_unregistered_marker_takes_precedence() -> No
         grid_max_height=0.0,
     )
     assert out == ("[z:9.frac]",)
+
+
+# ---------------------------------------------------------------------------
+# unresolved_placeholder_reasons – the cause behind each unresolved token
+# ---------------------------------------------------------------------------
+
+
+def _reasons(tpl: str, *, marker=None, registered=frozenset(), grid=0.0):  # noqa: ANN001, ANN202, B008
+    return unresolved_placeholder_reasons(
+        _ct(tpl),
+        default_marker_id=marker,
+        registered_marker_ids=registered,
+        grid_max_height=grid,
+    )
+
+
+def test_reason_default_marker_when_no_default_named() -> None:
+    assert _reasons("[x]", marker=None, registered=frozenset({0}), grid=4.0) == (("[x]", "default_marker"),)
+
+
+def test_reason_explicit_marker_when_target_unregistered() -> None:
+    assert _reasons("[x:9]", marker=0, registered=frozenset({0}), grid=4.0) == (("[x:9]", "explicit_marker"),)
+
+
+@pytest.mark.parametrize("tpl", ["[z.frac]", "[z.frac.inv]"])
+def test_reason_grid_height_when_marker_resolves_but_height_unset(tpl: str) -> None:
+    """The defect this API exists for: with the default marker set and
+    registered, a fractional-Z token is blocked only by the grid height.
+    Reported as a marker problem, it sent the operator to a control they
+    had already set."""
+    assert _reasons(tpl, marker=0, registered=frozenset({0}), grid=0.0) == ((tpl, "grid_height"),)
+
+
+def test_reason_grid_height_for_explicit_slot_whose_marker_is_registered() -> None:
+    """``[z:3.frac]`` with marker 3 registered is a grid problem, not the
+    "marker isn't registered" its explicit index would imply."""
+    assert _reasons("[z:3.frac]", marker=None, registered=frozenset({3}), grid=0.0) == (("[z:3.frac]", "grid_height"),)
+
+
+def test_reason_marker_precedes_grid_on_default_slot() -> None:
+    """Both causes apply; the marker one is reported so the message names
+    one next step. The grid cause surfaces once the marker resolves."""
+    assert _reasons("[z.frac]", marker=None, registered=frozenset({0}), grid=0.0) == (("[z.frac]", "default_marker"),)
+
+
+def test_reason_marker_precedes_grid_on_explicit_slot() -> None:
+    assert _reasons("[z:9.frac]", marker=None, registered=frozenset({0, 1}), grid=0.0) == (
+        ("[z:9.frac]", "explicit_marker"),
+    )
+
+
+def test_reason_duplicate_token_collapses_to_first() -> None:
+    assert _reasons("[z.frac]/[z.frac]", marker=0, registered=frozenset({0}), grid=0.0) == (
+        ("[z.frac]", "grid_height"),
+    )
+
+
+def test_reasons_preserve_appearance_order_across_causes() -> None:
+    out = _reasons("/p/[markerid]/[x:9]/[z.frac]", marker=None, registered=frozenset({0}), grid=0.0)
+    assert out == (
+        ("[markerid]", "default_marker"),
+        ("[x:9]", "explicit_marker"),
+        ("[z.frac]", "default_marker"),
+    )
+
+
+def test_reasons_empty_when_everything_resolves() -> None:
+    assert _reasons("[x] [z.frac] [markerid]", marker=0, registered=frozenset({0}), grid=4.0) == ()
+
+
+@pytest.mark.parametrize(
+    ("tpl", "marker", "registered", "grid"),
+    [
+        ("[x]", None, frozenset({0}), 4.0),
+        ("[x:9]", 0, frozenset({0}), 4.0),
+        ("[z.frac]", 0, frozenset({0}), 0.0),
+        ("/p/[markerid]/[x:9]/[z.frac]", None, frozenset({0}), 0.0),
+        ("[x] [z.frac] [markerid]", 0, frozenset({0}), 4.0),
+    ],
+)
+def test_token_api_is_the_projection_of_the_reason_api(tpl, marker, registered, grid) -> None:  # noqa: ANN001
+    """``unresolved_placeholders`` must stay the token half of the same
+    computation – the pill renderer compares against it."""
+    tokens = unresolved_placeholders(
+        _ct(tpl),
+        default_marker_id=marker,
+        registered_marker_ids=registered,
+        grid_max_height=grid,
+    )
+    assert tokens == tuple(t for t, _ in _reasons(tpl, marker=marker, registered=registered, grid=grid))

--- a/tests/test_web_osc_bindings.py
+++ b/tests/test_web_osc_bindings.py
@@ -40,6 +40,7 @@ from openfollow.web.routes import (
     _effective_default_marker_id,
     _midi_patches_for_form,
     _osc_binding_marker_display,
+    _osc_binding_unresolved_blur_error,
     _parse_osc_message,
     _parse_trigger_subtable,
     _row_unresolved_placeholders,
@@ -3424,3 +3425,94 @@ def test_test_send_pending_when_manager_attached_but_row_unserviced(tmp_path, mo
         assert json.loads(body) == {"available": False, "pending": True}
     finally:
         server.stop()
+
+
+# ---------------------------------------------------------------------------
+# Blur-error wording – one sentence per cause
+# ---------------------------------------------------------------------------
+
+
+def _blur_cfg(controlled, max_height):  # noqa: ANN001, ANN202
+    cfg = AppConfig()
+    cfg.controlled_marker_ids = list(controlled)
+    cfg.grid.max_height = max_height
+    return cfg
+
+
+def _blur(message, markers, controlled=(1,), max_height=8.0):  # noqa: ANN001, ANN202
+    return _osc_binding_unresolved_blur_error(
+        {"osc_message": message, "markers": markers},
+        _blur_cfg(controlled, max_height),
+    )
+
+
+_ADM_3D = "/adm/obj/[markerid]/xyz [x.frac] [y.frac] [z.frac]"
+
+
+@pytest.mark.unit
+def test_blur_error_names_grid_height_not_default_marker() -> None:
+    """With the default marker set and registered, ADM-OSC 3D's
+    ``[z.frac]`` is blocked only by the grid height. Naming the default
+    marker here pointed at a control the operator had already set, and
+    the token stayed flagged however they changed it."""
+    msg = _blur(_ADM_3D, "1", controlled=(1,), max_height=0.0)
+    assert msg == "[z.frac] needs Grid → Maximum Height set to a non-zero value."
+    assert "default marker" not in msg
+
+
+@pytest.mark.unit
+def test_blur_error_names_grid_height_for_explicit_registered_marker() -> None:
+    """``[z:2.frac]`` with marker 2 registered is a grid problem. The
+    explicit index previously routed it to "isn't registered", which
+    contradicted the registry."""
+    msg = _blur("/a [z:2.frac]", "1", controlled=(1, 2), max_height=0.0)
+    assert msg == "[z:2.frac] needs Grid → Maximum Height set to a non-zero value."
+    assert "registered" not in msg
+
+
+@pytest.mark.unit
+def test_blur_error_reports_default_marker_first_when_both_apply() -> None:
+    """No default marker and no grid height: every token wants the
+    marker, so the message names that one step. The grid cause surfaces
+    once the marker resolves (the test below)."""
+    msg = _blur(_ADM_3D, "", controlled=(), max_height=0.0)
+    assert msg == (
+        "[markerid], [x.frac], [y.frac], [z.frac] needs a default marker. "
+        "Set 'Default markers' to a controlled id, a controller alias (c1, c2, …), or 'all'."
+    )
+
+
+@pytest.mark.unit
+def test_blur_error_clears_once_marker_and_grid_are_both_set() -> None:
+    assert _blur(_ADM_3D, "1", controlled=(1,), max_height=8.0) is None
+
+
+@pytest.mark.unit
+def test_blur_error_separates_causes_into_one_sentence_each() -> None:
+    msg = _blur("/a [x:9] [z:2.frac]", "1", controlled=(1, 2), max_height=0.0)
+    assert msg == (
+        "[x:9] references a marker that isn't registered. "
+        "[z:2.frac] needs Grid → Maximum Height set to a non-zero value."
+    )
+
+
+@pytest.mark.unit
+def test_blur_error_none_for_literal_only_message() -> None:
+    assert _blur("/cue/go", "", controlled=(), max_height=0.0) is None
+
+
+def test_section_render_offers_a_z_frac_placeholder_chip(live_server) -> None:
+    """The curated transform chips are the one-click way to insert a
+    transform. ``[z.frac]`` was absent while ``[x.frac]`` / ``[y.frac]``
+    were present, so an operator who cleared ADM-OSC 3D's height
+    argument had no chip to put it back."""
+    _, base, cfg_path = live_server
+    cfg = load_config(cfg_path)
+    cfg.osc_transmitters.transmitters.append(
+        OscTransmitterConfig(id="r-chip", name="Chips", markers=["1"], address="/a", args=["[z.frac]"]),
+    )
+    save_config(cfg, cfg_path)
+    status, body = _get(base, "/section/osc_bindings")
+    assert status == 200
+    for token in ("[x.frac]", "[y.frac]", "[z.frac]"):
+        assert f'data-osc-placeholder="{token}"' in body, token

--- a/tests/test_web_osc_bindings.py
+++ b/tests/test_web_osc_bindings.py
@@ -15,6 +15,8 @@ import re
 import urllib.error
 import urllib.parse
 import urllib.request
+from pathlib import Path
+from typing import get_args
 
 import pytest
 
@@ -3452,9 +3454,8 @@ _ADM_3D = "/adm/obj/[markerid]/xyz [x.frac] [y.frac] [z.frac]"
 @pytest.mark.unit
 def test_blur_error_names_grid_height_not_default_marker() -> None:
     """With the default marker set and registered, ADM-OSC 3D's
-    ``[z.frac]`` is blocked only by the grid height. Naming the default
-    marker here pointed at a control the operator had already set, and
-    the token stayed flagged however they changed it."""
+    ``[z.frac]`` is blocked only by the grid height, so the message must
+    name the grid control."""
     msg = _blur(_ADM_3D, "1", controlled=(1,), max_height=0.0)
     assert msg == "[z.frac] needs Grid → Maximum Height set to a non-zero value."
     assert "default marker" not in msg
@@ -3462,9 +3463,8 @@ def test_blur_error_names_grid_height_not_default_marker() -> None:
 
 @pytest.mark.unit
 def test_blur_error_names_grid_height_for_explicit_registered_marker() -> None:
-    """``[z:2.frac]`` with marker 2 registered is a grid problem. The
-    explicit index previously routed it to "isn't registered", which
-    contradicted the registry."""
+    """``[z:2.frac]`` with marker 2 registered is a grid problem; the
+    message must not claim the marker is unregistered."""
     msg = _blur("/a [z:2.frac]", "1", controlled=(1, 2), max_height=0.0)
     assert msg == "[z:2.frac] needs Grid → Maximum Height set to a non-zero value."
     assert "registered" not in msg
@@ -3473,8 +3473,7 @@ def test_blur_error_names_grid_height_for_explicit_registered_marker() -> None:
 @pytest.mark.unit
 def test_blur_error_reports_default_marker_first_when_both_apply() -> None:
     """No default marker and no grid height: every token wants the
-    marker, so the message names that one step. The grid cause surfaces
-    once the marker resolves (the test below)."""
+    marker, so the message names that one step."""
     msg = _blur(_ADM_3D, "", controlled=(), max_height=0.0)
     assert msg == (
         "[markerid], [x.frac], [y.frac], [z.frac] needs a default marker. "
@@ -3503,9 +3502,7 @@ def test_blur_error_none_for_literal_only_message() -> None:
 
 def test_section_render_offers_a_z_frac_placeholder_chip(live_server) -> None:
     """The curated transform chips are the one-click way to insert a
-    transform. ``[z.frac]`` was absent while ``[x.frac]`` / ``[y.frac]``
-    were present, so an operator who cleared ADM-OSC 3D's height
-    argument had no chip to put it back."""
+    transform, so the fractional-height form needs one too."""
     _, base, cfg_path = live_server
     cfg = load_config(cfg_path)
     cfg.osc_transmitters.transmitters.append(
@@ -3516,3 +3513,93 @@ def test_section_render_offers_a_z_frac_placeholder_chip(live_server) -> None:
     assert status == 200
     for token in ("[x.frac]", "[y.frac]", "[z.frac]"):
         assert f'data-osc-placeholder="{token}"' in body, token
+
+
+@pytest.mark.unit
+def test_blur_error_omits_grid_cause_on_the_markers_field() -> None:
+    """The message is wired to the blurred field's error span. The
+    markers control cannot act on a grid-height cause, so that sentence
+    belongs only on the message field."""
+    assert _blur(_ADM_3D, "1", controlled=(1,), max_height=0.0) is not None
+    assert (
+        _osc_binding_unresolved_blur_error(
+            {"osc_message": _ADM_3D, "markers": "1"},
+            _blur_cfg((1,), 0.0),
+            field_name="markers",
+        )
+        is None
+    )
+
+
+@pytest.mark.unit
+def test_blur_error_keeps_marker_causes_on_the_markers_field() -> None:
+    msg = _osc_binding_unresolved_blur_error(
+        {"osc_message": "/a [x:9] [z:2.frac]", "markers": "1"},
+        _blur_cfg((1, 2), 0.0),
+        field_name="markers",
+    )
+    assert msg == "[x:9] references a marker that isn't registered."
+
+
+def test_section_render_carries_the_unresolved_cause_not_just_the_token(live_server) -> None:
+    """Pills render from the server's attributes before any client
+    recompute, so the cause has to travel with the token or the tooltip
+    has nothing to word its remediation from."""
+    _, base, cfg_path = live_server
+    cfg = load_config(cfg_path)
+    cfg.controlled_marker_ids = [1]
+    cfg.grid.max_height = 0.0
+    cfg.osc_transmitters.transmitters.append(
+        OscTransmitterConfig(id="r-why", name="Why", markers=["1"], address="/a", args=["[z.frac]"]),
+    )
+    save_config(cfg, cfg_path)
+    status, body = _get(base, "/section/osc_bindings")
+    assert status == 200
+    assert "grid_height" in body
+    assert "default_marker" not in body
+
+
+# ---------------------------------------------------------------------------
+# Server / client parity for the unresolved-cause surfaces
+# ---------------------------------------------------------------------------
+
+_TEMPLATE_DIR = Path(__file__).resolve().parents[1] / "openfollow" / "web" / "templates"
+_BASE_TPL = _TEMPLATE_DIR / "base.tpl"
+_BINDINGS_TPL = _TEMPLATE_DIR / "partials" / "osc_bindings.tpl"
+
+
+def _js_concatenated_string(source: str, start_marker: str, end_marker: str) -> str:
+    """Join a run of single-quoted JS fragments into the string it builds."""
+    region = source[source.index(start_marker) : source.index(end_marker) + len(end_marker)]
+    return "".join(re.findall(r"'((?:[^'\\]|\\.)*)'", region)).replace("\\'", "'")
+
+
+@pytest.mark.unit
+def test_js_remediation_table_covers_every_unresolved_reason() -> None:
+    """The tooltip keys its remediation off the cause. A reason with no
+    entry falls back to generic text, so the table has to keep up with
+    the alias."""
+    from openfollow.osc.template import UnresolvedReason
+
+    table = _BASE_TPL.read_text(encoding="utf-8")
+    block = table[table.index("const OSC_UNRESOLVED_REMEDIATION") :]
+    block = block[: block.index("};")]
+    for reason in get_args(UnresolvedReason):
+        assert f"{reason}:" in block, reason
+
+
+@pytest.mark.unit
+def test_enabled_screen_reader_text_matches_between_server_and_client() -> None:
+    """The server renders this string at first paint and after every
+    HTMX swap; the JS rewrites it on edit. They must name the same
+    causes or the announcement changes meaning as the operator types."""
+    js = _js_concatenated_string(
+        _BASE_TPL.read_text(encoding="utf-8"),
+        "'Will save disabled:",
+        "Maximum Height set).'",
+    )
+    served = _BINDINGS_TPL.read_text(encoding="utf-8")
+    start = served.index("'Will save disabled:")
+    rendered = served[start + 1 : served.index("'", start + 1)]
+    assert js == rendered
+    assert "Maximum Height" in js


### PR DESCRIPTION
Reported as "the 3D ADM-OSC template seems to be missing the `[z.frac]` placeholder". The template is fine: `[z.frac]` is present in the builtin, the shipped `.oftemplate`, the seeded copy, and the applied row. What was broken is the message the editor showed about it.

## The defect

`GridConfig.max_height` defaults to `0.0`, and `[z.frac]` has no denominator without it. That makes the token unresolved at edit time, correctly. But the editor then told the operator to set a **default marker**. Setting one cleared the other three tokens and left `[z.frac]` flagged, still asking for a marker that was already set. A placeholder that rejects the only fix offered reads as unsupported.

`unresolved_placeholders` evaluated two independent causes, a missing or unregistered marker and a missing grid height, then returned bare tokens. The message builder recovered a cause by asking whether the token carried an explicit index, which is a question about markers. Both answers were wrong for a grid-blocked token:

| Row state | Before | After |
|---|---|---|
| default marker set, `max_height` unset | `[z.frac] needs a default marker.` | `[z.frac] needs Grid → Maximum Height set to a non-zero value.` |
| `[z:2.frac]`, marker 2 **registered**, `max_height` unset | `[z:2.frac] references a marker that isn't registered.` | same grid sentence |
| nothing set | unchanged | unchanged |

The second case contradicted a registry the marker was in.

## Approach

`unresolved_placeholder_reasons` returns the cause alongside each token; `unresolved_placeholders` becomes its token projection. The rule keeps one home, and the pill renderer's token contract is untouched. Re-deriving the grid rule in the web layer was the alternative and would have duplicated it there.

A token blocked by both causes reports the marker one, so each message names a single next step and the grid cause surfaces once the marker resolves.

The runtime ring buffer already reported this correctly (`z.frac: Grid → Maximum Height is not set`); only the edit-time surface lied. The new wording follows it.

## Also in scope

Two smaller gaps in the same surface, folded in at the reporter's request:

- The Enabled checkbox's screen-reader text enumerated only the two marker causes.
- The curated transform chips offered `[x.frac]` and `[y.frac]` but no `[z.frac]`, so an operator who cleared the height argument had no chip to restore it.

## Testing

The unresolved **token set** was well covered; the **message text** was not, which is the seam this shipped through. Tests now pin the wording per cause.

Each new test was mutation-checked. Reintroducing the defect fails 7; flipping the precedence fails 3; removing the chip fails 1.

`make ci-remote` green at 992 passed, 100% coverage, build clean. No Pi was reachable, so it ran the Mac fallback rather than the aarch64 target; worth a Pi run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
