### PR TITLE
feat(osc): show why a binding row can never fire, on the row itself

### DIFF
--- a/openfollow/osc/template.py
+++ b/openfollow/osc/template.py
@@ -52,7 +52,7 @@ import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Any, Literal
+from typing import Any, Literal, NamedTuple
 
 from openfollow.osc.parser import classify_osc_literal
 
@@ -149,6 +149,20 @@ PLACEHOLDERS: frozenset[str] = _SOURCES
 # Why an edit-time placeholder can't resolve. Each surface words one
 # remediation per reason.
 UnresolvedReason = Literal["default_marker", "explicit_marker", "grid_height"]
+
+
+class UnresolvedPlaceholder(NamedTuple):
+    """One unresolved token, why, and which marker it named.
+
+    ``marker_id`` is the slot's explicit index, populated only for
+    ``explicit_marker`` so a caller can say *which* marker is missing.
+    It comes from the compiled slot, never from re-parsing ``token``.
+    """
+
+    token: str
+    reason: UnresolvedReason
+    marker_id: int | None = None
+
 
 # ``int:min-max`` / ``scale:min-max`` range bounds – signed, optionally
 # decimal. ``min > max`` inverts the mapping naturally. Matched as a
@@ -380,9 +394,10 @@ def unresolved_placeholder_reasons(
     default_marker_id: int | None,
     registered_marker_ids: frozenset[int],
     grid_max_height: float = 0.0,
-) -> tuple[tuple[str, UnresolvedReason], ...]:
-    """Return ``(token, reason)`` for each placeholder in ``parts`` that
-    can't be resolved given the current row + registry + grid state.
+) -> tuple[UnresolvedPlaceholder, ...]:
+    """Return an :class:`UnresolvedPlaceholder` for each placeholder in
+    ``parts`` that can't be resolved given the current row + registry +
+    grid state.
 
     ``token`` is the operator-facing form (``"[x]"`` / ``"[x:5]"`` /
     ``"[z.frac]"``); ``reason`` names the actionable fix, so a caller can
