### PR TITLE
build(deps): pin the PyGObject floor to the binding the package runs on

### DIFF
--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -17,12 +17,15 @@ is Pi-only).
 > **GObject-Introspection stack is the OS's, not bundled.** The venv is created
 > with `--system-site-packages` and the pip-built `PyGObject`/`pycairo` are
 > removed, so `gi` / GStreamer come from the distro packages (`python3-gi`,
-> `python3-gi-cairo`, the `gir1.2-*` typelibs). Reason: pip
-> resolves `PyGObject>=3.56` (the new **girepository-2.0** ABI), which Debian
+> `python3-gi-cairo`, the `gir1.2-*` typelibs). Reason: pip resolves the newest
+> `PyGObject` (the **girepository-2.0** ABI), which Debian
 > Trixie (`python3-gi 3.50` on `libgirepository-1.0-1`) cannot load –
 > `ImportError: libgirepository-2.0.so.0`. Using the OS bindings keeps the
 > bindings, the typelibs and `libgirepository` coherent. Everything else (numpy,
 > pygame, bottle, mido, the openfollow package, …) is still bundled in the venv.
+> The `PyGObject` floor in `pyproject.toml` therefore tracks what `python3-gi`
+> ships, not what pip would pick: a higher floor would declare the configuration
+> shipped here unsupported. `tests/test_system_dependencies.py` guards it.
 >
 > **Do not add `python3-gst-1.0` to `Depends`.** Its `gi/overrides/Gst.py`
 > makes `Gst.Caps.get_structure()` return a `StructureWrapper` that lacks

