### PR TITLE
fix(otp): bind one Component Name per folio and advertisement burst

### DIFF
--- a/openfollow/otp/server.py
+++ b/openfollow/otp/server.py
@@ -13,6 +13,7 @@ import struct
 import threading
 import time
 from collections.abc import Callable, Sequence
+from typing import NamedTuple
 from uuid import uuid4
 
 import multicast_expert
@@ -520,6 +521,14 @@ def encode_otp_system_advertisement_packet(
 # ---------------------------------------------------------------------------
 
 
+class _ComponentIdentity(NamedTuple):
+    """Who a folio says it came from – constant across its pages."""
+
+    name: str
+    system_number: int
+    priority: int
+
+
 class OtpServer:
     """Sends ANSI E1.59 OTP marker position data via multicast UDP.
 
@@ -718,15 +727,18 @@ class OtpServer:
         stale config.
         """
         self.stop()
-        self._system_name = system_name
-        self._system_number = system_number
-        self._port = port
-        self._source_ip = source_ip.strip()
-        self._priority = priority
-        # Recompute destinations for the new system_number.
-        self._transform_dest, self._advertisement_dest = self._resolve_destinations()
-        if self._mcast_ip_override is None:
-            self._mcast_ip = self._transform_dest
+        # Locked because stop() logs and continues past a send thread that
+        # outlived its join, and that survivor reads the identity under it.
+        with self._lock:
+            self._system_name = system_name
+            self._system_number = system_number
+            self._port = port
+            self._source_ip = source_ip.strip()
+            self._priority = priority
+            # Recompute destinations for the new system_number.
+            self._transform_dest, self._advertisement_dest = self._resolve_destinations()
+            if self._mcast_ip_override is None:
+                self._mcast_ip = self._transform_dest
         self.start()
         if self._is_multicast_mode() and self._socket is None:
             self.stop()
@@ -898,10 +910,18 @@ class OtpServer:
             self._send_advertisement_packets(stop)
             stop.wait(ADVERTISEMENT_INTERVAL_S)
 
-    def _snapshot_component(self) -> tuple[str, list[Marker]]:
-        """Return the Component Name and the marker list from one lock hold."""
+    def _snapshot_identity(self) -> tuple[_ComponentIdentity, list[Marker]]:
+        """Return the Component identity and the marker list from one lock hold.
+
+        Every identity field sits outside the split point list, so Sections
+        6.7-6.9 have it repeat verbatim on every page. Callers must bind the
+        result to locals and encode from those: reading an attribute inside a
+        per-page closure is what lets ``restart`` split one folio across two
+        identities.
+        """
         with self._lock:
-            return self._system_name, list(self._markers.values())
+            identity = _ComponentIdentity(self._system_name, self._system_number, self._priority)
+            return identity, list(self._markers.values())
 
     def _next_folio(self, name: str) -> int:
         attr = f"_{name}_folio"
@@ -982,9 +1002,9 @@ class OtpServer:
             return self._oversize_drops
 
     def _send_transform_packet(self, stop_event: threading.Event | None = None) -> None:
-        # Name and markers from one hold, and the name bound to a local: a rename
-        # between pages would otherwise put two Component Names in one folio.
-        name, markers = self._snapshot_component()
+        # Bound to locals, never re-read per page: the identity describes the
+        # folio, so a page contradicting its siblings describes no point set.
+        identity, markers = self._snapshot_identity()
         if not markers:
             return
         folio = self._next_folio("transform")
@@ -997,12 +1017,12 @@ class OtpServer:
         def encode(page_markers: Sequence[Marker], page: int, last_page: int) -> bytes:
             return encode_otp_transform_packet(
                 cid=self._cid,
-                component_name=name,
+                component_name=identity.name,
                 folio=folio,
-                system_number=self._system_number,
+                system_number=identity.system_number,
                 timestamp_us=timestamp_us,
                 markers=list(page_markers),
-                priority=self._priority,
+                priority=identity.priority,
                 page=page,
                 last_page=last_page,
                 now_us=now_us,
@@ -1012,16 +1032,13 @@ class OtpServer:
 
     def _send_advertisement_packets(self, stop_event: threading.Event | None = None) -> None:
         """Send Module, Name, and System advertisement packets in sequence."""
-        # One name for the whole burst, for the same reason the transform folio
-        # binds one: a rename landing mid-burst would advertise this Component
-        # under two names in a single cycle.
-        name, markers = self._snapshot_component()
+        identity, markers = self._snapshot_identity()
 
         if markers:
             self._send(
                 encode_otp_module_advertisement_packet(
                     cid=self._cid,
-                    component_name=name,
+                    component_name=identity.name,
                     folio=self._next_folio("module_adv"),
                 ),
                 self._advertisement_dest,
@@ -1036,9 +1053,9 @@ class OtpServer:
             def encode_names(page_markers: Sequence[Marker], page: int, last_page: int) -> bytes:
                 return encode_otp_name_advertisement_packet(
                     cid=self._cid,
-                    component_name=name,
+                    component_name=identity.name,
                     folio=name_folio,
-                    system_number=self._system_number,
+                    system_number=identity.system_number,
                     markers=list(page_markers),
                     page=page,
                     last_page=last_page,
@@ -1049,15 +1066,17 @@ class OtpServer:
         self._send(
             encode_otp_system_advertisement_packet(
                 cid=self._cid,
-                component_name=name,
+                component_name=identity.name,
                 folio=self._next_folio("system_adv"),
-                system_number=self._system_number,
+                system_number=identity.system_number,
             ),
             self._advertisement_dest,
             stop_event,
         )
 
     def _send(self, data: bytes, dest_ip: str, stop_event: threading.Event | None = None) -> None:
+        # Deliberately unlocked: locking would serialise every datagram behind
+        # the socket hand-over. A send racing teardown sends, returns, or fails.
         sock = self._socket
         if sock is None:
             return

--- a/openfollow/otp/server.py
+++ b/openfollow/otp/server.py
@@ -898,9 +898,10 @@ class OtpServer:
             self._send_advertisement_packets(stop)
             stop.wait(ADVERTISEMENT_INTERVAL_S)
 
-    def _snapshot_markers(self) -> list[Marker]:
+    def _snapshot_component(self) -> tuple[str, list[Marker]]:
+        """Return the Component Name and the marker list from one lock hold."""
         with self._lock:
-            return list(self._markers.values())
+            return self._system_name, list(self._markers.values())
 
     def _next_folio(self, name: str) -> int:
         attr = f"_{name}_folio"
@@ -981,7 +982,9 @@ class OtpServer:
             return self._oversize_drops
 
     def _send_transform_packet(self, stop_event: threading.Event | None = None) -> None:
-        markers = self._snapshot_markers()
+        # Name and markers from one hold, and the name bound to a local: a rename
+        # between pages would otherwise put two Component Names in one folio.
+        name, markers = self._snapshot_component()
         if not markers:
             return
         folio = self._next_folio("transform")
@@ -994,7 +997,7 @@ class OtpServer:
         def encode(page_markers: Sequence[Marker], page: int, last_page: int) -> bytes:
             return encode_otp_transform_packet(
                 cid=self._cid,
-                component_name=self._system_name,
+                component_name=name,
                 folio=folio,
                 system_number=self._system_number,
                 timestamp_us=timestamp_us,
@@ -1009,13 +1012,16 @@ class OtpServer:
 
     def _send_advertisement_packets(self, stop_event: threading.Event | None = None) -> None:
         """Send Module, Name, and System advertisement packets in sequence."""
-        markers = self._snapshot_markers()
+        # One name for the whole burst, for the same reason the transform folio
+        # binds one: a rename landing mid-burst would advertise this Component
+        # under two names in a single cycle.
+        name, markers = self._snapshot_component()
 
         if markers:
             self._send(
                 encode_otp_module_advertisement_packet(
                     cid=self._cid,
-                    component_name=self._system_name,
+                    component_name=name,
                     folio=self._next_folio("module_adv"),
                 ),
                 self._advertisement_dest,
@@ -1030,7 +1036,7 @@ class OtpServer:
             def encode_names(page_markers: Sequence[Marker], page: int, last_page: int) -> bytes:
                 return encode_otp_name_advertisement_packet(
                     cid=self._cid,
-                    component_name=self._system_name,
+                    component_name=name,
                     folio=name_folio,
                     system_number=self._system_number,
                     markers=list(page_markers),
@@ -1043,7 +1049,7 @@ class OtpServer:
         self._send(
             encode_otp_system_advertisement_packet(
                 cid=self._cid,
-                component_name=self._system_name,
+                component_name=name,
                 folio=self._next_folio("system_adv"),
                 system_number=self._system_number,
             ),

--- a/openfollow/psn/server.py
+++ b/openfollow/psn/server.py
@@ -471,10 +471,8 @@ class PsnServer:
         self._send_frame(self._next_info_frame_id(), trackers, encode, stop_event)
 
     def _send(self, data: bytes, stop_event: threading.Event | None = None) -> None:
-        # Read unlocked on purpose: a plain atomic reference captured to a local,
-        # with no ordering against the handover in stop() / _open_multicast_socket.
-        # A send racing teardown either uses the old socket or returns; taking the
-        # lock here would serialise every datagram behind that hand-over instead.
+        # Deliberately unlocked: locking would serialise every datagram behind
+        # the socket hand-over. A send racing teardown sends, returns, or fails.
         sock = self._socket
         if sock is None:
             return

--- a/openfollow/psn/server.py
+++ b/openfollow/psn/server.py
@@ -433,6 +433,11 @@ class PsnServer:
         with self._lock:
             return list(self._markers.values())
 
+    def _snapshot_info(self) -> tuple[str, list[Marker]]:
+        """Return the announced name and the marker list from one lock hold."""
+        with self._lock:
+            return self._system_name, list(self._markers.values())
+
     def _send_data_packet(self, stop_event: threading.Event | None = None) -> None:
         markers = self._snapshot_markers()
         if not markers:
@@ -453,11 +458,10 @@ class PsnServer:
         self._send_frame(self._next_data_frame_id(), trackers, encode, stop_event)
 
     def _send_info_packet(self, stop_event: threading.Event | None = None) -> None:
-        markers = self._snapshot_markers()
+        name, markers = self._snapshot_info()
         if not markers:
             return
         trackers = [t.to_psn_marker_info() for t in markers]
-        name = self._system_name
 
         def encode(info: pypsn.PsnInfo, chunk: Sequence[pypsn.PsnTrackerInfo]) -> bytes:
             packet = pypsn.PsnInfoPacket(info=info, name=name, trackers=list(chunk))
@@ -467,6 +471,10 @@ class PsnServer:
         self._send_frame(self._next_info_frame_id(), trackers, encode, stop_event)
 
     def _send(self, data: bytes, stop_event: threading.Event | None = None) -> None:
+        # Read unlocked on purpose: a plain atomic reference captured to a local,
+        # with no ordering against the handover in stop() / _open_multicast_socket.
+        # A send racing teardown either uses the old socket or returns; taking the
+        # lock here would serialise every datagram behind that hand-over instead.
         sock = self._socket
         if sock is None:
             return

--- a/openfollow/services.py
+++ b/openfollow/services.py
@@ -1590,9 +1590,8 @@ class AppRuntimeServices:
         Touches:
 
         - ``PsnServer._system_name`` (info packet name field)
-        - ``OtpServer._system_name`` (held for parity; encoders don't
-          read it today, but keeping it in sync prevents drift if a
-          future advertisement PDU gains a name field)
+        - ``OtpServer._system_name`` (the Component Name field every
+          transform and advertisement packet carries, Section 6.12)
         - ``ConfigWebServer.update_system_name`` (web beacon)
         - the GTK window title via ``_apply_window_title``
 

--- a/tests/test_otp.py
+++ b/tests/test_otp.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import struct
 import threading
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -999,11 +1000,74 @@ class TestOtpOverrideMcastIp:
         assert "239.159.2.1" in groups
 
 
+# Component Name sits at a fixed offset in the OTP Layer (Table 6-3): packet
+# identifier(12) + vector/length(4) + footer options/length(2) + CID(16) +
+# folio(4) + page/last page(4) + options(1) + reserved(4).
+_COMPONENT_NAME_START = 47
+_COMPONENT_NAME_END = _COMPONENT_NAME_START + COMPONENT_NAME_OCTETS
+
+
+def _component_name_of(payload: bytes) -> str:
+    """Read the Component Name a packet actually carries on the wire."""
+    return payload[_COMPONENT_NAME_START:_COMPONENT_NAME_END].rstrip(b"\x00").decode("utf-8")
+
+
+class _RenamingServer(OtpServer):
+    """Renames itself on every read of ``_system_name``.
+
+    Stands in for an operator rename landing mid-send. Any send path that
+    reads the name more than once per call will encode two different
+    Component Names, which is what these tests look for.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self._reads = 0
+        super().__init__(*args, **kwargs)
+
+    @property
+    def _system_name(self) -> str:
+        self._reads += 1
+        return f"Name{self._reads}"
+
+    @_system_name.setter
+    def _system_name(self, value: str) -> None:
+        self._name_value = value
+
+
 class TestOtpUpdateSystemName:
     def test_updates_system_name_under_lock(self) -> None:
         srv = OtpServer(system_name="Old")
         srv.update_system_name("New")
         assert srv._system_name == "New"
+
+    def test_advertisement_burst_carries_one_component_name(self) -> None:
+        """Module, Name and System advertisements describe one Component,
+        so a rename mid-burst must not split them across two identities."""
+        srv = _RenamingServer(system_number=1)
+        srv._socket = MagicMock()
+        srv.register_marker(_marker(1))
+
+        srv._send_advertisement_packets()
+
+        sent = [call[0][0] for call in srv._socket.sendto.call_args_list]
+        assert len(sent) == 3
+        assert len({_component_name_of(p) for p in sent}) == 1
+
+    def test_transform_folio_pages_carry_one_component_name(self) -> None:
+        """Section 6.7-6.9: everything outside the split point list repeats
+        verbatim on every page of a folio. A page disagreeing with its
+        siblings about who sent it describes no coherent point set."""
+        srv = _RenamingServer(system_number=1)
+        srv._socket = MagicMock()
+        for marker_id in range(1, 61):
+            srv.register_marker(_marker(marker_id))
+
+        srv._send_transform_packet()
+
+        pages = [call[0][0] for call in srv._socket.sendto.call_args_list]
+        # Guard the premise: a single-page folio could not show the defect.
+        assert len(pages) > 1
+        assert len({_component_name_of(p) for p in pages}) == 1
 
 
 class TestOtpStartFailsAndSpawnsRetryThread:

--- a/tests/test_otp.py
+++ b/tests/test_otp.py
@@ -70,6 +70,25 @@ def _marker(
     return t
 
 
+# Component Name sits at a fixed offset in the OTP Layer (Table 6-3): packet
+# identifier(12) + vector/length(4) + footer options/length(2) + CID(16) +
+# folio(4) + page/last page(4) + options(1) + reserved(4). The field-layout
+# tests below spell the offset out literally on purpose – one derived from
+# this constant could not catch the constant being wrong.
+_COMPONENT_NAME_START = 47
+_COMPONENT_NAME_END = _COMPONENT_NAME_START + COMPONENT_NAME_OCTETS
+
+
+def _component_name_of(payload: bytes) -> str:
+    """Read the Component Name a packet actually carries on the wire."""
+    return payload[_COMPONENT_NAME_START:_COMPONENT_NAME_END].rstrip(b"\x00").decode("utf-8")
+
+
+def _system_number_of(transform_payload: bytes) -> int:
+    """Read the Transform Layer's System Number (Section 8.3)."""
+    return transform_payload[_COMPONENT_NAME_END + 4]
+
+
 # ===========================================================================
 # Constants – sanity-check the values match Appendix A of the standard.
 # ===========================================================================
@@ -1000,38 +1019,36 @@ class TestOtpOverrideMcastIp:
         assert "239.159.2.1" in groups
 
 
-# Component Name sits at a fixed offset in the OTP Layer (Table 6-3): packet
-# identifier(12) + vector/length(4) + footer options/length(2) + CID(16) +
-# folio(4) + page/last page(4) + options(1) + reserved(4).
-_COMPONENT_NAME_START = 47
-_COMPONENT_NAME_END = _COMPONENT_NAME_START + COMPONENT_NAME_OCTETS
+class _DriftingIdentityServer(OtpServer):
+    """Changes its identity on every read of ``_system_name`` / ``_system_number``.
 
-
-def _component_name_of(payload: bytes) -> str:
-    """Read the Component Name a packet actually carries on the wire."""
-    return payload[_COMPONENT_NAME_START:_COMPONENT_NAME_END].rstrip(b"\x00").decode("utf-8")
-
-
-class _RenamingServer(OtpServer):
-    """Renames itself on every read of ``_system_name``.
-
-    Stands in for an operator rename landing mid-send. Any send path that
-    reads the name more than once per call will encode two different
-    Component Names, which is what these tests look for.
+    Stands in for a ``restart`` landing mid-send. Any send path that reads
+    an identity field more than once per call encodes two identities, which
+    is what these tests look for.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self._reads = 0
+        self._name_reads = 0
+        self._number_reads = 0
         super().__init__(*args, **kwargs)
 
     @property
     def _system_name(self) -> str:
-        self._reads += 1
-        return f"Name{self._reads}"
+        self._name_reads += 1
+        return f"Name{self._name_reads}"
 
     @_system_name.setter
     def _system_name(self, value: str) -> None:
         self._name_value = value
+
+    @property
+    def _system_number(self) -> int:
+        self._number_reads += 1
+        return self._number_reads
+
+    @_system_number.setter
+    def _system_number(self, value: int) -> None:
+        self._number_value = value
 
 
 class TestOtpUpdateSystemName:
@@ -1040,10 +1057,25 @@ class TestOtpUpdateSystemName:
         srv.update_system_name("New")
         assert srv._system_name == "New"
 
+    def test_rename_reaches_the_next_packets(self) -> None:
+        """Through the real property, not a probe: a rename has to land on
+        the wire, not just on the attribute."""
+        srv = OtpServer(system_number=1, system_name="Alpha")
+        srv._socket = MagicMock()
+        srv.register_marker(_marker(1))
+
+        srv.update_system_name("Bravo")
+        srv._send_transform_packet()
+        srv._send_advertisement_packets()
+
+        sent = [call[0][0] for call in srv._socket.sendto.call_args_list]
+        assert sent
+        assert {_component_name_of(p) for p in sent} == {"Bravo"}
+
     def test_advertisement_burst_carries_one_component_name(self) -> None:
         """Module, Name and System advertisements describe one Component,
         so a rename mid-burst must not split them across two identities."""
-        srv = _RenamingServer(system_number=1)
+        srv = _DriftingIdentityServer(system_number=1)
         srv._socket = MagicMock()
         srv.register_marker(_marker(1))
 
@@ -1057,7 +1089,7 @@ class TestOtpUpdateSystemName:
         """Section 6.7-6.9: everything outside the split point list repeats
         verbatim on every page of a folio. A page disagreeing with its
         siblings about who sent it describes no coherent point set."""
-        srv = _RenamingServer(system_number=1)
+        srv = _DriftingIdentityServer(system_number=1)
         srv._socket = MagicMock()
         for marker_id in range(1, 61):
             srv.register_marker(_marker(marker_id))
@@ -1068,6 +1100,7 @@ class TestOtpUpdateSystemName:
         # Guard the premise: a single-page folio could not show the defect.
         assert len(pages) > 1
         assert len({_component_name_of(p) for p in pages}) == 1
+        assert len({_system_number_of(p) for p in pages}) == 1
 
 
 class TestOtpStartFailsAndSpawnsRetryThread:

--- a/tests/test_psn_server_wire.py
+++ b/tests/test_psn_server_wire.py
@@ -563,9 +563,31 @@ class TestRebindMcastIp:
         srv.stop()
 
 
+class _UnlockedNameReadProbe(PsnServer):
+    """Counts reads of ``_system_name`` taken while ``_lock`` is not held.
+
+    The getter consults the lock but the setter does not: ``__init__``
+    assigns the attribute before ``_lock`` exists.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.unlocked_reads = 0
+        super().__init__(*args, **kwargs)
+
+    @property
+    def _system_name(self) -> str:
+        if not self._lock.locked():
+            self.unlocked_reads += 1
+        return self._name_value
+
+    @_system_name.setter
+    def _system_name(self, value: str) -> None:
+        self._name_value = value
+
+
 class TestUpdateSystemName:
     def test_in_place_mutation_no_socket_recycle(self) -> None:
-        """``update_system_name`` is a lock-protected attribute write –
+        """``update_system_name`` writes the attribute under the lock –
         no socket / thread recycle. The next info packet picks up the
         new name from ``_system_name``."""
         srv = PsnServer(system_name="Old")
@@ -574,6 +596,18 @@ class TestUpdateSystemName:
         # suite reading ``_send_info_packet`` with a bound sink.
         srv.update_system_name("New")
         assert srv._system_name == "New"
+
+    def test_info_packet_reads_the_name_under_the_lock(self) -> None:
+        """The write side takes ``_lock``; the read side has to as well,
+        or the lock orders nothing and a field added alongside the name
+        later would tear without any sign that it could."""
+        srv = _UnlockedNameReadProbe(system_name="Old")
+        srv.add_marker(1, "M1")
+        # Unstarted: ``_socket`` is None, so ``_send`` returns before
+        # touching the network. Encoding still reads the name.
+        srv._send_info_packet()
+
+        assert srv.unlocked_reads == 0
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_psn_server_wire.py
+++ b/tests/test_psn_server_wire.py
@@ -563,20 +563,23 @@ class TestRebindMcastIp:
         srv.stop()
 
 
-class _UnlockedNameReadProbe(PsnServer):
-    """Counts reads of ``_system_name`` taken while ``_lock`` is not held.
+class _NameReadProbe(PsnServer):
+    """Counts reads of ``_system_name``, split by whether ``_lock`` was held.
 
     The getter consults the lock but the setter does not: ``__init__``
     assigns the attribute before ``_lock`` exists.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.locked_reads = 0
         self.unlocked_reads = 0
         super().__init__(*args, **kwargs)
 
     @property
     def _system_name(self) -> str:
-        if not self._lock.locked():
+        if self._lock.locked():
+            self.locked_reads += 1
+        else:
             self.unlocked_reads += 1
         return self._name_value
 
@@ -588,25 +591,40 @@ class _UnlockedNameReadProbe(PsnServer):
 class TestUpdateSystemName:
     def test_in_place_mutation_no_socket_recycle(self) -> None:
         """``update_system_name`` writes the attribute under the lock –
-        no socket / thread recycle. The next info packet picks up the
-        new name from ``_system_name``."""
+        no socket / thread recycle."""
         srv = PsnServer(system_name="Old")
-        # No start() – we only assert the attribute mutation, not
-        # packet emission. The latter is covered by the integration
-        # suite reading ``_send_info_packet`` with a bound sink.
         srv.update_system_name("New")
         assert srv._system_name == "New"
+
+    def test_rename_reaches_the_next_info_packet(self) -> None:
+        """Through the real property, not a probe: a rename has to land on
+        the wire, not just on the attribute."""
+        srv = PsnServer(system_name="Alpha", mcast_ip="236.10.10.10")
+        srv._exit_stack = contextlib.ExitStack()
+        assert srv._try_open_multicast_socket_once(attempt=1) is True
+        srv.add_marker(1, "M1")
+
+        srv.update_system_name("Bravo")
+        srv._send_info_packet()
+
+        payload = srv._socket.sendto_calls[-1][0]  # type: ignore[union-attr]
+        assert b"Bravo" in payload
+        assert b"Alpha" not in payload
 
     def test_info_packet_reads_the_name_under_the_lock(self) -> None:
         """The write side takes ``_lock``; the read side has to as well,
         or the lock orders nothing and a field added alongside the name
         later would tear without any sign that it could."""
-        srv = _UnlockedNameReadProbe(system_name="Old")
+        srv = _NameReadProbe(system_name="Old")
         srv.add_marker(1, "M1")
         # Unstarted: ``_socket`` is None, so ``_send`` returns before
         # touching the network. Encoding still reads the name.
         srv._send_info_packet()
 
+        # Both halves: reading it under the lock, and reading it at all –
+        # a packet that stopped carrying the name would satisfy the
+        # unlocked count on its own.
+        assert srv.locked_reads >= 1
         assert srv.unlocked_reads == 0
 
 


### PR DESCRIPTION
Closes #97.

## What was wrong

`OtpServer`'s two send paths read `_system_name` from **inside their `encode` closures**, and `_encode_folio` invokes `encode` **once per page**. A rename landing mid-folio therefore emitted pages of one folio carrying **different Component Names** - which contradicts the invariant `_send_folio`'s own docstring states:

> Everything outside the split list repeats verbatim on every page ... a page that contradicted its siblings would describe no coherent point set at all.

`_send_advertisement_packets` read the name three more times across the module, name and system advertisements, so a single burst could advertise this Component under two identities.

The issue was filed about `PsnServer`, where the same setter exists without the consequence: `update_system_name` writes under `_lock` while the info-packet path read the attribute bare, so the lock ordered nothing. PSN frames cannot tear - the name is read once before the closure - but the next field added alongside it would have, with the existing lock making that look like an area where locking was already handled.

## What changed

- **OTP** - name and markers from one lock hold via `_snapshot_component`, name bound to a local the closures capture. Also closes the smaller window where `chunk_to_datagrams` measured a page with one name and `_encode_folio` re-encoded it with another. `_snapshot_markers` had no callers left and is removed.
- **PSN** - `_send_info_packet` reads both through `_snapshot_info`, so the write side's lock is honoured.
- **PSN `_socket`** - the class audit the issue asks for turned up one more attribute written under `_lock` and read bare. That one is correct as it stands (locking `_send` would serialise every datagram behind the socket hand-over), so it takes the issue's second direction and says so in a comment.

`RttrpmServer` carries no Component Name field, and `ConfigWebServer.update_system_name` takes no lock at all, so neither makes a false claim.

## Tests

Both are mutation-checked - reverting each fix makes them fail:

- `test_otp.py` - behavioural, asserting on the wire bytes. A server that renames itself on every `_system_name` read must still emit one Component Name across an advertisement burst and across the pages of one transform folio. Against the old code: `assert 2 == 1, where 2 = len({'Name63', 'Name64'})` - two names in one folio.
- `test_psn_server_wire.py` - the PSN side changes nothing observable, so the test encodes the contract directly: a probe counting reads of `_system_name` taken while `_lock` is unheld must see zero during `_send_info_packet`. A blocking test would not discriminate here, since `_snapshot_markers` already takes the lock first.

The existing `test_in_place_mutation_no_socket_recycle` docstring asserted "``update_system_name`` is a lock-protected attribute write" - the claim this PR makes true.

## Verification

`make ci-remote` - **CI PASSED** on pi66 (aarch64 / Python 3.13 / trixie), coverage 100.00%.

No hardware run needed: PSN frames are byte-identical, and OTP changes only in the mid-folio rename case, which is the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)