### PR TITLE
fix(net): bring marker sync back when the station interface returns

### DIFF
--- a/openfollow/app.py
+++ b/openfollow/app.py
@@ -799,13 +799,9 @@ class OpenFollowApp:
         # Sync follows the station interface, and stops with it: an empty
         # iface_ip joins the multicast group on whatever the OS picks, so a
         # station whose interface was down would trade marker names with peers
-        # over a network nobody chose.
-        #
-        # A dark interface yields None, which the sync holds as "stay silent".
-        # It is still constructed, because returning here instead left a
-        # station that BOOTED dark with no sync object at all - and the
-        # observer's recovery path can only repoint one that exists, so marker
-        # names never synced again until the next restart.
+        # over a network nobody chose. A dark interface yields None, which the
+        # sync holds as "stay silent" - constructed either way, because the
+        # observer's recovery path can only repoint a sync that exists.
         iface_ip = self._runtime_services.station_source_ip_or_none()
         sync = MarkerCatalogSync(
             self._marker_catalog,

--- a/openfollow/app.py
+++ b/openfollow/app.py
@@ -800,9 +800,13 @@ class OpenFollowApp:
         # iface_ip joins the multicast group on whatever the OS picks, so a
         # station whose interface was down would trade marker names with peers
         # over a network nobody chose.
+        #
+        # A dark interface yields None, which the sync holds as "stay silent".
+        # It is still constructed, because returning here instead left a
+        # station that BOOTED dark with no sync object at all - and the
+        # observer's recovery path can only repoint one that exists, so marker
+        # names never synced again until the next restart.
         iface_ip = self._runtime_services.station_source_ip_or_none()
-        if iface_ip is None:
-            return
         sync = MarkerCatalogSync(
             self._marker_catalog,
             self._config.station_id,

--- a/openfollow/marker_catalog/sync.py
+++ b/openfollow/marker_catalog/sync.py
@@ -485,6 +485,23 @@ class MarkerCatalogSync:
             raise
         return sock
 
+    def _wait_before_reopen(self, seconds: float) -> None:
+        """Back off after a failed TX open, without sleeping through a repoint.
+
+        Parked on the full interval this loop would ignore an address change
+        for up to a heartbeat - and a failed open is the state most likely to
+        be parked when the address moves, since it is what a down interface
+        produces. Polled in the same slices as the normal-path wait rather than
+        waiting on a second event, so there is one place that decides how long
+        a repoint can go unnoticed.
+        """
+        deadline = time.monotonic() + seconds
+        while not self._stop_event.is_set() and not self._tx_reopen.is_set():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            self._stop_event.wait(min(remaining, _REPOINT_CHECK_INTERVAL_S))
+
     def _send_loop(self) -> None:
         sock: socket.socket | None = None
         next_heartbeat = time.monotonic()
@@ -507,11 +524,11 @@ class MarkerCatalogSync:
                     if now - self._tx_down_log_ts >= _IFACE_DOWN_LOG_INTERVAL_S:
                         self._tx_down_log_ts = now
                         logger.warning("MarkerCatalogSync: %s", exc)
-                    self._stop_event.wait(HEARTBEAT_INTERVAL)
+                    self._wait_before_reopen(HEARTBEAT_INTERVAL)
                     continue
                 except Exception:
                     logger.exception("MarkerCatalogSync: TX socket open failed")
-                    self._stop_event.wait(HEARTBEAT_INTERVAL)
+                    self._wait_before_reopen(HEARTBEAT_INTERVAL)
                     continue
 
             now = time.monotonic()

--- a/openfollow/marker_catalog/sync.py
+++ b/openfollow/marker_catalog/sync.py
@@ -343,7 +343,7 @@ class MarkerCatalogSync:
 
     # -- Public API ----------------------------------------------------------
 
-    def update_iface_ip(self, iface_ip: str | None) -> None:
+    def update_iface_ip(self, iface_ip: str | None, *, force: bool = False) -> None:
         """Repoint both sockets after the station's address changed.
 
         ``None`` means the station interface currently has no address, which
@@ -357,12 +357,15 @@ class MarkerCatalogSync:
         than raising, so nothing triggers a rebuild. Without this, sync stops
         converging after an interface switch until the app restarts.
 
-        A no-op when the address is unchanged. That is *not* enough on its own:
-        an interface that drops and returns with the same lease has had its
+        A no-op when the address is unchanged, unless *force* is set. An
+        interface that drops and returns with the same lease has had its
         memberships torn down by the kernel while the address string stayed
-        put, so the station-follower path calls :meth:`reopen` on recovery.
+        put, so recovery passes ``force=True``. It is a flag here rather than a
+        separate :meth:`reopen` call afterwards because the two together
+        rebuild twice whenever the address *did* move, and a worker that
+        rebuilds between them tears down sockets it has just opened.
         """
-        if iface_ip == self._iface_ip:
+        if iface_ip == self._iface_ip and not force:
             return
         self._iface_ip = iface_ip
         self.reopen()
@@ -715,19 +718,34 @@ class MarkerCatalogSync:
 
         try:
             join_multicast_group_on_iface(sock, CATALOG_MCAST_GROUP, self._iface_ip)
-        except InterfaceUnavailable as exc:
-            now = time.monotonic()
-            if now - self._rx_down_log_ts >= _IFACE_DOWN_LOG_INTERVAL_S:
-                self._rx_down_log_ts = now
-                logger.warning("MarkerCatalogSync: %s", exc)
+        except InterfaceUnavailable:
+            # Propagated, not folded into the ``None`` that means "open
+            # failed": a pinned interface with no address is a state the
+            # caller is waiting out, and the generic failure budget would
+            # escalate it to an ERROR and park the loop.
             sock.close()
-            return None
+            raise
         except OSError as exc:
             logger.error("MarkerCatalogSync: join failed: %s", exc)
             sock.close()
             return None
         sock.settimeout(1.0)
         return sock
+
+    def _wait_before_rx_reopen(self, seconds: float) -> None:
+        """Back off after a down-interface RX open, waking on a repoint.
+
+        The RX counterpart of :meth:`_wait_before_reopen`, polled in the same
+        slices: a down interface is the state most likely to be parked when
+        the address returns, so the wait has to notice that rather than sleep
+        the interval out.
+        """
+        deadline = time.monotonic() + seconds
+        while not self._stop_event.is_set() and not self._rx_reopen.is_set():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            self._stop_event.wait(min(remaining, _REPOINT_CHECK_INTERVAL_S))
 
     def _recv_loop(self) -> None:
         # Outer loop so a repoint rebuilds the socket: the group membership is
@@ -742,7 +760,20 @@ class MarkerCatalogSync:
         while not self._stop_event.is_set():
             # Cleared before the open, for the same reason as TX.
             self._rx_reopen.clear()
-            sock = self._open_rx_socket()
+            try:
+                sock = self._open_rx_socket()
+            except InterfaceUnavailable as exc:
+                # Expected while the station interface is down, and outside the
+                # failure budget below: that budget exists to give up on a port
+                # this station will never get, whereas this one returns when the
+                # cable does. Counting it would retire sync input with an ERROR
+                # for a condition the operator already knows about.
+                now = time.monotonic()
+                if now - self._rx_down_log_ts >= _IFACE_DOWN_LOG_INTERVAL_S:
+                    self._rx_down_log_ts = now
+                    logger.warning("MarkerCatalogSync: %s", exc)
+                self._wait_before_rx_reopen(_RX_OPEN_RETRY_S)
+                continue
             if sock is None:
                 failures += 1
                 if failures >= _RX_OPEN_MAX_RETRIES:

--- a/openfollow/marker_catalog/sync.py
+++ b/openfollow/marker_catalog/sync.py
@@ -32,7 +32,11 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from openfollow.marker_catalog.catalog import MarkerCatalog, MarkerEntry, _sanitize_text
-from openfollow.net_utils import bind_multicast_send_iface, join_multicast_group_on_iface
+from openfollow.net_utils import (
+    InterfaceUnavailable,
+    bind_multicast_send_iface,
+    join_multicast_group_on_iface,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +70,8 @@ _MAX_RX_PACKET = 60 * 1024
 # (5-15s is normal), because that is exactly the window the retry exists to
 # cover - a shorter one gives up in the case it was added for. A port that is
 # permanently taken still stops rather than spinning for the whole show.
+# One line per minute while an interface is out, per loop.
+_IFACE_DOWN_LOG_INTERVAL_S = 60.0
 _RX_OPEN_MAX_RETRIES = 30
 _RX_OPEN_RETRY_S = 1.0
 
@@ -294,7 +300,7 @@ class MarkerCatalogSync:
         station_name_provider: Callable[[], str],
         selection_provider: Callable[[], tuple[list[int], list[int]]],
         on_change: Callable[[list[int]], None] | None = None,
-        iface_ip: str = "",
+        iface_ip: str | None = "",
     ) -> None:
         self._catalog = catalog
         self._station_id = station_id
@@ -330,11 +336,20 @@ class MarkerCatalogSync:
         self._rotation_log_ts = float("-inf")
         self._unchunkable_log_ts = float("-inf")
         self._envelope_log_ts = float("-inf")
+        # Rate-limits the "interface is down" line on each loop; separate
+        # counters because the two loops retry on different periods.
+        self._tx_down_log_ts = float("-inf")
+        self._rx_down_log_ts = float("-inf")
 
     # -- Public API ----------------------------------------------------------
 
-    def update_iface_ip(self, iface_ip: str) -> None:
+    def update_iface_ip(self, iface_ip: str | None) -> None:
         """Repoint both sockets after the station's address changed.
+
+        ``None`` means the station interface currently has no address, which
+        stops sync until it returns rather than moving it elsewhere. The sync
+        is constructed either way, so a station that booted with a dark
+        interface still has an object to bring back when the link returns.
 
         The TX socket pins ``IP_MULTICAST_IF`` and the RX socket joins
         ``IP_ADD_MEMBERSHIP`` on the address they were opened with, and neither
@@ -484,6 +499,16 @@ class MarkerCatalogSync:
                 self._tx_reopen.clear()
                 try:
                     sock = self._open_tx_socket()
+                except InterfaceUnavailable as exc:
+                    # Expected while the station interface is down, and it
+                    # retries every heartbeat - a traceback per attempt would
+                    # bury the journal for as long as the cable is out.
+                    now = time.monotonic()
+                    if now - self._tx_down_log_ts >= _IFACE_DOWN_LOG_INTERVAL_S:
+                        self._tx_down_log_ts = now
+                        logger.warning("MarkerCatalogSync: %s", exc)
+                    self._stop_event.wait(HEARTBEAT_INTERVAL)
+                    continue
                 except Exception:
                     logger.exception("MarkerCatalogSync: TX socket open failed")
                     self._stop_event.wait(HEARTBEAT_INTERVAL)
@@ -673,6 +698,13 @@ class MarkerCatalogSync:
 
         try:
             join_multicast_group_on_iface(sock, CATALOG_MCAST_GROUP, self._iface_ip, label="MarkerCatalogSync")
+        except InterfaceUnavailable as exc:
+            now = time.monotonic()
+            if now - self._rx_down_log_ts >= _IFACE_DOWN_LOG_INTERVAL_S:
+                self._rx_down_log_ts = now
+                logger.warning("MarkerCatalogSync: %s", exc)
+            sock.close()
+            return None
         except OSError as exc:
             logger.error("MarkerCatalogSync: join failed: %s", exc)
             sock.close()

--- a/openfollow/marker_catalog/sync.py
+++ b/openfollow/marker_catalog/sync.py
@@ -479,7 +479,7 @@ class MarkerCatalogSync:
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)
         try:
-            bind_multicast_send_iface(sock, self._iface_ip, label="MarkerCatalogSync")
+            bind_multicast_send_iface(sock, self._iface_ip)
         except OSError:
             sock.close()
             raise
@@ -697,7 +697,7 @@ class MarkerCatalogSync:
             return None
 
         try:
-            join_multicast_group_on_iface(sock, CATALOG_MCAST_GROUP, self._iface_ip, label="MarkerCatalogSync")
+            join_multicast_group_on_iface(sock, CATALOG_MCAST_GROUP, self._iface_ip)
         except InterfaceUnavailable as exc:
             now = time.monotonic()
             if now - self._rx_down_log_ts >= _IFACE_DOWN_LOG_INTERVAL_S:

--- a/openfollow/net_utils.py
+++ b/openfollow/net_utils.py
@@ -223,7 +223,7 @@ class InterfaceUnavailable(OSError):
     """
 
 
-def bind_multicast_send_iface(sock: socket.socket, iface_ip: str | None, *, label: str) -> None:
+def bind_multicast_send_iface(sock: socket.socket, iface_ip: str | None) -> None:
     """Pin a multicast TX socket to *iface_ip*, raising rather than roaming.
 
     An unbound multicast socket does not send "on all interfaces" - it sends on
@@ -239,8 +239,8 @@ def bind_multicast_send_iface(sock: socket.socket, iface_ip: str | None, *, labe
     """
     if iface_ip is None:
         raise InterfaceUnavailable(
-            f"{label}: the configured interface has no address; staying silent until it "
-            f"returns rather than sending on another interface"
+            "the configured interface has no address; staying silent until it returns "
+            "rather than sending on another interface"
         )
     if not iface_ip:
         return
@@ -248,12 +248,12 @@ def bind_multicast_send_iface(sock: socket.socket, iface_ip: str | None, *, labe
         sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton(iface_ip))
     except OSError as exc:
         raise InterfaceUnavailable(
-            f"{label}: interface address {iface_ip} is unavailable ({exc}); "
-            f"staying silent until it returns rather than sending on another interface"
+            f"interface address {iface_ip} is unavailable ({exc}); staying silent until it "
+            f"returns rather than sending on another interface"
         ) from exc
 
 
-def join_multicast_group_on_iface(sock: socket.socket, group: str, iface_ip: str | None, *, label: str) -> None:
+def join_multicast_group_on_iface(sock: socket.socket, group: str, iface_ip: str | None) -> None:
     """Join *group* on *iface_ip* only, raising rather than joining everywhere.
 
     The receive side of :func:`bind_multicast_send_iface`, with the same three
@@ -262,8 +262,8 @@ def join_multicast_group_on_iface(sock: socket.socket, group: str, iface_ip: str
     """
     if iface_ip is None:
         raise InterfaceUnavailable(
-            f"{label}: the configured interface has no address; staying unsubscribed until "
-            f"it returns rather than joining on every interface"
+            "the configured interface has no address; staying unsubscribed until it returns "
+            "rather than joining on every interface"
         )
     mreq = socket.inet_aton(group) + socket.inet_aton(iface_ip or "0.0.0.0")
     try:
@@ -272,6 +272,6 @@ def join_multicast_group_on_iface(sock: socket.socket, group: str, iface_ip: str
         if not iface_ip:
             raise
         raise InterfaceUnavailable(
-            f"{label}: interface address {iface_ip} is unavailable ({exc}); "
-            f"staying unsubscribed until it returns rather than joining on every interface"
+            f"interface address {iface_ip} is unavailable ({exc}); staying unsubscribed "
+            f"until it returns rather than joining on every interface"
         ) from exc

--- a/openfollow/services.py
+++ b/openfollow/services.py
@@ -33,7 +33,7 @@ from openfollow.psn import MARKER_STALE_AFTER_S, PsnReceiver, PsnServer
 from openfollow.psn.server import _UNCHANGED, _Unchanged
 from openfollow.rttrpm import RttrpmServer
 from openfollow.runtime.frame_timing import NOMINAL_FRAME_DT
-from openfollow.runtime.network_observer import NetworkPlaneObserver, Plane
+from openfollow.runtime.network_observer import DOWN_POLLS_BEFORE_SUSPEND, NetworkPlaneObserver, Plane
 from openfollow.runtime.overlay_state import OverlayState
 from openfollow.runtime.services_detection_pin import (
     apply_detection_pin as apply_detection_pin_helper,
@@ -634,6 +634,10 @@ class AppRuntimeServices:
         # Whether the station interface has been seen without an address since
         # the followers were last repointed.
         self._station_saw_outage = False
+        # Consecutive polls the station interface has looked addressless, and
+        # whether the followers have already been told to go quiet for it.
+        self._station_down_polls = 0
+        self._station_suspended = False
 
         backend_choice = self._network_backend_choice(app)
         self._network_adapter = _select_network_adapter(
@@ -1012,7 +1016,18 @@ class AppRuntimeServices:
         address, status = resolve_plane_source_ip("", self._app._config.psn_source_iface)
         if status in ("down", "none"):
             self._station_saw_outage = True
-            if status == "down":
+            self._station_down_polls += 1
+            # Debounced on the same count as the observer's own planes, and for
+            # the same reason: Apply and Renew DHCP lease take the interface
+            # down for ~1-5 s, so reacting to the first missing sample would
+            # mean the Network page's own buttons drop this station out of every
+            # peer's list. Resumption stays undebounced.
+            if (
+                status == "down"
+                and not self._station_suspended
+                and self._station_down_polls >= DOWN_POLLS_BEFORE_SUSPEND
+            ):
+                self._station_suspended = True
                 # Every station-follower stops on the same edge: each one
                 # carries this station's identity, so a survivor would put it
                 # on a network nobody chose while PSN is being stopped for
@@ -1033,6 +1048,8 @@ class AppRuntimeServices:
         # still looking healthy, converging with nobody.
         recovered = self._station_saw_outage
         self._station_saw_outage = False
+        self._station_down_polls = 0
+        self._station_suspended = False
 
         server = self._app._web_server
         if server is not None:

--- a/openfollow/services.py
+++ b/openfollow/services.py
@@ -894,11 +894,12 @@ class AppRuntimeServices:
 
         resolved, status = resolve_plane_source_ip("", self._app._config.psn_source_iface)
         if status == "down":
-            logger.error(
-                "Configured psn_source_iface '%s' has no address; PSN stays down until it "
-                "returns (it will not be sent on another interface).",
-                self._app._config.psn_source_iface,
-            )
+            # Deliberately quiet. This is a query, called once a second by the
+            # stats collector and again by the online-sync and beacon providers,
+            # so logging here put an identical ERROR line in the journal every
+            # second for the whole outage - burying the one thing an operator
+            # reading it is looking for. ``init_psn`` logs the startup decision
+            # and the network observer logs the down and up edges.
             return None
         return resolved
 
@@ -1082,15 +1083,28 @@ class AppRuntimeServices:
 
     def init_psn(self) -> None:
         source_ip = self.station_source_ip_or_none()
-        if source_ip is None:
-            # Configured station interface has no address. Binding "" would
-            # send PSN via the OS routing table.
-            return
         server = PsnServer(
             system_name=self._app._config.psn_system_name,
             mcast_ip=self._app._config.psn_mcast_ip,
-            source_ip=source_ip,
+            source_ip=source_ip or "",
         )
+        if source_ip is None:
+            # Down means silent, not absent. The server is built but never
+            # started, so nothing is sent - binding "" would send PSN via the
+            # OS routing table, which is the outcome the pin exists to prevent.
+            #
+            # Returning here instead left ``_server`` None, which skips markers
+            # and every dependent output for the life of the process, and the
+            # observer's recovery only repoints a server that already exists -
+            # so a station booted with its interface dark never sent a packet
+            # again, while the recovery logged that output had resumed.
+            logger.error(
+                "Configured psn_source_iface '%s' has no address; PSN output stays silent "
+                "until it returns (it will not be sent on another interface).",
+                self._app._config.psn_source_iface,
+            )
+            self._app._server = server
+            return
         # Assign only after start() succeeds: a failed start must leave
         # ``_server`` None so the dependent init group is skipped, not run
         # against a server whose send threads never came up.
@@ -1230,13 +1244,15 @@ class AppRuntimeServices:
         # group on whatever interface the OS picks, so the station would answer
         # on a network the operator did not choose while its output was stopped.
         source_ip = self.station_source_ip_or_none()
-        if source_ip is None:
-            return
-        self._app._psn_receiver = PsnReceiver(
+        receiver = PsnReceiver(
             ignore_ids=self._app._controlled_ids,
-            source_ip=source_ip,
+            source_ip=source_ip or "",
         )
-        self._app._psn_receiver.start()
+        # Built either way, started only with an address, for the same reason
+        # as the server: the recovery path can only rebind one that exists.
+        if source_ip is not None:
+            receiver.start()
+        self._app._psn_receiver = receiver
 
     def init_virtual_faders(self) -> None:
         """Re-apply the persisted virtual-fader config and provision the

--- a/openfollow/services.py
+++ b/openfollow/services.py
@@ -1046,6 +1046,11 @@ class AppRuntimeServices:
         # this a replug that returns the same DHCP lease leaves catalog sync
         # and the beacon joined to memberships the kernel already dropped -
         # still looking healthy, converging with nobody.
+        #
+        # Exactly one rebuild per plane either way: each entry point reports
+        # (or is told) whether it has already done it, because a forced reopen
+        # stacked on top of a repoint tears down sockets the worker may have
+        # just opened.
         recovered = self._station_saw_outage
         self._station_saw_outage = False
         self._station_down_polls = 0
@@ -1053,14 +1058,12 @@ class AppRuntimeServices:
 
         server = self._app._web_server
         if server is not None:
-            server.refresh_local_ip()
-            if recovered:
+            repointed = server.refresh_local_ip()
+            if recovered and not repointed:
                 server.reopen_beacons()
         sync = getattr(self._app, "_marker_catalog_sync", None)
         if sync is not None:
-            sync.update_iface_ip(address)
-            if recovered:
-                sync.reopen()
+            sync.update_iface_ip(address, force=recovered)
 
     def network_alerts(self) -> list[str]:
         """Planes currently stopped because their interface has no address."""

--- a/openfollow/services.py
+++ b/openfollow/services.py
@@ -1011,9 +1011,17 @@ class AppRuntimeServices:
         address, status = resolve_plane_source_ip("", self._app._config.psn_source_iface)
         if status in ("down", "none"):
             self._station_saw_outage = True
-            server = self._app._web_server
-            if status == "down" and server is not None:
-                server.suspend_beacons()
+            if status == "down":
+                # Every station-follower stops on the same edge: each one
+                # carries this station's identity, so a survivor would put it
+                # on a network nobody chose while PSN is being stopped for
+                # exactly that reason.
+                server = self._app._web_server
+                if server is not None:
+                    server.suspend_beacons()
+                sync = getattr(self._app, "_marker_catalog_sync", None)
+                if sync is not None:
+                    sync.update_iface_ip(None)
             return
 
         # The observer forces its own planes to rebuild after an outage even at

--- a/openfollow/web/discovery.py
+++ b/openfollow/web/discovery.py
@@ -210,7 +210,7 @@ class BeaconSender:
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)
         try:
-            bind_multicast_send_iface(sock, self._iface_ip, label="BeaconSender")
+            bind_multicast_send_iface(sock, self._iface_ip)
         except OSError:
             sock.close()
             raise
@@ -434,7 +434,7 @@ class BeaconReceiver:
             pass  # SO_REUSEPORT not available on all platforms
         try:
             sock.bind(("", BEACON_PORT))
-            join_multicast_group_on_iface(sock, BEACON_MCAST_GROUP, self._iface_ip, label="BeaconReceiver")
+            join_multicast_group_on_iface(sock, BEACON_MCAST_GROUP, self._iface_ip)
             sock.settimeout(1.0)
         except OSError:
             sock.close()

--- a/openfollow/web/server.py
+++ b/openfollow/web/server.py
@@ -524,8 +524,12 @@ class ConfigWebServer:
             logger.exception("PSN source advisory provider raised")
             return empty
 
-    def _refresh_local_ip(self) -> None:
+    def _refresh_local_ip(self) -> bool:
         """Re-resolve this host's primary IP and adopt it if it changed.
+
+        Returns True only when the beacons were actually repointed, so a
+        caller that would otherwise force a rebuild afterwards can tell it has
+        already happened.
 
         The IP captured at startup goes stale when the operator switches the
         interface from static to DHCP (or a lease hands back a new address)
@@ -539,17 +543,17 @@ class ConfigWebServer:
         enumeration, so it must not re-resolve on every hit.
         """
         if self._local_ip_provider is None:
-            return
+            return False
         now = time.monotonic()
         with self._local_ip_lock:
             if now - self._local_ip_refresh_ts < _LOCAL_IP_REFRESH_TTL:
-                return
+                return False
             self._local_ip_refresh_ts = now
         try:
             candidate = self._local_ip_provider()
         except Exception:  # noqa: BLE001
             logger.exception("local_ip provider raised")
-            return
+            return False
         # ``None`` is the one state that means *stop*: an interface is pinned
         # and has no address. Blank or loopback only mean "could not resolve",
         # which is no reason to unpin a beacon that is working - unpinned
@@ -558,29 +562,29 @@ class ConfigWebServer:
             with self._local_ip_lock:
                 self._beacon_sender.update_iface_ip(None)
                 self._beacon_receiver.update_iface_ip(None)
-            return
+            return True
         if not candidate or candidate.startswith("127."):
-            return
+            return False
         with self._local_ip_lock:
             if candidate == self._local_ip and self._beacon_sender.iface_ip == candidate:
-                return
+                return False
             self._local_ip = candidate
             # Repoint beacons under the lock so IP + interface stay consistent
             # under concurrent refreshes (update_iface_ip never blocks).
             self._beacon_sender.update_iface_ip(candidate)
             self._beacon_receiver.update_iface_ip(candidate)
         logger.info("Local IP changed to %s; beacon interface repointed.", candidate)
+        return True
 
-    def refresh_local_ip(self) -> None:
-        """Public entry point for the runtime network observer.
+    def refresh_local_ip(self) -> bool:
+        """Re-resolve this station's address; True when the beacons repointed.
 
-        The refresh used to happen only on a request path, so a station whose
-        address changed healed its self-row and beacon interface only while
-        somebody had a browser tab open. The observer calls this on a timer
-        instead; the internal throttle still applies, so the request paths
-        calling it too costs nothing.
+        Called by the runtime network observer on a timer and by the request
+        paths; the internal throttle makes the extra calls free. The return
+        value lets the observer's recovery path tell whether the beacons have
+        already been rebuilt, so it does not rebuild them a second time.
         """
-        self._refresh_local_ip()
+        return self._refresh_local_ip()
 
     def suspend_beacons(self) -> None:
         """Stop both beacons because the station interface has no address.

--- a/tests/test_app_marker_catalog_helpers.py
+++ b/tests/test_app_marker_catalog_helpers.py
@@ -679,10 +679,19 @@ class TestMarkerCatalogSyncFollowsTheStationInterface:
         OpenFollowApp._init_marker_catalog_sync(fake)  # type: ignore[arg-type]
         return built
 
-    def test_does_not_start_when_the_interface_is_down(self, tmp_path, monkeypatch) -> None:
+    def test_is_built_silent_when_the_interface_is_down(self, tmp_path, monkeypatch) -> None:
+        """Down means silent, not absent.
+
+        Returning early here left a station that BOOTED dark with no sync
+        object at all, and the observer's recovery path can only repoint one
+        that exists - so marker names never synced again until the next
+        restart, long after the cable was back. ``None`` is the "stay silent"
+        state the sync itself understands.
+        """
         fake = self._fake(tmp_path, None)
-        assert self._run(fake, monkeypatch) == []
-        assert fake._marker_catalog_sync is None
+        built = self._run(fake, monkeypatch)
+        assert [k["iface_ip"] for k in built] == [None]
+        assert fake._marker_catalog_sync is not None
 
     def test_starts_bound_to_the_station_address(self, tmp_path, monkeypatch) -> None:
         fake = self._fake(tmp_path, "10.20.0.5")

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -5294,6 +5294,23 @@ class TestControllerButtonTrigger:
         assert ControllerButtonTrigger().kind == "controller_button"
 
 
+class TestCoerceOptionalMarkerIdBlankString:
+    """Pins the blank-string arm deterministically.
+
+    Its only caller strips and returns before reaching the helper, so the
+    public boundary cannot drive this arm and no ordinary test covers it. What
+    did cover it was a Hypothesis property test happening to draw a
+    whitespace-only string, which made the 100% gate depend on a random draw -
+    green on one machine and red on the next with no code change between them.
+    """
+
+    @pytest.mark.parametrize("value", ["", " ", "\t", "   \n "])
+    def test_a_blank_string_collapses_to_none(self, value: str) -> None:
+        from openfollow.configuration import _coerce_optional_marker_id
+
+        assert _coerce_optional_marker_id(value) is None
+
+
 class TestCoerceOptionalInt:
     """Wildcard-or-bounded-int coercion helper tests.
 

--- a/tests/test_marker_sync.py
+++ b/tests/test_marker_sync.py
@@ -1783,3 +1783,73 @@ class TestUpdateIfaceIp:
         with patch.object(_socket, "socket", return_value=sock):
             assert sync._open_rx_socket() is sock
         assert memberships[0].endswith(_socket.inet_aton("10.0.0.9"))
+
+
+class TestADarkInterfaceStaysQuiet:
+    """Both loops retry for as long as the pinned interface is out, and say so
+    at most once a minute.
+
+    An interface with no address is an expected state on this path, not a
+    fault: the loops are *meant* to sit there retrying until the cable comes
+    back. Reporting each attempt puts a line in the journal every heartbeat for
+    the whole outage, which buries whatever the operator is actually looking
+    for - so the retry is silent after the first line.
+    """
+
+    def _sync(self, iface_ip: str | None = None) -> MarkerCatalogSync:
+        return MarkerCatalogSync(
+            MarkerCatalog(),
+            station_id="station-A",
+            station_name_provider=lambda: "X",
+            selection_provider=lambda: ([], []),
+            iface_ip=iface_ip,
+        )
+
+    def test_the_send_loop_keeps_retrying_and_logs_once(self, monkeypatch, caplog) -> None:
+        monkeypatch.setattr(marker_sync, "HEARTBEAT_INTERVAL", 0.0)
+        sync = self._sync()
+        attempts: list[int] = []
+
+        def open_dark():
+            attempts.append(1)
+            if len(attempts) >= 3:
+                sync._stop_event.set()
+            raise marker_sync.InterfaceUnavailable("the configured interface has no address")
+
+        with caplog.at_level("WARNING", logger=marker_sync.logger.name):
+            with patch.object(sync, "_open_tx_socket", side_effect=open_dark):
+                sync._send_loop()
+
+        assert len(attempts) == 3, "the send loop stopped retrying while the interface was out"
+        assert len(caplog.records) == 1, "every retry reported itself instead of only the first"
+
+    def test_the_receive_open_reports_the_outage_once(self, caplog) -> None:
+        sync = self._sync()
+        with caplog.at_level("WARNING", logger=marker_sync.logger.name):
+            with patch.object(_socket, "socket", return_value=MagicMock()):
+                assert sync._open_rx_socket() is None
+                assert sync._open_rx_socket() is None
+
+        assert len(caplog.records) == 1, "the second attempt reported the same outage again"
+
+    def test_an_unpinned_join_failure_is_still_reported(self, caplog) -> None:
+        """Blank is "nothing configured", so a failed join there is a real fault.
+
+        It is not the outage this class is about and must not be rate-limited
+        into the same quiet path - nobody asked for that interface, so nothing
+        is expected to bring it back.
+        """
+        sync = self._sync(iface_ip="")
+        sock = MagicMock()
+
+        def setsockopt(level, opt, val):
+            if opt == _socket.IP_ADD_MEMBERSHIP:
+                raise OSError("no such device")
+
+        sock.setsockopt.side_effect = setsockopt
+        with caplog.at_level("ERROR", logger=marker_sync.logger.name):
+            with patch.object(_socket, "socket", return_value=sock):
+                assert sync._open_rx_socket() is None
+
+        assert [r.levelname for r in caplog.records] == ["ERROR"]
+        sock.close.assert_called_once()

--- a/tests/test_marker_sync.py
+++ b/tests/test_marker_sync.py
@@ -1785,6 +1785,46 @@ class TestUpdateIfaceIp:
         assert memberships[0].endswith(_socket.inet_aton("10.0.0.9"))
 
 
+class TestABackoffDoesNotSleepThroughARepoint:
+    """A failed TX open is the state most likely to be parked when the address
+    moves, because a down interface is what produces it.
+
+    Parked on the full heartbeat, the loop would keep IP_MULTICAST_IF pointed at
+    the dead address for up to HEARTBEAT_INTERVAL after the operator's interface
+    came back - the same delay the normal-path wait is capped to avoid.
+    """
+
+    def _sync(self) -> MarkerCatalogSync:
+        return MarkerCatalogSync(
+            MarkerCatalog(),
+            station_id="station-A",
+            station_name_provider=lambda: "X",
+            selection_provider=lambda: ([], []),
+            iface_ip=None,
+        )
+
+    def test_a_pending_repoint_ends_the_backoff_early(self) -> None:
+        sync = self._sync()
+        sync._tx_reopen.set()
+        started = time.monotonic()
+        sync._wait_before_reopen(30.0)
+        assert time.monotonic() - started < 1.0, "the backoff slept through a repoint"
+
+    def test_a_stop_ends_the_backoff_early(self) -> None:
+        sync = self._sync()
+        sync._stop_event.set()
+        started = time.monotonic()
+        sync._wait_before_reopen(30.0)
+        assert time.monotonic() - started < 1.0, "the backoff slept through a stop"
+
+    def test_it_waits_when_nothing_is_pending(self) -> None:
+        """It is still a backoff: without a repoint it must not spin."""
+        sync = self._sync()
+        started = time.monotonic()
+        sync._wait_before_reopen(0.05)
+        assert time.monotonic() - started >= 0.05
+
+
 class TestADarkInterfaceStaysQuiet:
     """Both loops retry for as long as the pinned interface is out, and say so
     at most once a minute.

--- a/tests/test_marker_sync.py
+++ b/tests/test_marker_sync.py
@@ -1321,7 +1321,8 @@ class TestRecvLoopOneIteration:
 
         sock.setsockopt.side_effect = setsockopt
         with patch.object(_socket, "socket", return_value=sock):
-            assert sync._open_rx_socket() is None
+            with pytest.raises(marker_sync.InterfaceUnavailable):
+                sync._open_rx_socket()
         # Exactly one attempt, on the pinned interface - never a wildcard retry.
         assert len(membership_calls) == 1
         assert membership_calls[0].endswith(_socket.inet_aton("10.0.0.5"))
@@ -1824,6 +1825,30 @@ class TestABackoffDoesNotSleepThroughARepoint:
         sync._wait_before_reopen(0.05)
         assert time.monotonic() - started >= 0.05
 
+    def test_the_receive_backoff_ends_on_a_repoint(self) -> None:
+        """RX parks on the same kind of wait and needs the same escape: the
+        down interface returning is precisely when it must stop waiting."""
+        sync = self._sync()
+        sync._rx_reopen.set()
+        started = time.monotonic()
+        sync._wait_before_rx_reopen(30.0)
+        assert time.monotonic() - started < 1.0, "the receive backoff slept through a repoint"
+
+    def test_the_receive_backoff_ends_on_a_stop(self) -> None:
+        sync = self._sync()
+        sync._stop_event.set()
+        started = time.monotonic()
+        sync._wait_before_rx_reopen(30.0)
+        assert time.monotonic() - started < 1.0, "the receive backoff slept through a stop"
+
+    def test_the_receive_backoff_still_backs_off(self) -> None:
+        """Without it the loop would re-attempt the join as fast as the CPU
+        allows for the whole outage."""
+        sync = self._sync()
+        started = time.monotonic()
+        sync._wait_before_rx_reopen(0.05)
+        assert time.monotonic() - started >= 0.05
+
 
 class TestADarkInterfaceStaysQuiet:
     """Both loops retry for as long as the pinned interface is out, and say so
@@ -1863,14 +1888,68 @@ class TestADarkInterfaceStaysQuiet:
         assert len(attempts) == 3, "the send loop stopped retrying while the interface was out"
         assert len(caplog.records) == 1, "every retry reported itself instead of only the first"
 
-    def test_the_receive_open_reports_the_outage_once(self, caplog) -> None:
+    def test_the_receive_loop_keeps_retrying_and_logs_once(self, monkeypatch, caplog) -> None:
+        monkeypatch.setattr(marker_sync, "_RX_OPEN_RETRY_S", 0.0)
         sync = self._sync()
-        with caplog.at_level("WARNING", logger=marker_sync.logger.name):
-            with patch.object(_socket, "socket", return_value=MagicMock()):
-                assert sync._open_rx_socket() is None
-                assert sync._open_rx_socket() is None
+        attempts: list[int] = []
 
-        assert len(caplog.records) == 1, "the second attempt reported the same outage again"
+        def open_dark():
+            attempts.append(1)
+            if len(attempts) >= 3:
+                sync._stop_event.set()
+            raise marker_sync.InterfaceUnavailable("the configured interface has no address")
+
+        with caplog.at_level("WARNING", logger=marker_sync.logger.name):
+            with patch.object(sync, "_open_rx_socket", side_effect=open_dark):
+                sync._recv_loop()
+
+        assert len(attempts) == 3, "the receive loop stopped retrying while the interface was out"
+        assert len(caplog.records) == 1, "every retry reported itself instead of only the first"
+
+    def test_a_dark_interface_never_retires_the_receive_loop(self, monkeypatch, caplog) -> None:
+        """The failure budget exists to give up on a port this station will
+        never get. A pinned interface with no address is the opposite: it comes
+        back when the cable does, so counting it would retire sync input with
+        an ERROR for a condition the operator already knows about - and the
+        rate-limited warning above would have been pointless.
+        """
+        monkeypatch.setattr(marker_sync, "_RX_OPEN_RETRY_S", 0.0)
+        monkeypatch.setattr(marker_sync, "_RX_OPEN_MAX_RETRIES", 3)
+        sync = self._sync()
+        attempts: list[int] = []
+
+        def open_dark():
+            attempts.append(1)
+            if len(attempts) >= marker_sync._RX_OPEN_MAX_RETRIES * 3:
+                sync._stop_event.set()
+            raise marker_sync.InterfaceUnavailable("the configured interface has no address")
+
+        with caplog.at_level("ERROR", logger=marker_sync.logger.name):
+            with patch.object(sync, "_open_rx_socket", side_effect=open_dark):
+                sync._recv_loop()
+
+        assert len(attempts) == marker_sync._RX_OPEN_MAX_RETRIES * 3
+        assert caplog.records == [], "an expected outage was escalated to an ERROR"
+
+    def test_a_real_open_failure_still_spends_the_budget(self, monkeypatch, caplog) -> None:
+        """The distinction has to cut both ways: a port this station cannot
+        have must still give up and say so, rather than retrying forever."""
+        monkeypatch.setattr(marker_sync, "_RX_OPEN_RETRY_S", 0.0)
+        monkeypatch.setattr(marker_sync, "_RX_OPEN_MAX_RETRIES", 3)
+        sync = self._sync()
+        attempts: list[int] = []
+
+        def open_failed():
+            attempts.append(1)
+            if len(attempts) >= marker_sync._RX_OPEN_MAX_RETRIES:
+                sync._stop_event.set()
+            return None
+
+        with caplog.at_level("ERROR", logger=marker_sync.logger.name):
+            with patch.object(sync, "_open_rx_socket", side_effect=open_failed):
+                sync._recv_loop()
+
+        assert [r.levelname for r in caplog.records] == ["ERROR"]
 
     def test_an_unpinned_join_failure_is_still_reported(self, caplog) -> None:
         """Blank is "nothing configured", so a failed join there is a real fault.
@@ -1892,4 +1971,6 @@ class TestADarkInterfaceStaysQuiet:
                 assert sync._open_rx_socket() is None
 
         assert [r.levelname for r in caplog.records] == ["ERROR"]
+        # And it stays inside the failure budget, unlike the pinned outage:
+        # nothing is expected to bring an unconfigured interface back.
         sock.close.assert_called_once()

--- a/tests/test_net_utils.py
+++ b/tests/test_net_utils.py
@@ -802,29 +802,29 @@ class TestMulticastIfacePinning:
 
     def test_an_address_pins_the_send_socket(self) -> None:
         sock = self._Sock()
-        net_utils_module.bind_multicast_send_iface(sock, "10.0.0.5", label="X")
+        net_utils_module.bind_multicast_send_iface(sock, "10.0.0.5")
         assert sock.calls == [(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton("10.0.0.5"))]
 
     def test_blank_leaves_the_send_socket_to_the_os(self) -> None:
         """Nothing configured is not the same as a pin that failed."""
         sock = self._Sock()
-        net_utils_module.bind_multicast_send_iface(sock, "", label="X")
+        net_utils_module.bind_multicast_send_iface(sock, "")
         assert sock.calls == []
 
     def test_none_refuses_to_send(self) -> None:
         sock = self._Sock()
         with pytest.raises(net_utils_module.InterfaceUnavailable):
-            net_utils_module.bind_multicast_send_iface(sock, None, label="X")
+            net_utils_module.bind_multicast_send_iface(sock, None)
         assert sock.calls == []
 
     def test_a_failed_pin_refuses_to_send(self) -> None:
         sock = self._Sock(fail_on=socket.IP_MULTICAST_IF)
         with pytest.raises(net_utils_module.InterfaceUnavailable):
-            net_utils_module.bind_multicast_send_iface(sock, "10.0.0.5", label="X")
+            net_utils_module.bind_multicast_send_iface(sock, "10.0.0.5")
 
     def test_an_address_joins_only_that_iface(self) -> None:
         sock = self._Sock()
-        net_utils_module.join_multicast_group_on_iface(sock, "239.1.2.3", "10.0.0.5", label="X")
+        net_utils_module.join_multicast_group_on_iface(sock, "239.1.2.3", "10.0.0.5")
         assert sock.calls == [
             (
                 socket.IPPROTO_IP,
@@ -835,19 +835,19 @@ class TestMulticastIfacePinning:
 
     def test_blank_joins_the_wildcard(self) -> None:
         sock = self._Sock()
-        net_utils_module.join_multicast_group_on_iface(sock, "239.1.2.3", "", label="X")
+        net_utils_module.join_multicast_group_on_iface(sock, "239.1.2.3", "")
         assert sock.calls[0][2].endswith(socket.inet_aton("0.0.0.0"))
 
     def test_none_refuses_to_join(self) -> None:
         sock = self._Sock()
         with pytest.raises(net_utils_module.InterfaceUnavailable):
-            net_utils_module.join_multicast_group_on_iface(sock, "239.1.2.3", None, label="X")
+            net_utils_module.join_multicast_group_on_iface(sock, "239.1.2.3", None)
         assert sock.calls == []
 
     def test_a_failed_join_does_not_retry_on_the_wildcard(self) -> None:
         sock = self._Sock(fail_on=socket.IP_ADD_MEMBERSHIP)
         with pytest.raises(net_utils_module.InterfaceUnavailable):
-            net_utils_module.join_multicast_group_on_iface(sock, "239.1.2.3", "10.0.0.5", label="X")
+            net_utils_module.join_multicast_group_on_iface(sock, "239.1.2.3", "10.0.0.5")
         assert sock.calls == []
 
     def test_an_unpinned_join_failure_propagates_unchanged(self) -> None:
@@ -856,7 +856,7 @@ class TestMulticastIfacePinning:
         """
         sock = self._Sock(fail_on=socket.IP_ADD_MEMBERSHIP)
         with pytest.raises(OSError) as excinfo:
-            net_utils_module.join_multicast_group_on_iface(sock, "239.1.2.3", "", label="X")
+            net_utils_module.join_multicast_group_on_iface(sock, "239.1.2.3", "")
         assert not isinstance(excinfo.value, net_utils_module.InterfaceUnavailable)
 
     def test_the_error_is_an_oserror(self) -> None:

--- a/tests/test_services_init_and_updates.py
+++ b/tests/test_services_init_and_updates.py
@@ -552,8 +552,14 @@ class TestInitPsn:
         monkeypatch.setattr(services_module, "PsnServer", factory)
 
         services.init_psn()
-        assert factory.last_kwargs == {}
-        assert services._app._server is None
+        # Built, so the observer has something to rebind when the interface
+        # returns, but never started and never handed another interface's
+        # address - the two things that would put PSN on the wire.
+        assert factory.instances[0].start_called is False, "PSN started on a down interface"
+        assert factory.last_kwargs["source_ip"] == "", "PSN was handed a borrowed address"
+        assert services._app._server is not None, (
+            "a server that is absent cannot be repointed, so PSN never returns without a restart"
+        )
 
     def _stub_primary_ip(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import socket as _socket
@@ -4156,15 +4162,44 @@ class TestStationFollowersDoNotBindOnADownInterface:
     def test_psn_receiver_does_not_start(self, services: AppRuntimeServices, monkeypatch: pytest.MonkeyPatch) -> None:
         self._down_station(services, monkeypatch)
         built: list[object] = []
+        started: list[int] = []
         monkeypatch.setattr(
             services_module,
             "PsnReceiver",
-            lambda **kw: built.append(kw) or SimpleNamespace(start=lambda: None),
+            lambda **kw: built.append(kw) or SimpleNamespace(start=lambda: started.append(1)),
         )
         services._app._psn_receiver = None
         services.init_psn_receiver()
-        assert built == [], f"receiver was constructed with {built!r}"
-        assert services._app._psn_receiver is None
+        assert started == [], "receiver joined the multicast group on a down interface"
+        assert built and built[0]["source_ip"] == "", "receiver was handed a borrowed address"
+        assert services._app._psn_receiver is not None, (
+            "a receiver that is absent cannot be repointed when the interface returns"
+        )
+
+    def test_psn_output_returns_when_the_interface_comes_back(
+        self, services: AppRuntimeServices, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The gap this shape exists to close.
+
+        A station booted with its pinned interface dark used to leave ``_server``
+        None, which skips markers and every dependent output for the life of the
+        process - and the observer's recovery only repoints a server that
+        already exists, so it logged that output had resumed while nothing had.
+        """
+        self._down_station(services, monkeypatch)
+        factory = _FakePsnServerFactory()
+        monkeypatch.setattr(services_module, "PsnServer", factory)
+        services.init_psn()
+        server = services._app._server
+        assert server is not None and server.start_called is False
+
+        # The cable goes back in and the observer repoints the plane.
+        services._app._psn_receiver = None
+        services.apply_psn_source_ip_change("192.168.4.20")
+
+        assert server.rebind_calls == ["192.168.4.20"], (
+            "PSN never came back after the interface returned; it needs a restart"
+        )
 
     def test_psn_receiver_still_starts_on_a_live_interface(
         self, services: AppRuntimeServices, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_services_startup.py
+++ b/tests/test_services_startup.py
@@ -958,9 +958,18 @@ def test_a_dark_station_interface_suspends_the_beacons(monkeypatch) -> None:
     server = _Server()
     services._app._web_server = server
     services._app._marker_catalog_sync = None
-    services._follow_station_ip()
 
+    # A blip shorter than the debounce must not drop the station out of every
+    # peer's list: Apply and Renew DHCP lease each produce one.
+    _drive_down_polls(services, 1)
+    assert server.suspends == 0, "a single missing sample suspended discovery"
+
+    _drive_down_polls(services)
     assert server.suspends == 1
+    # Once, on the transition: the beacons are already silent, and re-suspending
+    # every second for the length of the outage only refills the journal.
+    _drive_down_polls(services)
+    assert server.suspends == 1, "discovery was re-suspended while already quiet"
     assert server.refreshes == 0, "a dark interface must not repoint to anything"
 
 
@@ -1013,7 +1022,7 @@ def test_sync_recovers_from_a_station_booted_with_a_dark_interface(monkeypatch) 
 
     # Booted dark: the interface the pin names has no address.
     _fake_ifaces(monkeypatch, {})
-    services._follow_station_ip()
+    _drive_down_polls(services)
     assert sync.ips == [None], "a dark interface must put sync into its silent state"
 
     # The cable goes back in. No restart, no config change.
@@ -1038,7 +1047,7 @@ def test_a_station_with_no_web_server_still_silences_sync(monkeypatch) -> None:
     services._app._web_server = None
 
     _fake_ifaces(monkeypatch, {})
-    services._follow_station_ip()
+    _drive_down_polls(services)
 
     assert sync.ips == [None], "sync kept sending because there was no web server to suspend alongside it"
 
@@ -1162,7 +1171,7 @@ def test_station_followers_do_not_move_to_another_interface(monkeypatch) -> None
     sync, server = _Sync(), _Server()
     services._app._marker_catalog_sync = sync
     services._app._web_server = server
-    services._follow_station_ip()
+    _drive_down_polls(services)
     assert server.refreshes == 0
     # Not merely "not repointed": both followers are told to stop, so each
     # goes quiet by decision instead of waiting for a send on a dead address
@@ -1250,6 +1259,19 @@ class _FollowerServer:
 
     def suspend_beacons(self) -> None:
         self.suspends += 1
+
+
+def _drive_down_polls(services, count: int | None = None) -> None:
+    """Poll a down interface until the suspend debounce clears.
+
+    The followers debounce on the same count as the observer's own planes, so a
+    test that wants the suspended state has to earn it rather than assume the
+    first poll does it.
+    """
+    from openfollow.runtime.network_observer import DOWN_POLLS_BEFORE_SUSPEND
+
+    for _ in range(DOWN_POLLS_BEFORE_SUSPEND if count is None else count):
+        services._follow_station_ip()
 
 
 def _wire_followers(services):

--- a/tests/test_services_startup.py
+++ b/tests/test_services_startup.py
@@ -999,6 +999,50 @@ def test_nothing_configured_does_not_suspend_the_beacons(monkeypatch) -> None:
     assert server.suspends == 0
 
 
+def test_sync_recovers_from_a_station_booted_with_a_dark_interface(monkeypatch) -> None:
+    """The gap a bench run found: the beacon self-healed and sync did not.
+
+    Sync used not to be constructed at all when the station booted dark, and
+    the recovery path can only repoint an object that exists - so marker names
+    stayed unsynced until somebody restarted the station, long after the cable
+    was back in.
+    """
+    services = _build_services_with_psutil_backend(monkeypatch)
+    services._app._config.psn_source_iface = "eth0"
+    sync, server = _wire_followers(services)
+
+    # Booted dark: the interface the pin names has no address.
+    _fake_ifaces(monkeypatch, {})
+    services._follow_station_ip()
+    assert sync.ips == [None], "a dark interface must put sync into its silent state"
+
+    # The cable goes back in. No restart, no config change.
+    _fake_ifaces(monkeypatch, {"eth0": "192.168.1.5"})
+    services._follow_station_ip()
+
+    assert sync.ips == [None, "192.168.1.5"], "sync never came back after the interface returned"
+    assert sync.reopens == 1, "the membership the kernel dropped was not rebuilt"
+
+
+def test_a_station_with_no_web_server_still_silences_sync(monkeypatch) -> None:
+    """The two followers stop independently.
+
+    Each puts this station's identity on its own socket, so whichever one
+    exists has to go quiet on the down edge regardless of the other. Guarding
+    them together would leave marker names on an excluded network on any
+    station whose web server had not been built.
+    """
+    services = _build_services_with_psutil_backend(monkeypatch)
+    services._app._config.psn_source_iface = "eth0"
+    sync, _server = _wire_followers(services)
+    services._app._web_server = None
+
+    _fake_ifaces(monkeypatch, {})
+    services._follow_station_ip()
+
+    assert sync.ips == [None], "sync kept sending because there was no web server to suspend alongside it"
+
+
 def test_follow_station_ip_tolerates_missing_services(monkeypatch) -> None:
     services = _build_services_with_psutil_backend(monkeypatch)
     services._app._web_server = None
@@ -1119,10 +1163,11 @@ def test_station_followers_do_not_move_to_another_interface(monkeypatch) -> None
     services._app._marker_catalog_sync = sync
     services._app._web_server = server
     services._follow_station_ip()
-    assert sync.ips == []
     assert server.refreshes == 0
-    # Not merely "not repointed": discovery is told to stop, so it goes quiet
-    # by decision instead of waiting for a send on a dead address to fail.
+    # Not merely "not repointed": both followers are told to stop, so each
+    # goes quiet by decision instead of waiting for a send on a dead address
+    # to fail. None is the sync's own "stay silent" state.
+    assert sync.ips == [None]
     assert server.suspends == 1
 
 
@@ -1181,10 +1226,10 @@ def test_plane_current_reports_the_live_binding(monkeypatch) -> None:
 
 class _FollowerSync:
     def __init__(self) -> None:
-        self.ips: list[str] = []
+        self.ips: list[str | None] = []
         self.reopens = 0
 
-    def update_iface_ip(self, ip: str) -> None:
+    def update_iface_ip(self, ip: str | None) -> None:
         self.ips.append(ip)
 
     def reopen(self) -> None:

--- a/tests/test_services_startup.py
+++ b/tests/test_services_startup.py
@@ -912,8 +912,9 @@ def test_station_followers_are_repointed_without_a_web_request(monkeypatch) -> N
         def __init__(self) -> None:
             self.refreshes = 0
 
-        def refresh_local_ip(self) -> None:
+        def refresh_local_ip(self) -> bool:
             self.refreshes += 1
+            return False
 
         def suspend_beacons(self) -> None:
             raise AssertionError("a healthy interface must not suspend the beacons")
@@ -922,7 +923,7 @@ def test_station_followers_are_repointed_without_a_web_request(monkeypatch) -> N
         def __init__(self) -> None:
             self.ips: list[str] = []
 
-        def update_iface_ip(self, ip: str) -> None:
+        def update_iface_ip(self, ip: str, *, force: bool = False) -> None:
             self.ips.append(ip)
 
     server, sync = _Server(), _Sync()
@@ -1018,19 +1019,23 @@ def test_sync_recovers_from_a_station_booted_with_a_dark_interface(monkeypatch) 
     """
     services = _build_services_with_psutil_backend(monkeypatch)
     services._app._config.psn_source_iface = "eth0"
-    sync, server = _wire_followers(services)
+    # Booted dark, so both followers start pointed nowhere - not at an address
+    # they never had.
+    sync, server = _FollowerSync(None), _FollowerServer(None)
+    services._app._marker_catalog_sync = sync
+    services._app._web_server = server
 
-    # Booted dark: the interface the pin names has no address.
     _fake_ifaces(monkeypatch, {})
     _drive_down_polls(services)
     assert sync.ips == [None], "a dark interface must put sync into its silent state"
+    assert sync.rebuilds == 0, "a sync that never pointed anywhere had nothing to tear down"
 
     # The cable goes back in. No restart, no config change.
-    _fake_ifaces(monkeypatch, {"eth0": "192.168.1.5"})
+    _fake_ifaces(monkeypatch, {"eth0": _FOLLOWER_ADDRESS})
     services._follow_station_ip()
 
-    assert sync.ips == [None, "192.168.1.5"], "sync never came back after the interface returned"
-    assert sync.reopens == 1, "the membership the kernel dropped was not rebuilt"
+    assert sync.ips == [None, _FOLLOWER_ADDRESS], "sync never came back after the interface returned"
+    assert sync.rebuilds == 1, "the membership the kernel dropped was not rebuilt exactly once"
 
 
 def test_a_station_with_no_web_server_still_silences_sync(monkeypatch) -> None:
@@ -1233,32 +1238,64 @@ def test_plane_current_reports_the_live_binding(monkeypatch) -> None:
     assert planes["OTP output"].current() is None
 
 
+# The address every follower test's interface resolves to.
+_FOLLOWER_ADDRESS = "192.168.1.5"
+
+
 class _FollowerSync:
-    def __init__(self) -> None:
+    """Models the real short-circuit, not just the call.
+
+    A double that only recorded the address could not tell one rebuild from
+    two, which is exactly the defect this shape exists to catch: a forced
+    reopen stacked on a repoint tears down sockets the worker may have just
+    opened. ``rebuilds`` counts what the real object would actually do.
+    """
+
+    def __init__(self, iface_ip: str | None = None) -> None:
         self.ips: list[str | None] = []
         self.reopens = 0
+        self.rebuilds = 0
+        self._iface_ip = iface_ip
 
-    def update_iface_ip(self, ip: str | None) -> None:
+    def update_iface_ip(self, ip: str | None, *, force: bool = False) -> None:
         self.ips.append(ip)
+        if ip == self._iface_ip and not force:
+            return
+        self._iface_ip = ip
+        self.reopen()
 
     def reopen(self) -> None:
         self.reopens += 1
+        self.rebuilds += 1
 
 
 class _FollowerServer:
-    def __init__(self) -> None:
+    """Same contract as the real server: the refresh reports whether it
+    repointed, so a caller can tell the rebuild has already happened."""
+
+    def __init__(self, local_ip: str | None = None) -> None:
         self.refreshes = 0
         self.reopens = 0
         self.suspends = 0
+        self.rebuilds = 0
+        self._local_ip = local_ip
 
-    def refresh_local_ip(self) -> None:
+    def refresh_local_ip(self) -> bool:
         self.refreshes += 1
+        if self._local_ip == _FOLLOWER_ADDRESS:
+            return False
+        self._local_ip = _FOLLOWER_ADDRESS
+        self.rebuilds += 1
+        return True
 
     def reopen_beacons(self) -> None:
         self.reopens += 1
+        self.rebuilds += 1
 
     def suspend_beacons(self) -> None:
         self.suspends += 1
+        self.rebuilds += 1
+        self._local_ip = None
 
 
 def _drive_down_polls(services, count: int | None = None) -> None:
@@ -1275,7 +1312,11 @@ def _drive_down_polls(services, count: int | None = None) -> None:
 
 
 def _wire_followers(services):
-    sync, server = _FollowerSync(), _FollowerServer()
+    """Wired the way production starts: both followers already pointed at the
+    station address, so a steady poll is a genuine no-op rather than an
+    artefact of the double booting blank."""
+    sync = _FollowerSync(_FOLLOWER_ADDRESS)
+    server = _FollowerServer(_FOLLOWER_ADDRESS)
     services._app._marker_catalog_sync = sync
     services._app._web_server = server
     return sync, server
@@ -1291,17 +1332,52 @@ def test_station_followers_rebuild_after_a_same_lease_flap(monkeypatch) -> None:
     services._app._config.psn_source_iface = "eth0"
     sync, server = _wire_followers(services)
 
-    _fake_ifaces(monkeypatch, {"eth0": "192.168.1.5"})
+    _fake_ifaces(monkeypatch, {"eth0": _FOLLOWER_ADDRESS})
     services._follow_station_ip()
-    assert (sync.reopens, server.reopens) == (0, 0)
+    assert (sync.rebuilds, server.rebuilds) == (0, 0)
 
     _fake_ifaces(monkeypatch, {})  # cable out
+    _drive_down_polls(services)
+
+    before = (sync.rebuilds, server.rebuilds)
+    _fake_ifaces(monkeypatch, {"eth0": _FOLLOWER_ADDRESS})  # same lease back
     services._follow_station_ip()
 
-    _fake_ifaces(monkeypatch, {"eth0": "192.168.1.5"})  # same lease back
+    # Exactly one, not zero and not two: zero leaves both joined to
+    # memberships the kernel dropped, and two tears down sockets the worker
+    # may have just opened.
+    assert sync.rebuilds - before[0] == 1
+    assert server.rebuilds - before[1] == 1
+
+
+def test_a_blip_shorter_than_the_debounce_still_forces_a_rebuild(monkeypatch) -> None:
+    """The case the forced rebuild actually exists for.
+
+    An outage too short to trip the suspend debounce never puts the followers
+    into their silent state, so the address they hold is still the one that
+    comes back - and their own short-circuit would skip the rebuild. The
+    kernel dropped the membership and the egress route regardless of how long
+    the cable was out, so the flag has to override that guard.
+    """
+    services = _build_services_with_psutil_backend(monkeypatch)
+    services._app._config.psn_source_iface = "eth0"
+    sync, server = _wire_followers(services)
+
+    _fake_ifaces(monkeypatch, {"eth0": _FOLLOWER_ADDRESS})
     services._follow_station_ip()
-    assert sync.reopens == 1
-    assert server.reopens == 1
+    assert (sync.rebuilds, server.rebuilds) == (0, 0)
+
+    # One missed sample - below DOWN_POLLS_BEFORE_SUSPEND, so nothing suspends.
+    _fake_ifaces(monkeypatch, {})
+    services._follow_station_ip()
+    assert server.suspends == 0, "the blip should not have reached the suspend"
+    assert None not in sync.ips, "the blip should not have silenced sync"
+
+    _fake_ifaces(monkeypatch, {"eth0": _FOLLOWER_ADDRESS})
+    services._follow_station_ip()
+
+    assert sync.rebuilds == 1, "the unchanged address skipped the rebuild the kernel needs"
+    assert server.rebuilds == 1
 
 
 def test_a_steady_station_never_forces_a_rebuild(monkeypatch) -> None:
@@ -1309,10 +1385,10 @@ def test_a_steady_station_never_forces_a_rebuild(monkeypatch) -> None:
     services = _build_services_with_psutil_backend(monkeypatch)
     services._app._config.psn_source_iface = "eth0"
     sync, server = _wire_followers(services)
-    _fake_ifaces(monkeypatch, {"eth0": "192.168.1.5"})
+    _fake_ifaces(monkeypatch, {"eth0": _FOLLOWER_ADDRESS})
     for _ in range(5):
         services._follow_station_ip()
-    assert (sync.reopens, server.reopens) == (0, 0)
+    assert (sync.rebuilds, server.rebuilds) == (0, 0)
 
 
 def test_the_outage_flag_clears_after_one_recovery(monkeypatch) -> None:
@@ -1320,12 +1396,14 @@ def test_the_outage_flag_clears_after_one_recovery(monkeypatch) -> None:
     services._app._config.psn_source_iface = "eth0"
     sync, server = _wire_followers(services)
     _fake_ifaces(monkeypatch, {})
+    _drive_down_polls(services)
+    before = (sync.rebuilds, server.rebuilds)
+    _fake_ifaces(monkeypatch, {"eth0": _FOLLOWER_ADDRESS})
     services._follow_station_ip()
-    _fake_ifaces(monkeypatch, {"eth0": "192.168.1.5"})
     services._follow_station_ip()
-    services._follow_station_ip()
-    assert sync.reopens == 1
-    assert server.reopens == 1
+    # The second healthy poll must not force a further rebuild.
+    assert sync.rebuilds - before[0] == 1
+    assert server.rebuilds - before[1] == 1
 
 
 # VLAN providers / handlers

--- a/tests/test_web_server_unit.py
+++ b/tests/test_web_server_unit.py
@@ -1389,6 +1389,86 @@ def test_a_station_pin_going_down_stops_the_beacons(tmp_path, monkeypatch) -> No
     assert srv.local_ip == "10.0.0.1", "the displayed address should not be downgraded"
 
 
+class TestTheRefreshReportsWhetherItRepointed:
+    """The observer's recovery path forces a rebuild only when the refresh did
+    not already do one. Getting this backwards costs a rebuild in one
+    direction and doubles it in the other, and neither shows up in a test that
+    only checks where the beacons ended up."""
+
+    def _server(self, tmp_path, monkeypatch, resolved, **kwargs):
+        monkeypatch.setattr(
+            "openfollow.web.server.get_local_ipv4_addresses",
+            lambda: {"10.0.0.1", "10.0.0.2"},
+        )
+        return _make_quiet_server(
+            tmp_path,
+            monkeypatch,
+            local_ip_provider=lambda: resolved[0],
+            **kwargs,
+        )
+
+    def test_an_unchanged_address_reports_no_repoint(self, tmp_path, monkeypatch) -> None:
+        """The case the forced rebuild exists for: nothing moved, so nothing
+        was rebuilt, and the caller still has to rebuild the membership the
+        kernel dropped."""
+        resolved: list[str | None] = ["10.0.0.1"]
+        srv = self._server(tmp_path, monkeypatch, resolved, local_ip="10.0.0.1", station_ip="10.0.0.1")
+        srv._local_ip_refresh_ts -= 1000.0
+
+        assert srv.refresh_local_ip() is False
+
+    def test_a_new_address_reports_the_repoint(self, tmp_path, monkeypatch) -> None:
+        resolved: list[str | None] = ["10.0.0.2"]
+        srv = self._server(tmp_path, monkeypatch, resolved, local_ip="10.0.0.1", station_ip="10.0.0.1")
+        srv._local_ip_refresh_ts -= 1000.0
+
+        assert srv.refresh_local_ip() is True
+
+    def test_going_dark_reports_the_repoint(self, tmp_path, monkeypatch) -> None:
+        """Stopping the beacons is a rebuild too - the caller must not stack a
+        forced reopen on top of sockets that were just torn down."""
+        resolved: list[str | None] = [None]
+        srv = self._server(tmp_path, monkeypatch, resolved, local_ip="10.0.0.1", station_ip="10.0.0.1")
+        srv._local_ip_refresh_ts -= 1000.0
+
+        assert srv.refresh_local_ip() is True
+
+    def test_a_throttled_call_reports_no_repoint(self, tmp_path, monkeypatch) -> None:
+        """A call that never read the provider cannot have repointed anything,
+        so reporting a repoint would suppress the rebuild recovery owes."""
+        resolved: list[str | None] = ["10.0.0.1"]
+        srv = self._server(tmp_path, monkeypatch, resolved, local_ip="10.0.0.1", station_ip="10.0.0.1")
+        srv._local_ip_refresh_ts -= 1000.0
+        assert srv.refresh_local_ip() is False  # opens the throttle window
+
+        # A value that WOULD repoint, so False can only mean "did not run".
+        resolved[0] = "10.0.0.2"
+        assert srv.refresh_local_ip() is False
+        assert srv._beacon_sender.iface_ip != "10.0.0.2", "the throttled call ran after all"
+
+    def test_an_unresolved_address_reports_no_repoint(self, tmp_path, monkeypatch) -> None:
+        resolved: list[str | None] = [""]
+        srv = self._server(tmp_path, monkeypatch, resolved, local_ip="10.0.0.1", station_ip="10.0.0.1")
+        srv._local_ip_refresh_ts -= 1000.0
+
+        assert srv.refresh_local_ip() is False
+
+    def test_a_raising_provider_reports_no_repoint(self, tmp_path, monkeypatch) -> None:
+        def _boom() -> str:
+            raise OSError("no interfaces")
+
+        srv = _make_quiet_server(tmp_path, monkeypatch, local_ip="10.0.0.1", local_ip_provider=_boom)
+        srv._local_ip_refresh_ts -= 1000.0
+
+        assert srv.refresh_local_ip() is False
+
+    def test_a_server_with_no_provider_reports_no_repoint(self, tmp_path, monkeypatch) -> None:
+        srv = _make_quiet_server(tmp_path, monkeypatch, local_ip="10.0.0.1")
+        srv._local_ip_refresh_ts -= 1000.0
+
+        assert srv.refresh_local_ip() is False
+
+
 def test_the_beacons_come_back_when_the_interface_returns(tmp_path, monkeypatch) -> None:
     """Recovery needs no restart - the observer's next poll repins both."""
     monkeypatch.setattr(


### PR DESCRIPTION
Two fixes found on the bench during the fail-open validation on pi66, both of
which the pre-push gate then turned up missing coverage for.

## Marker sync never came back after a boot-dark interface

A station that **booted** with its pinned interface dark never synced marker
names again, even after the cable went back in, until somebody restarted it.

`_init_marker_catalog_sync` returned early when the station address resolved to
`None`, so no sync object was ever constructed, and the observer's recovery path
is guarded on `if sync is not None` - it had nothing to repoint. The discovery
beacon self-heals because it is built either way and simply holds the silent
state; sync did not. That asymmetry is what the bench run measured: the beacon
returned on the pinned interface and sync stayed absent across two 16 s windows.

Down now means silent, not absent. The sync is always constructed and takes
`None` as its "stay silent" state, the same as the beacons, so there is an
object for the observer to bring back. The down edge tells it to go quiet
explicitly rather than leaving it to discover a dead address on its next send.

An unavailable interface is an expected state on that path, so it no longer logs
a traceback every heartbeat for as long as the cable is out - one rate-limited
line per loop instead.

If sync was already running when the interface went away it recovered correctly
before this change; the gap was boot-while-dark only.

## The journal named each component twice

Every caller of the multicast pin helpers already logs under its own component
prefix, so carrying a label inside the exception text produced
`MarkerCatalogSync: MarkerCatalogSync: the configured interface has no address`
and `BeaconSender: socket open failed (3 consecutive): BeaconSender: ...`. The
parameter existed only to duplicate what the log line says, so it goes rather
than being worked around.

## What the gate added

Neither fix had been through `make ci-remote` when it was written. Running it
found two real gaps, both closed here:

- **`sync.py` was at 97.6%.** The catalog fix added two `except
  InterfaceUnavailable` branches (`_send_loop` TX, `_open_rx_socket` RX) with no
  test. `TestADarkInterfaceStaysQuiet` covers retry-and-log-once on both, plus
  the unpinned (`iface_ip=""`) join failure that must *not* be rate-limited into
  the same quiet path - blank means "nothing configured", so a failure there is a
  real fault nobody is waiting to see recover.
- **`services.py 1020->1022`**, one partial branch. Nesting `if server is not
  None:` inside `if status == "down":` created a branch pair no test drove. That
  one is genuine behaviour rather than a coverage technicality: the two
  station-followers stop **independently**, so a station whose web server is
  absent must still silence sync.

## Verification

Every regression test was mutation-checked - the fix reverted, the test confirmed
red - because reviews on this project keep finding tests that cannot fail at 100%
coverage. All eight go red:

| Mutation | Result |
|---|---|
| Restore the early return in `_init_marker_catalog_sync` | red |
| Drop the down-edge `update_iface_ip(None)` | red |
| Drop the recovery `reopen()` | red |
| TX logs every attempt (drop the rate limit) | red |
| TX gives up instead of retrying | red |
| RX logs every attempt | red |
| Unpinned join failure routed into the quiet path | red |
| Followers guard each other again (the pre-fix shape) | red |

`make ci-remote` green on pi66 (aarch64 / py3.13): 9538 unit, 1130 integration,
1 smoke e2e, `Required test coverage of 100% reached`.

Not yet re-measured on the bench: the boot-dark recovery was diagnosed there but
the fix has only been gated, not re-run against a live station.

Part of the multi-interface networking work (#50); targets the integration
branch, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