--- a/poetry.lock
+++ b/poetry.lock
@@ -4047,4 +4047,4 @@ export = ["ultralytics"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "8fba7201275c33c82a865d01b7b78687a035d04eb765cdf27b39df8c3acc483c"
+content-hash = "3a9e5c59f25e2c28979bae96003a24019c7842ced5676e4eeba6479691a0a41c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ dependencies = [
     "bottle>=0.12",
     "pygame>=2.5.0",
     "multicast-expert>=1.4",
-    "PyGObject>=3.58.0",
+    # Floor is what Debian Trixie's python3-gi ships: a packaged install runs the
+    # OS bindings, not the pip build (packaging/build-deb.sh drops the pip copy).
+    "PyGObject>=3.50",
     "psutil>=5.9",
     "python-osc>=1.10.2",
     # USB MIDI support. mido is pure Python; python-rtmidi is C++ extension

--- a/tests/test_system_dependencies.py
+++ b/tests/test_system_dependencies.py
@@ -9,6 +9,11 @@ inputs too, so a pipeline refactor that drops those could remove it by accident
 and silently kill WebP uploads. Pin it to the gallery here, in both the .deb
 ``Depends`` and the manual install script, so removing it fails CI rather than
 the feature.
+
+The PyGObject floor is the same shape of invariant read the other way: a
+packaged install runs the OS bindings, so a floor above what the distro ships
+declares the shipped configuration unsupported and forces ``pip install`` into
+a source build to reach a state that already works.
 """
 
 from __future__ import annotations
@@ -16,12 +21,17 @@ from __future__ import annotations
 import pathlib
 
 import pytest
+import tomllib
 
 pytestmark = pytest.mark.unit
 
 _ROOT = pathlib.Path(__file__).resolve().parent.parent
 _CONTROL = _ROOT / "packaging" / "debian" / "control.in"
 _INSTALL = _ROOT / "scripts" / "install-system-deps.sh"
+_PYPROJECT = _ROOT / "pyproject.toml"
+
+# python3-gi on Debian Trixie, the binding a packaged install actually imports.
+_OS_PYGOBJECT_VERSION = (3, 50, 0)
 
 # Provides webpdec/webpenc (Media Gallery WebP) and srtsrc (SRT input). It is a
 # dedicated dependency of WebP support, not only of the current input pipeline.
@@ -37,4 +47,29 @@ def test_webp_package_declared_in_deb_depends() -> None:
 def test_webp_package_declared_in_install_script() -> None:
     assert _WEBP_PACKAGE in _INSTALL.read_text(), (
         f"{_WEBP_PACKAGE} provides webpdec for the Media Gallery; it must stay in install-system-deps.sh."
+    )
+
+
+def _version_tuple(text: str) -> tuple[int, int, int]:
+    parts = [int(part) for part in text.split(".")]
+    parts += [0] * (3 - len(parts))
+    return parts[0], parts[1], parts[2]
+
+
+def _declared_pygobject_floor() -> tuple[int, int, int]:
+    dependencies = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))["project"]["dependencies"]
+    specs = [spec for spec in dependencies if spec.lower().replace("-", "").startswith("pygobject")]
+    assert len(specs) == 1, f"expected exactly one PyGObject dependency, found {specs}."
+    floor = specs[0].partition(">=")[2].strip()
+    assert floor, f"PyGObject must declare a >= floor so this guard can read it, got {specs[0]!r}."
+    return _version_tuple(floor)
+
+
+def test_pygobject_floor_does_not_exceed_os_binding() -> None:
+    """The declared floor must not rule out the binding the packaged app runs on."""
+    assert _declared_pygobject_floor() <= _OS_PYGOBJECT_VERSION, (
+        "The PyGObject floor in pyproject.toml is above the python3-gi that Debian Trixie ships "
+        f"({'.'.join(str(part) for part in _OS_PYGOBJECT_VERSION)}), which is the binding a packaged "
+        "install imports - build-deb.sh drops the pip-built copy. Raising the floor declares the "
+        "shipped configuration unsupported and forces a source build to reach a working state."
     )


### PR DESCRIPTION
The declared `PyGObject` floor had drifted above the binding a packaged install actually imports, ruling out the configuration this project ships.

## What was wrong

A packaged install runs the **OS** bindings, not the pip build. `packaging/build-deb.sh` installs the dependency closure, then uninstalls the pip-built `PyGObject` / `pycairo` and enables system site-packages, so `gi` and GStreamer come from the distro packages. On Debian Trixie that is `python3-gi` **3.50.0** (confirmed on the test Pi: `python3-gi 3.50.0-4+b1`). `packaging/debian/control.in` depends on it directly.

Meanwhile `pyproject.toml` declared `PyGObject>=3.58.0`. So the floor said the shipped, working configuration was unsupported, and `pip install openfollow` on a Trixie host was pushed into a source build of 3.58 to reach a state 3.50 already satisfies.

The floor had never moved on its own account: it entered at the initial public release as `>=3.56.3` and was raised exactly once, inside a grouped dependency PR titled as a ruff bump. That is also the shape in which it would have kept drifting, weekly.

## The change

`PyGObject>=3.50`, matching what `python3-gi` provides, with a comment naming why.

This changes no resolution anywhere. A floor is a minimum and there is no upper bound, so pip still picks the newest release; `poetry.lock` stays on 3.58.0 and moves by its content hash alone. Verified separately that 3.58.0 still builds from sdist on the aarch64 Pi target, so nothing about the dev path regresses either.

## The guard

`tests/test_system_dependencies.py` reads the floor out of `pyproject.toml` and fails when it exceeds the OS binding, so the next raise fails CI rather than arriving under an unrelated title. It sits beside `tests/test_lint_toolchain_pin.py`, which holds the same shape of invariant between `pyproject.toml` and the pre-commit hook.

Every assertion was mutation-checked: the floor back at `>=3.58.0`, at `>=3.51`, at `>=3.50.1` (a single patch above), and removed entirely all fail; `>=3.49` passes.

## Known limitation

This does **not** remove the wasted sdist compile during the `.deb` build. With no upper bound pip still fetches the newest `PyGObject` and `build-deb.sh` still discards it. Removing that means changing how the venv is populated, which is a larger change and deliberately not bundled here.

## Verification

`make ci-remote` green on the aarch64 Pi target: 1028 passed at 100% coverage, e2e smoke, build clean. The `docs/PACKAGING.md` edit landed after the rsync, so the gate did not cover it; a Markdown change is inert to lint, test and build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)