@@ -413,13 +428,14 @@ def unresolved_placeholder_reasons(
 
     Duplicates collapse on the token, which keeps the first reason seen.
     """
-    out: list[tuple[str, UnresolvedReason]] = []
+    out: list[UnresolvedPlaceholder] = []
     seen: set[str] = set()
 
     def _add(slot: _Slot, reason: UnresolvedReason) -> None:
         token = _slot_token(slot)
         if token not in seen:
-            out.append((token, reason))
+            marker_id = slot.ref_index if reason == "explicit_marker" else None
+            out.append(UnresolvedPlaceholder(token, reason, marker_id))
             seen.add(token)
 
     for p in parts:
@@ -467,8 +483,8 @@ def unresolved_placeholders(
     message want that function instead, so the message names the cause.
     """
     return tuple(
-        token
-        for token, _ in unresolved_placeholder_reasons(
+        entry.token
+        for entry in unresolved_placeholder_reasons(
             parts,
             default_marker_id=default_marker_id,
             registered_marker_ids=registered_marker_ids,

--- a/openfollow/web/help/osc_bindings.md
+++ b/openfollow/web/help/osc_bindings.md
@@ -104,6 +104,21 @@ Positions (`[x]` `[y]` `[z]`) accept `.inv` / `.frac`. Faders (`[fader]` `[marke
 
 ## Diagnostics
 
+A red dot on a collapsed row means it can never fire, and the reason sits
+next to the name. Up to three are shown, separated by `·`; any beyond that
+are counted as `+N more errors`. Open the row to see them all.
+
+| Badge | Fix |
+|---|---|
+| `No destination` | Pick one under **Destination**, or add it in OSC Destinations |
+| `No controlled marker` | Name a marker this station controls under **Default markers** |
+| `No default marker` | The message uses `[x]`-style placeholders with no marker to resolve them |
+| `Marker 9 not registered` | That `:N` reference names a marker this station doesn't control |
+| `Grid Maximum Height not set` | `[z.frac]` divides by it – set **Grid → Maximum Height** |
+
+A row with no red dot can still fail at send time; the panels below are
+what show that.
+
 Read-only panels showing what the transmitter is doing right now.
 
 - **Live status** – connection state (UDP ready, or TCP connected / connecting / backing off), packets per second, and the last error. Click the refresh button to update.

--- a/openfollow/web/help/osc_bindings.md
+++ b/openfollow/web/help/osc_bindings.md
@@ -106,7 +106,8 @@ Positions (`[x]` `[y]` `[z]`) accept `.inv` / `.frac`. Faders (`[fader]` `[marke
 
 A red dot on a collapsed row means it can never fire, and the reason sits
 next to the name. Up to three are shown, separated by `·`; any beyond that
-are counted as `+N more errors`. Open the row to see them all.
+are counted as `+N more errors`. Fix the ones named and the rest take their
+place.
 
 | Badge | Fix |
 |---|---|

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -43,6 +43,7 @@ import openfollow
 import openfollow.web._bottle_charset_fix  # noqa: F401
 
 if TYPE_CHECKING:
+    from openfollow.osc.template import UnresolvedPlaceholder
     from openfollow.video.inputs._base import VideoInputBase
     from openfollow.web.discovery import PeerInfo
     from openfollow.web.server import ConfigWebServer
@@ -1975,15 +1976,15 @@ def _osc_binding_unresolved_blur_error(
     seen: set[str] = set()
     by_reason: dict[UnresolvedReason, list[str]] = {}
     for tpl in (address, *args):
-        for token, reason in unresolved_placeholder_reasons(
+        for entry in unresolved_placeholder_reasons(
             compile_template(tpl),
             default_marker_id=marker_id,
             registered_marker_ids=registered,
             grid_max_height=cfg.grid.max_height,
         ):
-            if token not in seen:
-                by_reason.setdefault(reason, []).append(token)
-                seen.add(token)
+            if entry.token not in seen:
+                by_reason.setdefault(entry.reason, []).append(entry.token)
+                seen.add(entry.token)
     # One sentence per cause, each naming the control that fixes it.
     # Order is fixed rather than first-seen so the message reads the same
     # however the operator ordered the arguments.
@@ -2108,18 +2109,70 @@ def _render_midi_fader_capture_status(
     )
 
 
-def _row_unresolved_reasons(
+# Visible fault labels shown on a collapsed OSC binding row, in the order
+# an operator works through them. The three placeholder causes keep the
+# blur message's order so the row's badge and its inline message never
+# lead with different problems.
+_MAX_VISIBLE_FAULTS = 3
+
+
+def _row_fault_labels(
+    row: OscTransmitterConfig,
+    *,
+    destination_ids: frozenset[str],
+    markers_unusable: bool,
+    registered_marker_ids: frozenset[int],
+    grid_max_height: float = 0.0,
+) -> tuple[str, ...]:
+    """Every reason this row can never fire, worded for the operator.
+
+    Empty when the row is fine. Callers render the first
+    :data:`_MAX_VISIBLE_FAULTS` and summarise the rest, so the order is
+    the fix order rather than the order the faults were discovered.
+    Unregistered markers group into one entry because they are one fix.
+    """
+    faults: list[str] = []
+    if not row.destination_id or row.destination_id not in destination_ids:
+        faults.append("No destination")
+    if markers_unusable:
+        faults.append("No controlled marker")
+
+    entries = _row_unresolved_entries(row, registered_marker_ids, grid_max_height=grid_max_height)
+    causes = {e.reason for e in entries}
+    if "default_marker" in causes:
+        faults.append("No default marker")
+    if "explicit_marker" in causes:
+        missing = sorted({e.marker_id for e in entries if e.reason == "explicit_marker" and e.marker_id is not None})
+        ids = ", ".join(str(m) for m in missing)
+        faults.append(f"Marker{'s' if len(missing) > 1 else ''} {ids} not registered")
+    if "grid_height" in causes:
+        faults.append("Grid Maximum Height not set")
+    return tuple(faults)
+
+
+def _row_fault_summary(faults: Sequence[str]) -> tuple[tuple[str, ...], str]:
+    """Split ``faults`` into the visible ones and an overflow phrase.
+
+    The phrase is empty when everything fits.
+    """
+    visible = tuple(faults[:_MAX_VISIBLE_FAULTS])
+    hidden = len(faults) - len(visible)
+    if hidden <= 0:
+        return visible, ""
+    return visible, f"+{hidden} more error{'s' if hidden > 1 else ''}"
+
+
+def _row_unresolved_entries(
     row: OscTransmitterConfig,
     registered_marker_ids: frozenset[int],
     *,
     grid_max_height: float = 0.0,
-) -> dict[str, str]:
-    """Token -> cause for every placeholder in ``row``'s address + args
-    that can't resolve, in address-then-args appearance order.
+) -> tuple[UnresolvedPlaceholder, ...]:
+    """Every unresolved placeholder in ``row``'s address + args, in
+    address-then-args appearance order, first occurrence of each token.
 
-    The pill tooltip and the blur message word a remediation per cause,
-    so the cause travels with the token rather than being re-derived
-    from its shape at each surface.
+    The one scan behind the pill list, the tooltip's cause map, and the
+    row's fault labels.
     """
     from openfollow.osc.template import (
         compile_template,
@@ -2127,16 +2180,19 @@ def _row_unresolved_reasons(
     )
 
     effective_marker_id = _effective_default_marker_id(row.markers, registered_marker_ids)
-    out: dict[str, str] = {}
+    out: list[UnresolvedPlaceholder] = []
+    seen: set[str] = set()
     for tpl in (row.address, *row.args):
-        for token, reason in unresolved_placeholder_reasons(
+        for entry in unresolved_placeholder_reasons(
             compile_template(tpl),
             default_marker_id=effective_marker_id,
             registered_marker_ids=registered_marker_ids,
             grid_max_height=grid_max_height,
         ):
-            out.setdefault(token, reason)
-    return out
+            if entry.token not in seen:
+                out.append(entry)
+                seen.add(entry.token)
+    return tuple(out)
 
 
 def _row_unresolved_placeholders(
@@ -2158,9 +2214,9 @@ def _row_unresolved_placeholders(
       (it keys off ``aria-invalid``), keeping the "Save with enabled=False"
       workflow available.
 
-    The token half of :func:`_row_unresolved_reasons`.
+    The token half of :func:`_row_unresolved_entries`.
     """
-    return tuple(_row_unresolved_reasons(row, registered_marker_ids, grid_max_height=grid_max_height))
+    return tuple(e.token for e in _row_unresolved_entries(row, registered_marker_ids, grid_max_height=grid_max_height))
 
 
 def _apply_osc_binding_fields(
@@ -5597,15 +5653,33 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         only after the operator saves a row."""
         registered = frozenset(cfg.controlled_marker_ids)
         # Scan each row once; the token list is the reason map's keys.
-        reasons_by_row = {
-            row.id: _row_unresolved_reasons(row, registered, grid_max_height=cfg.grid.max_height)
+        entries_by_row = {
+            row.id: _row_unresolved_entries(row, registered, grid_max_height=cfg.grid.max_height)
+            for row in cfg.osc_transmitters.transmitters
+        }
+        marker_display = _osc_binding_marker_display(cfg, server.get_marker_catalog())
+        destination_ids = frozenset(d.id for d in cfg.osc_destinations.destinations)
+        faults_by_row = {
+            row.id: _row_fault_labels(
+                row,
+                destination_ids=destination_ids,
+                markers_unusable=marker_display.get(row.id, {}).get("markers_unusable", False),
+                registered_marker_ids=registered,
+                grid_max_height=cfg.grid.max_height,
+            )
             for row in cfg.osc_transmitters.transmitters
         }
         return {
             "registered_marker_ids": sorted(registered),
-            "unresolved_by_row": {row_id: tuple(reasons) for row_id, reasons in reasons_by_row.items()},
-            "unresolved_reasons_by_row": reasons_by_row,
-            "marker_display_by_row": _osc_binding_marker_display(cfg, server.get_marker_catalog()),
+            "unresolved_by_row": {
+                row_id: tuple(e.token for e in entries) for row_id, entries in entries_by_row.items()
+            },
+            "unresolved_reasons_by_row": {
+                row_id: {e.token: e.reason for e in entries} for row_id, entries in entries_by_row.items()
+            },
+            "marker_display_by_row": marker_display,
+            "faults_by_row": faults_by_row,
+            "fault_summary_by_row": {row_id: _row_fault_summary(faults) for row_id, faults in faults_by_row.items()},
         }
 
     def _render_osc_bindings_section(

--- a/openfollow/web/routes.py
+++ b/openfollow/web/routes.py
@@ -43,7 +43,7 @@ import openfollow
 import openfollow.web._bottle_charset_fix  # noqa: F401
 
 if TYPE_CHECKING:
-    from openfollow.osc.template import UnresolvedPlaceholder
+    from openfollow.osc.template import UnresolvedPlaceholder, UnresolvedReason
     from openfollow.video.inputs._base import VideoInputBase
     from openfollow.web.discovery import PeerInfo
     from openfollow.web.server import ConfigWebServer
@@ -1968,7 +1968,6 @@ def _osc_binding_unresolved_blur_error(
     markers = _coerce_marker_tokens(query.get("markers", ""))
     marker_id = _effective_default_marker_id(markers, registered)
     from openfollow.osc.template import (
-        UnresolvedReason,
         compile_template,
         unresolved_placeholder_reasons,
     )
@@ -1988,21 +1987,20 @@ def _osc_binding_unresolved_blur_error(
     # One sentence per cause, each naming the control that fixes it.
     # Order is fixed rather than first-seen so the message reads the same
     # however the operator ordered the arguments.
-    templates: tuple[tuple[UnresolvedReason, str], ...] = (
-        (
-            "default_marker",
+    templates: dict[UnresolvedReason, str] = {
+        "default_marker": (
             "{tokens} needs a default marker. Set 'Default markers' to a controlled id, "
-            "a controller alias (c1, c2, …), or 'all'.",
+            "a controller alias (c1, c2, …), or 'all'."
         ),
-        ("explicit_marker", "{tokens} references a marker that isn't registered."),
-        ("grid_height", "{tokens} needs Grid → Maximum Height set to a non-zero value."),
-    )
+        "explicit_marker": "{tokens} references a marker that isn't registered.",
+        "grid_height": "{tokens} needs Grid → Maximum Height set to a non-zero value.",
+    }
     # The markers field can only act on the marker causes; a grid-height
     # sentence there would describe a control it has no bearing on.
     actionable = _MARKER_BLUR_REASONS if field_name == "markers" else None
     parts: list[str] = [
-        text.format(tokens=", ".join(by_reason[reason]))
-        for reason, text in templates
+        templates[reason].format(tokens=", ".join(by_reason[reason]))
+        for reason in _UNRESOLVED_CAUSE_ORDER
         if reason in by_reason and (actionable is None or reason in actionable)
     ]
     # Guard the join, not the token set: a reason with no entry above
@@ -2109,27 +2107,32 @@ def _render_midi_fader_capture_status(
     )
 
 
-# Visible fault labels shown on a collapsed OSC binding row, in the order
-# an operator works through them. The three placeholder causes keep the
-# blur message's order so the row's badge and its inline message never
-# lead with different problems.
+# The order an operator works through placeholder causes. The badge and
+# the blur message both follow it, so they never lead with different
+# problems.
+_UNRESOLVED_CAUSE_ORDER: tuple[UnresolvedReason, ...] = (
+    "default_marker",
+    "explicit_marker",
+    "grid_height",
+)
+
+# Faults shown on a collapsed row before the rest are counted.
 _MAX_VISIBLE_FAULTS = 3
 
 
 def _row_fault_labels(
     row: OscTransmitterConfig,
     *,
+    entries: Sequence[UnresolvedPlaceholder],
     destination_ids: frozenset[str],
     markers_unusable: bool,
-    registered_marker_ids: frozenset[int],
-    grid_max_height: float = 0.0,
 ) -> tuple[str, ...]:
     """Every reason this row can never fire, worded for the operator.
 
-    Empty when the row is fine. Callers render the first
-    :data:`_MAX_VISIBLE_FAULTS` and summarise the rest, so the order is
-    the fix order rather than the order the faults were discovered.
-    Unregistered markers group into one entry because they are one fix.
+    Empty when the row is fine. ``entries`` is the row's already-scanned
+    unresolved set, so the caller pays for one scan. Callers render the
+    first :data:`_MAX_VISIBLE_FAULTS` and count the rest, so the order is
+    the fix order rather than the order the faults were found.
     """
     faults: list[str] = []
     if not row.destination_id or row.destination_id not in destination_ids:
@@ -2137,29 +2140,41 @@ def _row_fault_labels(
     if markers_unusable:
         faults.append("No controlled marker")
 
-    entries = _row_unresolved_entries(row, registered_marker_ids, grid_max_height=grid_max_height)
     causes = {e.reason for e in entries}
-    if "default_marker" in causes:
-        faults.append("No default marker")
-    if "explicit_marker" in causes:
-        missing = sorted({e.marker_id for e in entries if e.reason == "explicit_marker" and e.marker_id is not None})
-        ids = ", ".join(str(m) for m in missing)
-        faults.append(f"Marker{'s' if len(missing) > 1 else ''} {ids} not registered")
-    if "grid_height" in causes:
-        faults.append("Grid Maximum Height not set")
+    for cause in _UNRESOLVED_CAUSE_ORDER:
+        if cause not in causes:
+            continue
+        if cause == "default_marker":
+            # An unusable marker list is why the default won't resolve;
+            # naming both spends a slot on one fix.
+            if not markers_unusable:
+                faults.append("No default marker")
+        elif cause == "explicit_marker":
+            missing = sorted({e.marker_id for e in entries if e.reason == cause and e.marker_id is not None})
+            # Every cause must yield a label, or the row reads as healthy
+            # while it can never fire. An entry without its id still says so.
+            if missing:
+                ids = ", ".join(str(m) for m in missing)
+                faults.append(f"Marker{'s' if len(missing) > 1 else ''} {ids} not registered")
+            else:
+                faults.append("Marker not registered")
+        else:
+            faults.append("Grid Maximum Height not set")
     return tuple(faults)
 
 
-def _row_fault_summary(faults: Sequence[str]) -> tuple[tuple[str, ...], str]:
-    """Split ``faults`` into the visible ones and an overflow phrase.
+def _row_fault_summary(faults: Sequence[str]) -> tuple[tuple[str, ...], str, tuple[str, ...]]:
+    """``(visible, overflow_phrase, all)`` for one row.
 
-    The phrase is empty when everything fits.
+    The phrase is empty when everything fits. ``all`` rides along for the
+    assistive-tech list, which is never truncated.
     """
-    visible = tuple(faults[:_MAX_VISIBLE_FAULTS])
-    hidden = len(faults) - len(visible)
+    full = tuple(faults)
+    visible = full[:_MAX_VISIBLE_FAULTS]
+    hidden = len(full) - len(visible)
     if hidden <= 0:
-        return visible, ""
-    return visible, f"+{hidden} more error{'s' if hidden > 1 else ''}"
+        return visible, "", full
+    return visible, f"+{hidden} more error{'s' if hidden > 1 else ''}", full
 
 
 def _row_unresolved_entries(
@@ -5652,21 +5667,12 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
         chips, unresolved pills, and status dots appear at first paint, not
         only after the operator saves a row."""
         registered = frozenset(cfg.controlled_marker_ids)
-        # Scan each row once; the token list is the reason map's keys.
-        entries_by_row = {
-            row.id: _row_unresolved_entries(row, registered, grid_max_height=cfg.grid.max_height)
-            for row in cfg.osc_transmitters.transmitters
-        }
         marker_display = _osc_binding_marker_display(cfg, server.get_marker_catalog())
         destination_ids = frozenset(d.id for d in cfg.osc_destinations.destinations)
-        faults_by_row = {
-            row.id: _row_fault_labels(
-                row,
-                destination_ids=destination_ids,
-                markers_unusable=marker_display.get(row.id, {}).get("markers_unusable", False),
-                registered_marker_ids=registered,
-                grid_max_height=cfg.grid.max_height,
-            )
+        # One scan per row feeds the pills, the tooltip's cause map and
+        # the fault labels.
+        entries_by_row = {
+            row.id: _row_unresolved_entries(row, registered, grid_max_height=cfg.grid.max_height)
             for row in cfg.osc_transmitters.transmitters
         }
         return {
@@ -5678,8 +5684,17 @@ def setup_routes(app: Bottle, server: ConfigWebServer) -> None:
                 row_id: {e.token: e.reason for e in entries} for row_id, entries in entries_by_row.items()
             },
             "marker_display_by_row": marker_display,
-            "faults_by_row": faults_by_row,
-            "fault_summary_by_row": {row_id: _row_fault_summary(faults) for row_id, faults in faults_by_row.items()},
+            "fault_summary_by_row": {
+                row.id: _row_fault_summary(
+                    _row_fault_labels(
+                        row,
+                        entries=entries_by_row[row.id],
+                        destination_ids=destination_ids,
+                        markers_unusable=marker_display.get(row.id, {}).get("markers_unusable", False),
+                    )
+                )
+                for row in cfg.osc_transmitters.transmitters
+            },
         }
 
     def _render_osc_bindings_section(

--- a/openfollow/web/templates/base.tpl
+++ b/openfollow/web/templates/base.tpl
@@ -1425,7 +1425,7 @@
  border: 1px solid rgba(255, 140, 140, 0.3);
  font-weight: 500; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
  }
- .osc-binding-fault-more { color: var(--muted); font-weight: 400; margin-left: 0.4rem; }
+ .osc-binding-fault-more { color: var(--muted); font-size: 0.7rem; flex: none; white-space: nowrap; }
  .osc-binding-target { color: var(--muted); font-size: 0.8rem; margin-left: auto; }
  /* Secondary markers nested under a fanned-out transmitter row: read-only
  chips sharing the parent's destination / message / trigger. */

--- a/openfollow/web/templates/base.tpl
+++ b/openfollow/web/templates/base.tpl
@@ -1416,6 +1416,16 @@
  .osc-binding-enabled-dot.invalid { background: var(--danger); }
  .osc-binding-kind-badge, .osc-destination-proto-badge { font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 0.4rem; background: rgba(255,255,255,0.05); color: var(--muted); }
  .osc-binding-marker-badge { font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 0.4rem; background: rgba(255,255,255,0.05); color: var(--muted); }
+ /* Why a row can never fire, on its collapsed summary. Capped at three
+    entries by the renderer; the full list rides in a sibling
+    visually-hidden span so assistive tech never gets the truncation. */
+ .osc-binding-fault {
+ font-size: 0.7rem; padding: 0.1rem 0.45rem; border-radius: 0.4rem;
+ background: rgba(255, 140, 140, 0.14); color: var(--danger);
+ border: 1px solid rgba(255, 140, 140, 0.3);
+ font-weight: 500; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+ }
+ .osc-binding-fault-more { color: var(--muted); font-weight: 400; margin-left: 0.4rem; }
  .osc-binding-target { color: var(--muted); font-size: 0.8rem; margin-left: auto; }
  /* Secondary markers nested under a fanned-out transmitter row: read-only
  chips sharing the parent's destination / message / trigger. */

--- a/openfollow/web/templates/index.tpl
+++ b/openfollow/web/templates/index.tpl
@@ -137,7 +137,9 @@
     %     placeholders=sorted(PLACEHOLDERS),
     %     registered_marker_ids=registered_marker_ids,
     %     unresolved_by_row=unresolved_by_row,
-    %     marker_display_by_row=marker_display_by_row)
+    %     marker_display_by_row=marker_display_by_row,
+    %     unresolved_reasons_by_row=unresolved_reasons_by_row,
+    %     fault_summary_by_row=fault_summary_by_row)
 </div>
 
 <!-- Person Detection -->

--- a/openfollow/web/templates/partials/osc_bindings.tpl
+++ b/openfollow/web/templates/partials/osc_bindings.tpl
@@ -21,7 +21,6 @@
 % # round-trip to the server.
 % _unresolved_by_row = defined('unresolved_by_row') and unresolved_by_row or {}
 % _unresolved_reasons_by_row = defined('unresolved_reasons_by_row') and unresolved_reasons_by_row or {}
-% _faults_by_row = defined('faults_by_row') and faults_by_row or {}
 % _fault_summary_by_row = defined('fault_summary_by_row') and fault_summary_by_row or {}
 % _registered_marker_ids = defined('registered_marker_ids') and registered_marker_ids or []
 % # per-row marker display: {row_id: {"header": <single-marker label|None>,
@@ -58,18 +57,9 @@
  % _row_marker = _marker_display_by_row.get(row.id, {})
  % _marker_header = _row_marker.get('header')
  % _marker_nested = _row_marker.get('nested', [])
- % _markers_unusable = _row_marker.get('markers_unusable', False)
- % # The row's status dot is red when this transmitter can never fire: no
- % # destination (or a dangling one), no controlled marker among those it
- % # names, or an invalid address/arg (an unresolvable placeholder).
- % # Otherwise amber when enabled, grey when off. An uncontrolled *secondary*
- % # marker (with at least one controlled) reddens its own nested chip, not
- % # this dot.
- % _dest_missing = (not row.destination_id) or (row.destination_id not in _dest_by_id)
- % _faults = _faults_by_row.get(row.id, ())
- % _fault_visible, _fault_more = _fault_summary_by_row.get(row.id, ((), ''))
+ % # Red when the row can never fire; the badge beside the name says why.
+ % _fault_visible, _fault_more, _faults = _fault_summary_by_row.get(row.id, ((), '', ()))
  % _dot_broken = bool(_faults)
- % _dot_state = 'invalid' if _dot_broken else ('on' if row.enabled else 'off')
  <details class="osc-binding-row" data-row-id="{{row.id}}" data-trigger-kind="{{trigger_kind}}"
  data-reorder-url="/section/osc_bindings/reorder" data-reorder-target="osc-bindings-section" {{'open' if is_focus else ''}}>
  <summary class="osc-binding-summary">
@@ -93,15 +83,14 @@
  % if _dot_broken:
  <span class="osc-binding-enabled-dot invalid" aria-hidden="true"></span>
  % else:
- <span class="osc-binding-enabled-dot {{_dot_state}}" aria-label="{{'Enabled' if row.enabled else 'Disabled'}}"></span>
+ <span class="osc-binding-enabled-dot {{'on' if row.enabled else 'off'}}" aria-label="{{'Enabled' if row.enabled else 'Disabled'}}"></span>
  % end
  <span class="osc-binding-title">{{row.name or '(unnamed)'}}</span>
  % if _dot_broken:
- <span class="osc-binding-fault" aria-hidden="true">{{' · '.join(_fault_visible)}}\\
-% if _fault_more:
-<span class="osc-binding-fault-more">{{_fault_more}}</span>\\
-% end
-</span>
+ <span class="osc-binding-fault" aria-hidden="true">{{' · '.join(_fault_visible)}}</span>
+ % if _fault_more:
+ <span class="osc-binding-fault-more" aria-hidden="true">{{_fault_more}}</span>
+ % end
  <span class="visually-hidden">{{'. '.join(_faults)}}.</span>
  % end
  <span class="osc-binding-kind-badge">{{pretty_label(trigger_kind)}}</span>

--- a/openfollow/web/templates/partials/osc_bindings.tpl
+++ b/openfollow/web/templates/partials/osc_bindings.tpl
@@ -21,6 +21,8 @@
 % # round-trip to the server.
 % _unresolved_by_row = defined('unresolved_by_row') and unresolved_by_row or {}
 % _unresolved_reasons_by_row = defined('unresolved_reasons_by_row') and unresolved_reasons_by_row or {}
+% _faults_by_row = defined('faults_by_row') and faults_by_row or {}
+% _fault_summary_by_row = defined('fault_summary_by_row') and fault_summary_by_row or {}
 % _registered_marker_ids = defined('registered_marker_ids') and registered_marker_ids or []
 % # per-row marker display: {row_id: {"header": <single-marker label|None>,
 % #   "nested": [<chip>...], "markers_unusable": <bool>}}. Built server-side
@@ -64,9 +66,10 @@
  % # marker (with at least one controlled) reddens its own nested chip, not
  % # this dot.
  % _dest_missing = (not row.destination_id) or (row.destination_id not in _dest_by_id)
- % _dot_broken = _dest_missing or _markers_unusable or has_unresolved
+ % _faults = _faults_by_row.get(row.id, ())
+ % _fault_visible, _fault_more = _fault_summary_by_row.get(row.id, ((), ''))
+ % _dot_broken = bool(_faults)
  % _dot_state = 'invalid' if _dot_broken else ('on' if row.enabled else 'off')
- % _dot_label = 'No destination' if _dest_missing else ('No controlled marker' if _markers_unusable else ('Invalid OSC message' if has_unresolved else ('Enabled' if row.enabled else 'Disabled')))
  <details class="osc-binding-row" data-row-id="{{row.id}}" data-trigger-kind="{{trigger_kind}}"
  data-reorder-url="/section/osc_bindings/reorder" data-reorder-target="osc-bindings-section" {{'open' if is_focus else ''}}>
  <summary class="osc-binding-summary">
@@ -87,8 +90,20 @@
  title="Drag to reorder"
  onpointerdown="event.stopPropagation()"
  onclick="event.preventDefault(); event.stopPropagation();">⋮⋮</span>
- <span class="osc-binding-enabled-dot {{_dot_state}}" aria-label="{{_dot_label}}"></span>
+ % if _dot_broken:
+ <span class="osc-binding-enabled-dot invalid" aria-hidden="true"></span>
+ % else:
+ <span class="osc-binding-enabled-dot {{_dot_state}}" aria-label="{{'Enabled' if row.enabled else 'Disabled'}}"></span>
+ % end
  <span class="osc-binding-title">{{row.name or '(unnamed)'}}</span>
+ % if _dot_broken:
+ <span class="osc-binding-fault" aria-hidden="true">{{' · '.join(_fault_visible)}}\\
+% if _fault_more:
+<span class="osc-binding-fault-more">{{_fault_more}}</span>\\
+% end
+</span>
+ <span class="visually-hidden">{{'. '.join(_faults)}}.</span>
+ % end
  <span class="osc-binding-kind-badge">{{pretty_label(trigger_kind)}}</span>
  % if _marker_header:
  <span class="osc-binding-marker-badge">{{_marker_header}}</span>

--- a/tests/test_osc_template.py
+++ b/tests/test_osc_template.py
@@ -1198,52 +1198,76 @@ def _reasons(tpl: str, *, marker=None, registered=frozenset(), grid=0.0):  # noq
 
 
 def test_reason_default_marker_when_no_default_named() -> None:
-    assert _reasons("[x]", marker=None, registered=frozenset({0}), grid=4.0) == (("[x]", "default_marker"),)
+    assert _reasons("[x]", marker=None, registered=frozenset({0}), grid=4.0) == (("[x]", "default_marker", None),)
 
 
 def test_reason_explicit_marker_when_target_unregistered() -> None:
-    assert _reasons("[x:9]", marker=0, registered=frozenset({0}), grid=4.0) == (("[x:9]", "explicit_marker"),)
+    assert _reasons("[x:9]", marker=0, registered=frozenset({0}), grid=4.0) == (("[x:9]", "explicit_marker", 9),)
 
 
 @pytest.mark.parametrize("tpl", ["[z.frac]", "[z.frac.inv]"])
 def test_reason_grid_height_when_marker_resolves_but_height_unset(tpl: str) -> None:
     """With the default marker set and registered, a fractional-Z token
     is blocked only by the grid height."""
-    assert _reasons(tpl, marker=0, registered=frozenset({0}), grid=0.0) == ((tpl, "grid_height"),)
+    assert _reasons(tpl, marker=0, registered=frozenset({0}), grid=0.0) == ((tpl, "grid_height", None),)
 
 
 def test_reason_grid_height_for_explicit_slot_whose_marker_is_registered() -> None:
     """``[z:3.frac]`` with marker 3 registered is a grid problem; the
     explicit index says nothing about which cause applies."""
-    assert _reasons("[z:3.frac]", marker=None, registered=frozenset({3}), grid=0.0) == (("[z:3.frac]", "grid_height"),)
+    assert _reasons("[z:3.frac]", marker=None, registered=frozenset({3}), grid=0.0) == (
+        ("[z:3.frac]", "grid_height", None),
+    )
 
 
 def test_reason_marker_precedes_grid_on_default_slot() -> None:
     """Both causes apply; the marker one is reported so the message names
     one next step."""
-    assert _reasons("[z.frac]", marker=None, registered=frozenset({0}), grid=0.0) == (("[z.frac]", "default_marker"),)
+    assert _reasons("[z.frac]", marker=None, registered=frozenset({0}), grid=0.0) == (
+        ("[z.frac]", "default_marker", None),
+    )
 
 
 def test_reason_marker_precedes_grid_on_explicit_slot() -> None:
     assert _reasons("[z:9.frac]", marker=None, registered=frozenset({0, 1}), grid=0.0) == (
-        ("[z:9.frac]", "explicit_marker"),
+        ("[z:9.frac]", "explicit_marker", 9),
     )
 
 
 def test_reason_repeated_token_reported_once() -> None:
     assert _reasons("[z.frac]/[z.frac]", marker=0, registered=frozenset({0}), grid=0.0) == (
-        ("[z.frac]", "grid_height"),
+        ("[z.frac]", "grid_height", None),
     )
 
 
 def test_reasons_preserve_appearance_order_across_causes() -> None:
     out = _reasons("/p/[markerid]/[x:9]/[z.frac]", marker=None, registered=frozenset({0}), grid=0.0)
     assert out == (
-        ("[markerid]", "default_marker"),
-        ("[x:9]", "explicit_marker"),
-        ("[z.frac]", "default_marker"),
+        ("[markerid]", "default_marker", None),
+        ("[x:9]", "explicit_marker", 9),
+        ("[z.frac]", "default_marker", None),
     )
 
 
 def test_reasons_empty_when_everything_resolves() -> None:
     assert _reasons("[x] [z.frac] [markerid]", marker=0, registered=frozenset({0}), grid=4.0) == ()
+
+
+def test_reason_carries_the_explicit_marker_id() -> None:
+    """``marker_id`` comes from the compiled slot, so a caller can name
+    which marker is missing without re-parsing the token."""
+    (entry,) = _reasons("[x:12]", marker=0, registered=frozenset({0}), grid=4.0)
+    assert (entry.token, entry.reason, entry.marker_id) == ("[x:12]", "explicit_marker", 12)
+
+
+@pytest.mark.parametrize(
+    ("tpl", "marker", "registered", "grid"),
+    [
+        ("[x]", None, frozenset({0}), 4.0),
+        ("[z.frac]", 0, frozenset({0}), 0.0),
+        ("[z:3.frac]", None, frozenset({3}), 0.0),
+    ],
+)
+def test_reason_marker_id_is_none_for_non_explicit_causes(tpl, marker, registered, grid) -> None:  # noqa: ANN001
+    (entry,) = _reasons(tpl, marker=marker, registered=registered, grid=grid)
+    assert entry.marker_id is None

--- a/tests/test_web_osc_bindings.py
+++ b/tests/test_web_osc_bindings.py
@@ -45,6 +45,8 @@ from openfollow.web.routes import (
     _osc_binding_unresolved_blur_error,
     _parse_osc_message,
     _parse_trigger_subtable,
+    _row_fault_labels,
+    _row_fault_summary,
     _row_unresolved_placeholders,
     _virtual_fader_names_for_form,
 )
@@ -3603,3 +3605,216 @@ def test_enabled_screen_reader_text_matches_between_server_and_client() -> None:
     rendered = served[start + 1 : served.index("'", start + 1)]
     assert js == rendered
     assert "Maximum Height" in js
+
+
+# ---------------------------------------------------------------------------
+# Row fault labels – what the collapsed row says is wrong
+# ---------------------------------------------------------------------------
+
+_DESTS = frozenset({"eos"})
+
+
+def _faults(row, *, markers_unusable=False, registered=frozenset({1}), grid=8.0):  # noqa: ANN001, ANN202, B008
+    return _row_fault_labels(
+        row,
+        destination_ids=_DESTS,
+        markers_unusable=markers_unusable,
+        registered_marker_ids=registered,
+        grid_max_height=grid,
+    )
+
+
+def _row(**kw):  # noqa: ANN003, ANN202
+    kw.setdefault("destination_id", "eos")
+    kw.setdefault("markers", ["1"])
+    kw.setdefault("address", "/a")
+    return OscTransmitterConfig(**kw)
+
+
+@pytest.mark.unit
+def test_fault_labels_empty_for_a_healthy_row() -> None:
+    assert _faults(_row(args=["[x]"])) == ()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("destination_id", ["", "gone"])
+def test_fault_labels_report_missing_or_dangling_destination(destination_id: str) -> None:
+    assert _faults(_row(destination_id=destination_id, args=["[x]"]))[0] == "No destination"
+
+
+@pytest.mark.unit
+def test_fault_labels_report_unusable_markers() -> None:
+    assert _faults(_row(args=["[x]"]), markers_unusable=True) == ("No controlled marker",)
+
+
+@pytest.mark.unit
+def test_fault_labels_report_missing_default_marker() -> None:
+    assert _faults(_row(args=["[x]"]), registered=frozenset()) == ("No default marker",)
+
+
+@pytest.mark.unit
+def test_fault_labels_report_grid_height() -> None:
+    assert _faults(_row(args=["[z.frac]"]), grid=0.0) == ("Grid Maximum Height not set",)
+
+
+@pytest.mark.unit
+def test_fault_labels_name_a_single_unregistered_marker() -> None:
+    assert _faults(_row(args=["[x:9]"])) == ("Marker 9 not registered",)
+
+
+@pytest.mark.unit
+def test_fault_labels_group_unregistered_markers_sorted() -> None:
+    """One entry, because registering them is one fix. Sorted so the
+    label doesn't reorder with the arguments."""
+    assert _faults(_row(args=["[y:12]", "[x:9]", "[z:9]"])) == ("Markers 9, 12 not registered",)
+
+
+@pytest.mark.unit
+def test_fault_labels_use_a_fixed_order_independent_of_argument_order() -> None:
+    """Destination, markers, then the placeholder causes in the same
+    order the blur message uses, so the two never disagree about which
+    problem leads."""
+    forward = _faults(
+        _row(destination_id="", args=["[x]", "[y:9]", "[z:1.frac]"]),
+        markers_unusable=True,
+        registered=frozenset(),
+        grid=0.0,
+    )
+    reversed_args = _faults(
+        _row(destination_id="", args=["[z:1.frac]", "[y:9]", "[x]"]),
+        markers_unusable=True,
+        registered=frozenset(),
+        grid=0.0,
+    )
+    assert forward == reversed_args
+    assert forward[:2] == ("No destination", "No controlled marker")
+
+
+@pytest.mark.unit
+def test_fault_labels_can_report_both_a_marker_and_a_grid_cause() -> None:
+    """Marker 1 is registered but the row names no default, so bare
+    ``[x]`` wants a default marker while ``[z:1.frac]`` resolves its
+    marker and is blocked only by the height. Both surface at once."""
+    out = _faults(
+        _row(markers=[], args=["[x]", "[z:1.frac]"]),
+        registered=frozenset({1}),
+        grid=0.0,
+    )
+    assert out == ("No default marker", "Grid Maximum Height not set")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("count", "expected_more"),
+    [(1, ""), (3, ""), (4, "+1 more error"), (5, "+2 more errors")],
+)
+def test_fault_summary_caps_at_three_and_counts_the_rest(count: int, expected_more: str) -> None:
+    faults = tuple(f"problem {i}" for i in range(count))
+    visible, more = _row_fault_summary(faults)
+    assert visible == faults[:3]
+    assert more == expected_more
+
+
+@pytest.mark.unit
+def test_fault_summary_of_no_faults_is_empty() -> None:
+    assert _row_fault_summary(()) == ((), "")
+
+
+def _seed_fault_rows(cfg_path):  # noqa: ANN001, ANN202
+    cfg = load_config(cfg_path)
+    cfg.controlled_marker_ids = [1]
+    cfg.grid.max_height = 0.0
+    cfg.osc_destinations.destinations = [
+        OscDestinationConfig(id="eos", name="eos", host="10.0.0.5", port=8000),
+    ]
+    cfg.osc_transmitters.transmitters = [
+        OscTransmitterConfig(
+            id="r-grid",
+            name="ADM-OSC 3D",
+            destination_id="eos",
+            markers=["1"],
+            address="/adm/obj/[markerid]/xyz",
+            args=["[x.frac]", "[y.frac]", "[z.frac]"],
+        ),
+        OscTransmitterConfig(
+            id="r-many",
+            name="Everything wrong",
+            destination_id="",
+            markers=[],
+            address="/a",
+            args=["[x]", "[y:9]", "[z:1.frac]"],
+        ),
+        OscTransmitterConfig(
+            id="r-ok",
+            name="Healthy",
+            destination_id="eos",
+            markers=["1"],
+            address="/a",
+            args=["[x]"],
+            enabled=True,
+        ),
+    ]
+    save_config(cfg, cfg_path)
+    return cfg
+
+
+def test_section_render_shows_the_fault_reason_on_the_collapsed_row(live_server) -> None:
+    """The reason is visible text, not only the dot's accessible name."""
+    _, base, cfg_path = live_server
+    _seed_fault_rows(cfg_path)
+    status, body = _get(base, "/section/osc_bindings")
+    assert status == 200
+    assert "Grid Maximum Height not set" in body
+    assert "No destination" in body
+    assert "Marker 9 not registered" in body
+
+
+def test_section_render_separates_faults_with_a_middle_dot(live_server) -> None:
+    _, base, cfg_path = live_server
+    _seed_fault_rows(cfg_path)
+    _, body = _get(base, "/section/osc_bindings")
+    assert "No destination \u00b7 No default marker" in body or "No destination · No default marker" in body
+
+
+def test_section_render_hides_the_dot_from_assistive_tech_when_a_fault_shows(live_server) -> None:
+    """The badge speaks for a broken row, so the dot must not repeat it.
+    A healthy row keeps its accessible name, or its state goes silent."""
+    _, base, cfg_path = live_server
+    _seed_fault_rows(cfg_path)
+    _, body = _get(base, "/section/osc_bindings")
+    assert '<span class="osc-binding-enabled-dot invalid" aria-hidden="true">' in body
+    assert 'aria-label="Enabled"' in body
+    assert 'aria-label="Invalid OSC message"' not in body
+
+
+def test_section_render_gives_assistive_tech_the_untruncated_fault_list(live_server) -> None:
+    """The badge caps at three; the hidden list must carry all of them so
+    a screen-reader user never gets the truncated set."""
+    _, base, cfg_path = live_server
+    cfg = load_config(cfg_path)
+    cfg.controlled_marker_ids = [1]
+    cfg.grid.max_height = 0.0
+    cfg.osc_destinations.destinations = []
+    cfg.osc_transmitters.transmitters = [
+        OscTransmitterConfig(
+            id="r-overflow",
+            name="Overflow",
+            destination_id="",
+            markers=["7"],
+            address="/a",
+            args=["[x]", "[y:9]", "[z:1.frac]"],
+        ),
+    ]
+    save_config(cfg, cfg_path)
+    _, body = _get(base, "/section/osc_bindings")
+    assert "+2 more errors" in body
+    hidden = re.search(r'<span class="visually-hidden">([^<]*Grid Maximum Height not set[^<]*)</span>', body)
+    assert hidden is not None, "untruncated fault list missing"
+    for expected in (
+        "No destination",
+        "No controlled marker",
+        "No default marker",
+        "Marker 9 not registered",
+        "Grid Maximum Height not set",
+    ):
+        assert expected in hidden.group(1), expected

--- a/tests/test_web_osc_bindings.py
+++ b/tests/test_web_osc_bindings.py
@@ -47,6 +47,7 @@ from openfollow.web.routes import (
     _parse_trigger_subtable,
     _row_fault_labels,
     _row_fault_summary,
+    _row_unresolved_entries,
     _row_unresolved_placeholders,
     _virtual_fader_names_for_form,
 )
@@ -3617,10 +3618,9 @@ _DESTS = frozenset({"eos"})
 def _faults(row, *, markers_unusable=False, registered=frozenset({1}), grid=8.0):  # noqa: ANN001, ANN202, B008
     return _row_fault_labels(
         row,
+        entries=_row_unresolved_entries(row, registered, grid_max_height=grid),
         destination_ids=_DESTS,
         markers_unusable=markers_unusable,
-        registered_marker_ids=registered,
-        grid_max_height=grid,
     )
 
 
@@ -3645,6 +3645,15 @@ def test_fault_labels_report_missing_or_dangling_destination(destination_id: str
 @pytest.mark.unit
 def test_fault_labels_report_unusable_markers() -> None:
     assert _faults(_row(args=["[x]"]), markers_unusable=True) == ("No controlled marker",)
+
+
+@pytest.mark.unit
+def test_fault_labels_do_not_repeat_one_fix_as_two_problems() -> None:
+    """An unusable marker list is *why* a bare ``[x]`` has no default, so
+    naming both spends one of three slots restating a single fix."""
+    out = _faults(_row(args=["[x]"]), markers_unusable=True, registered=frozenset())
+    assert out == ("No controlled marker",)
+    assert "No default marker" not in out
 
 
 @pytest.mark.unit
@@ -3710,14 +3719,15 @@ def test_fault_labels_can_report_both_a_marker_and_a_grid_cause() -> None:
 )
 def test_fault_summary_caps_at_three_and_counts_the_rest(count: int, expected_more: str) -> None:
     faults = tuple(f"problem {i}" for i in range(count))
-    visible, more = _row_fault_summary(faults)
+    visible, more, full = _row_fault_summary(faults)
     assert visible == faults[:3]
     assert more == expected_more
+    assert full == faults, "the untruncated list must survive for assistive tech"
 
 
 @pytest.mark.unit
 def test_fault_summary_of_no_faults_is_empty() -> None:
-    assert _row_fault_summary(()) == ((), "")
+    assert _row_fault_summary(()) == ((), "", ())
 
 
 def _seed_fault_rows(cfg_path):  # noqa: ANN001, ANN202
@@ -3773,7 +3783,7 @@ def test_section_render_separates_faults_with_a_middle_dot(live_server) -> None:
     _, base, cfg_path = live_server
     _seed_fault_rows(cfg_path)
     _, body = _get(base, "/section/osc_bindings")
-    assert "No destination \u00b7 No default marker" in body or "No destination · No default marker" in body
+    assert "No destination · No default marker" in body
 
 
 def test_section_render_hides_the_dot_from_assistive_tech_when_a_fault_shows(live_server) -> None:
@@ -3807,14 +3817,76 @@ def test_section_render_gives_assistive_tech_the_untruncated_fault_list(live_ser
     ]
     save_config(cfg, cfg_path)
     _, body = _get(base, "/section/osc_bindings")
-    assert "+2 more errors" in body
+    assert "+1 more error" in body
     hidden = re.search(r'<span class="visually-hidden">([^<]*Grid Maximum Height not set[^<]*)</span>', body)
     assert hidden is not None, "untruncated fault list missing"
     for expected in (
         "No destination",
         "No controlled marker",
-        "No default marker",
         "Marker 9 not registered",
         "Grid Maximum Height not set",
     ):
         assert expected in hidden.group(1), expected
+    assert "No default marker" not in hidden.group(1), "duplicate of 'No controlled marker'"
+
+
+@pytest.mark.unit
+def test_every_unresolved_reason_produces_a_fault_label() -> None:
+    """The row's red state is ``bool(faults)``. A cause with no label
+    would render a row that can never fire as healthy, so the label set
+    has to keep up with the alias."""
+    from openfollow.osc.template import UnresolvedPlaceholder, UnresolvedReason
+
+    row = _row(args=["[x]"])
+    for reason in get_args(UnresolvedReason):
+        marker_id = 9 if reason == "explicit_marker" else None
+        entry = UnresolvedPlaceholder("[x:9]" if marker_id else "[x]", reason, marker_id)
+        out = _row_fault_labels(
+            row,
+            entries=(entry,),
+            destination_ids=_DESTS,
+            markers_unusable=False,
+        )
+        assert out, f"{reason} produced no fault label"
+
+
+@pytest.mark.unit
+def test_badge_and_blur_message_share_one_cause_order() -> None:
+    """Both surfaces iterate ``_UNRESOLVED_CAUSE_ORDER``; if they drifted
+    the badge would lead with a different problem than the message
+    inside the row."""
+    from openfollow.osc.template import UnresolvedPlaceholder
+
+    entries = (
+        UnresolvedPlaceholder("[z.frac]", "grid_height", None),
+        UnresolvedPlaceholder("[y:9]", "explicit_marker", 9),
+        UnresolvedPlaceholder("[x]", "default_marker", None),
+    )
+    labels = _row_fault_labels(_row(args=["[x]"]), entries=entries, destination_ids=_DESTS, markers_unusable=False)
+    assert labels == (
+        "No default marker",
+        "Marker 9 not registered",
+        "Grid Maximum Height not set",
+    )
+    blur = _osc_binding_unresolved_blur_error(
+        {"osc_message": "/a [z:1.frac] [y:9] [x]", "markers": ""},
+        _blur_cfg((1,), 0.0),
+    )
+    assert blur is not None
+    order = [blur.index(p) for p in ("needs a default marker", "isn't registered", "Maximum Height")]
+    assert order == sorted(order), "blur message order diverged from the badge"
+
+
+@pytest.mark.unit
+def test_fault_label_for_an_explicit_marker_entry_without_its_id() -> None:
+    """A malformed entry must still name the fault rather than render a
+    blank id or, worse, no label at all."""
+    from openfollow.osc.template import UnresolvedPlaceholder
+
+    out = _row_fault_labels(
+        _row(args=["[x:9]"]),
+        entries=(UnresolvedPlaceholder("[x:9]", "explicit_marker", None),),
+        destination_ids=_DESTS,
+        markers_unusable=False,
+    )
+    assert out == ("Marker not registered",)


### PR DESCRIPTION
Follow-on to #111. That PR fixed the *wording* of an unresolved-placeholder message; this one fixes where the operator finds it at all.

## The problem

A broken OSC row shows a red dot. The reason was computed in the template purely for the dot's `aria-label`, so it reached screen readers and nobody else — and it flattened three distinct placeholder faults into `Invalid OSC message`. An operator asking "why is this not working" had to expand the row and hunt.

## What the row shows now

Every reason, in fix order, separated by `·`, capped at three with the rest counted:

| Row state | Badge |
|---|---|
| Dangling destination | `No destination` |
| `[z.frac]`, `max_height` 0 | `Grid Maximum Height not set` |
| `[x:9]` and `[y:12]` unregistered | `Markers 9, 12 not registered` |
| Fresh row, nothing configured | `No destination · No controlled marker · No default marker` |
| …plus a grid fault | `… No default marker` `+2 more errors` |

Showing **all** faults rather than the first is deliberate: fixing one and only then discovering the next is what made this feel like guesswork.

Unregistered markers are named, not described, and grouped into one entry because registering them is one action. The id travels from the compiled slot through `unresolved_placeholder_reasons` — it is never re-parsed out of the token text, which is the inference #111 removed.

## Structure

- The precedence chain moves from the template into `_row_fault_labels`, where every combination is testable at a boundary the suite reaches. It was previously untestable template logic.
- The placeholder causes keep the blur message's order, so the badge and the message inside the row never lead with different problems.
- Each row is scanned once; the pill list, the tooltip's cause map and the labels all derive from that one scan.

## Accessibility

When a fault shows, the dot stops announcing (the badge speaks) and a visually-hidden sibling carries the **untruncated** list, so a screen-reader user never receives the capped set. A healthy row keeps its `Enabled` / `Disabled` label rather than going silent.

## Testing

Unit tests per fault, every combination, ordering independent of argument order, id grouping and sorting, the three-cap, and singular/plural. Render tests for the badge, the separator, the dot's ARIA contract and the untruncated hidden list.

Six mutations, each caught: raising the cap, un-sorting the ids, forcing the plural, reordering the causes, restoring the dot's `aria-label`, and dropping the carried marker id.

`make ci-remote` green on the Pi (aarch64): 1016 passed, 100% coverage, build clean.

## Scope

Config-time faults only. A correctly configured row failing at *runtime* — stale marker, unreachable destination, unregistered fader — still shows a plain amber dot. That needs live status polling and is the natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
